### PR TITLE
Add 3 website redesign mockups with comparison guide

### DIFF
--- a/mockups/COMPARISON.md
+++ b/mockups/COMPARISON.md
@@ -1,0 +1,124 @@
+# Website Redesign Mockups — Comparison Guide
+
+> Open each HTML file in your browser to see the live mockup. All support dark mode toggle.
+
+---
+
+## Current Site Issues (Why Redesign?)
+
+| Problem | Detail |
+|---------|--------|
+| **Too spread out** | 3 separate pages (index, projects, contact) for relatively little content |
+| **Oversized hero** | 85vh hero with large image takes up most of the first viewport |
+| **Hidden content** | Projects page uses tabs — users must click to discover content |
+| **Redundant elements** | Same header/footer duplicated across all pages |
+| **Low information density** | Large spacing and decorative elements push content below the fold |
+| **Too many clicks** | Visiting all content requires navigating to 3 pages + clicking 5 tabs |
+
+---
+
+## Mockup A: Condensed Single-Page
+**File:** `mockup-a-condensed.html`
+
+### Design Philosophy
+Strip everything down to a single scrollable page. Compact hero (circular photo, 50vh). All content visible without tabs. Tight vertical spacing. Minimal decorative elements.
+
+### Key Changes from Current Site
+- **Single page** — no navigation between pages
+- **50vh compact hero** with circular profile photo instead of 85vh
+- **"What I Do" as chips** — compact horizontal pills instead of 6 full cards
+- **Research as a list** — clickable rows with arrows instead of large cards
+- **Projects as small cards** — 3-column grid, minimal padding
+- **Clinical as inline table** — date | content layout, no vertical timeline
+- **Contact is a single row** — text + social pill links inline
+- **One-line footer** — no multi-column footer grid
+
+### Best For
+- Users who value speed and scannability
+- Mobile-first audiences
+- Minimalists who want everything accessible in one scroll
+
+### Vibe
+Clean, functional, developer-portfolio aesthetic. GitHub README energy.
+
+---
+
+## Mockup B: Bento Grid
+**File:** `mockup-b-bento.html`
+
+### Design Philosophy
+Everything is a "tile" in a masonry-style bento grid. Inspired by Apple product pages and Linear's design language. Highly visual. Cards of varying sizes create visual rhythm. Looks incredible in dark mode.
+
+### Key Changes from Current Site
+- **No traditional page sections** — everything is bento cards
+- **Full-width hero card** spanning the grid
+- **Education, Languages, Interests** as separate small tiles
+- **Research as a 2x2 grid inside a wide card** — visual and clickable
+- **Tech projects as a stacked list card**
+- **Clinical as a compact list card**
+- **"Let's Connect" as a gradient accent card** — visually striking CTA
+- **Location gets its own micro-card**
+- **Entire site is one viewport-ish view** on desktop
+
+### Best For
+- Making a strong visual first impression
+- Audiences who value modern/trendy design
+- Portfolio reviews where aesthetics matter
+
+### Vibe
+Apple keynote energy. Modern, visual-first, statement-making.
+
+---
+
+## Mockup C: Editorial / Magazine
+**File:** `mockup-c-editorial.html`
+
+### Design Philosophy
+Typography-forward. Serif headings (Playfair Display) with sans-serif body (Inter). Two-column newspaper-style layouts. Academic but elegant. Dense content without feeling cluttered. Warm, golden accent color.
+
+### Key Changes from Current Site
+- **Serif masthead** — classic editorial feel, centered navigation
+- **Photo has grayscale filter** — editorial photography style
+- **Two-column body** — about text left, education/languages right (newspaper columns)
+- **Research as bordered entries** — left-border accent, hover background
+- **Projects as a structured table/list** — year | name | tag format
+- **Clinical as a CV-style list** — academic formatting
+- **Interests written as prose** with inline tag chips — feels human and readable
+- **Warm gold accent** instead of blue — more sophisticated, academic
+
+### Best For
+- Academic/professional audiences (attendings, department chairs)
+- When content depth matters more than visual flash
+- Standing out from the sea of blue-accent tech portfolios
+
+### Vibe
+New Yorker profile page. Academic elegance. Refined and intellectual.
+
+---
+
+## Quick Comparison Matrix
+
+| Feature | A (Condensed) | B (Bento) | C (Editorial) |
+|---------|:---:|:---:|:---:|
+| Pages | 1 | 1 | 1 |
+| Hero size | Compact (50vh) | Card-based | Compact + photo |
+| Primary font | DM Sans + Inter | DM Sans + Inter | Playfair + Inter |
+| Layout style | Linear scroll | Grid tiles | Columnar |
+| Information density | High | Medium-High | High |
+| Visual impact | Medium | Very High | High (typographic) |
+| Dark mode | Yes | Yes (exceptional) | Yes |
+| Academic feel | Medium | Low | Very High |
+| Mobile behavior | Stacked sections | Stacked cards | Single column |
+| Content visibility | All visible | All visible | All visible |
+| Accent color | Blue (#4a6cf7) | Apple Blue (#0071e3) | Gold (#b8860b) |
+
+---
+
+## Recommendation
+
+You can mix-and-match elements. For example:
+- **Bento grid layout** + **Editorial typography** = bold but intellectual
+- **Condensed structure** + **Bento cards** for just the "What I Do" section
+- **Editorial research section** in any layout (the left-border entries are excellent)
+
+All three mockups solve the core issues: they're single-page, content-dense, and everything is visible without clicking through tabs.

--- a/mockups/mockup-a-condensed.html
+++ b/mockups/mockup-a-condensed.html
@@ -1,0 +1,407 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mockup A: Condensed Single-Page | skflx.MD</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <style>
+        /* ========================================================
+           MOCKUP A: CONDENSED SINGLE-PAGE
+
+           Concept: Everything on one scrollable page.
+           Hero is compact (50vh max). Sections use tight spacing.
+           Navigation becomes an anchor scroll menu.
+           Content is denser, fewer decorative elements.
+           ======================================================== */
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        :root {
+            --bg: #fafafa;
+            --bg-alt: #f0f0f0;
+            --text: #1a1a2e;
+            --text-secondary: #555;
+            --text-muted: #888;
+            --accent: #4a6cf7;
+            --accent-soft: #e8edff;
+            --border: #e0e0e0;
+            --card-bg: #fff;
+            --font-body: 'Inter', sans-serif;
+            --font-display: 'DM Sans', sans-serif;
+            --radius: 10px;
+        }
+
+        [data-theme="dark"] {
+            --bg: #0d1117;
+            --bg-alt: #161b22;
+            --text: #e6edf3;
+            --text-secondary: #a0aec0;
+            --text-muted: #6e7681;
+            --accent: #6b8afd;
+            --accent-soft: #1c2333;
+            --border: #2d333b;
+            --card-bg: #161b22;
+        }
+
+        html { scroll-behavior: smooth; }
+        body {
+            font-family: var(--font-body);
+            color: var(--text);
+            background: var(--bg);
+            line-height: 1.6;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        .container { max-width: 960px; margin: 0 auto; padding: 0 24px; }
+
+        /* --- HEADER: Slim, sticky, blurred --- */
+        .header {
+            position: sticky; top: 0; z-index: 100;
+            background: color-mix(in srgb, var(--bg) 85%, transparent);
+            backdrop-filter: blur(16px);
+            border-bottom: 1px solid var(--border);
+            height: 56px; display: flex; align-items: center;
+        }
+        .header .container { display: flex; justify-content: space-between; align-items: center; width: 100%; }
+        .logo { font-family: var(--font-display); font-weight: 700; font-size: 1.1rem; color: var(--text); text-decoration: none; }
+        .nav-links { list-style: none; display: flex; gap: 24px; }
+        .nav-links a { color: var(--text-muted); text-decoration: none; font-size: 0.85rem; font-weight: 500; transition: color 0.2s; }
+        .nav-links a:hover { color: var(--accent); }
+        .theme-btn { background: none; border: 1px solid var(--border); border-radius: 6px; padding: 6px 10px; cursor: pointer; color: var(--text-muted); font-size: 0.8rem; }
+
+        /* --- HERO: Compact, 50vh max --- */
+        .hero {
+            min-height: 50vh; display: flex; align-items: center;
+            padding: 48px 0;
+            border-bottom: 1px solid var(--border);
+        }
+        .hero-inner { display: flex; gap: 48px; align-items: center; }
+        .hero-photo {
+            width: 160px; height: 160px; border-radius: 50%;
+            object-fit: cover; flex-shrink: 0;
+            border: 3px solid var(--accent-soft);
+        }
+        .hero-text h1 { font-family: var(--font-display); font-size: 2rem; font-weight: 700; margin-bottom: 8px; }
+        .hero-text .subtitle { color: var(--accent); font-size: 0.9rem; font-weight: 500; margin-bottom: 12px; }
+        .hero-text p { color: var(--text-secondary); font-size: 0.95rem; max-width: 480px; margin-bottom: 16px; }
+        .hero-links { display: flex; gap: 12px; flex-wrap: wrap; }
+        .hero-links a {
+            display: inline-flex; align-items: center; gap: 6px;
+            padding: 8px 16px; border-radius: 6px; font-size: 0.85rem; font-weight: 500; text-decoration: none;
+            transition: all 0.2s;
+        }
+        .btn-fill { background: var(--accent); color: #fff; }
+        .btn-fill:hover { filter: brightness(1.1); }
+        .btn-ghost { border: 1px solid var(--border); color: var(--text-secondary); }
+        .btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+
+        /* --- SECTIONS: Tight vertical rhythm --- */
+        .section { padding: 48px 0; }
+        .section + .section { border-top: 1px solid var(--border); }
+        .section-title {
+            font-family: var(--font-display); font-size: 1.1rem; font-weight: 600;
+            text-transform: uppercase; letter-spacing: 0.08em;
+            color: var(--text-muted); margin-bottom: 24px;
+        }
+
+        /* --- ABOUT: Two-column text + stats sidebar --- */
+        .about-layout { display: grid; grid-template-columns: 2fr 1fr; gap: 48px; }
+        .about-text p { color: var(--text-secondary); margin-bottom: 12px; font-size: 0.92rem; }
+        .stat-pills { display: flex; flex-direction: column; gap: 12px; }
+        .stat-pill {
+            background: var(--card-bg); border: 1px solid var(--border); border-radius: var(--radius);
+            padding: 14px 16px; text-align: center;
+        }
+        .stat-pill .label { font-size: 0.75rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+        .stat-pill .value { font-family: var(--font-display); font-weight: 600; font-size: 0.95rem; color: var(--text); margin-top: 2px; }
+
+        /* --- WHAT I DO: Horizontal scroll chips --- */
+        .chips { display: flex; flex-wrap: wrap; gap: 10px; }
+        .chip {
+            display: inline-flex; align-items: center; gap: 8px;
+            padding: 10px 18px; background: var(--card-bg); border: 1px solid var(--border);
+            border-radius: var(--radius); font-size: 0.88rem; font-weight: 500;
+            color: var(--text); text-decoration: none; transition: all 0.2s;
+        }
+        .chip:hover { border-color: var(--accent); color: var(--accent); transform: translateY(-1px); }
+        .chip i { color: var(--accent); font-size: 0.9rem; }
+
+        /* --- RESEARCH: Compact list --- */
+        .research-list { display: grid; gap: 12px; }
+        .research-item {
+            display: flex; align-items: center; gap: 16px;
+            padding: 16px; background: var(--card-bg); border: 1px solid var(--border);
+            border-radius: var(--radius); text-decoration: none; transition: all 0.2s;
+        }
+        .research-item:hover { border-color: var(--accent); transform: translateX(4px); }
+        .research-icon {
+            width: 40px; height: 40px; border-radius: 8px;
+            background: var(--accent-soft); color: var(--accent);
+            display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+        }
+        .research-item h3 { font-size: 0.95rem; font-weight: 600; color: var(--text); margin-bottom: 2px; }
+        .research-item p { font-size: 0.82rem; color: var(--text-muted); margin: 0; }
+        .research-item .arrow { margin-left: auto; color: var(--text-muted); font-size: 0.8rem; }
+
+        /* --- TECH PROJECTS: Compact cards --- */
+        .project-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; }
+        .project-card {
+            padding: 20px; background: var(--card-bg); border: 1px solid var(--border);
+            border-radius: var(--radius); transition: all 0.2s;
+        }
+        .project-card:hover { border-color: var(--accent); }
+        .project-card h3 { font-size: 0.95rem; font-weight: 600; margin-bottom: 6px; }
+        .project-card p { font-size: 0.85rem; color: var(--text-muted); margin-bottom: 8px; }
+        .project-card .tag { font-size: 0.75rem; color: var(--accent); background: var(--accent-soft); padding: 3px 8px; border-radius: 4px; }
+
+        /* --- CLINICAL TIMELINE: Ultra-compact --- */
+        .mini-timeline { display: grid; gap: 0; }
+        .mini-timeline-item {
+            display: grid; grid-template-columns: 100px 1fr; gap: 16px;
+            padding: 14px 0; border-bottom: 1px solid var(--border);
+        }
+        .mini-timeline-item:last-child { border-bottom: none; }
+        .mini-timeline-item .date { font-size: 0.8rem; color: var(--accent); font-weight: 600; padding-top: 2px; }
+        .mini-timeline-item h3 { font-size: 0.9rem; font-weight: 600; margin-bottom: 4px; }
+        .mini-timeline-item p { font-size: 0.82rem; color: var(--text-muted); margin: 0; }
+
+        /* --- CONTACT: Inline row --- */
+        .contact-row { display: flex; gap: 16px; flex-wrap: wrap; align-items: center; }
+        .contact-row p { color: var(--text-secondary); font-size: 0.92rem; margin: 0; }
+        .contact-links { display: flex; gap: 10px; }
+        .contact-pill {
+            display: inline-flex; align-items: center; gap: 6px;
+            padding: 8px 14px; background: var(--card-bg); border: 1px solid var(--border);
+            border-radius: 6px; text-decoration: none; color: var(--text-secondary); font-size: 0.85rem;
+            transition: all 0.2s;
+        }
+        .contact-pill:hover { border-color: var(--accent); color: var(--accent); }
+        .contact-pill i { font-size: 0.9rem; }
+
+        /* --- FOOTER: Minimal single line --- */
+        .footer {
+            padding: 24px 0; border-top: 1px solid var(--border);
+            text-align: center; font-size: 0.8rem; color: var(--text-muted);
+        }
+
+        /* --- RESPONSIVE --- */
+        @media (max-width: 768px) {
+            .hero-inner { flex-direction: column; text-align: center; }
+            .hero-links { justify-content: center; }
+            .about-layout { grid-template-columns: 1fr; }
+            .nav-links { gap: 16px; }
+            .nav-links a { font-size: 0.8rem; }
+            .mini-timeline-item { grid-template-columns: 80px 1fr; }
+            .contact-row { flex-direction: column; text-align: center; }
+        }
+    </style>
+</head>
+<body>
+    <!-- HEADER -->
+    <header class="header">
+        <div class="container">
+            <a href="#" class="logo">skflx.MD</a>
+            <nav style="display:flex;align-items:center;gap:20px;">
+                <ul class="nav-links">
+                    <li><a href="#about">About</a></li>
+                    <li><a href="#research">Research</a></li>
+                    <li><a href="#projects">Projects</a></li>
+                    <li><a href="#clinical">Clinical</a></li>
+                    <li><a href="#contact">Contact</a></li>
+                </ul>
+                <button class="theme-btn" onclick="document.documentElement.toggleAttribute('data-theme') || (document.documentElement.dataset.theme = document.documentElement.dataset.theme === 'dark' ? '' : 'dark'); if(!document.documentElement.dataset.theme) delete document.documentElement.dataset.theme;">
+                    <i class="fas fa-circle-half-stroke"></i>
+                </button>
+            </nav>
+        </div>
+    </header>
+
+    <!-- HERO: Compact -->
+    <section class="hero">
+        <div class="container">
+            <div class="hero-inner">
+                <img src="../images/me_large.jpg" alt="Dr. Samipya Kafle" class="hero-photo">
+                <div class="hero-text">
+                    <div class="subtitle"><i class="fas fa-stethoscope"></i> PGY-2 Otolaryngology Resident</div>
+                    <h1>Samipya Kafle, MD</h1>
+                    <p>Surgeon-scientist in the Pacific Northwest. Passionate about technology, surgical education, and the intersection of medicine and innovation.</p>
+                    <div class="hero-links">
+                        <a href="#contact" class="btn-fill"><i class="fas fa-paper-plane"></i> Get in Touch</a>
+                        <a href="#" class="btn-ghost"><i class="fas fa-file-pdf"></i> CV</a>
+                        <a href="https://linkedin.com/in/skflx" target="_blank" class="btn-ghost"><i class="fab fa-linkedin"></i></a>
+                        <a href="https://github.com/skflx" target="_blank" class="btn-ghost"><i class="fab fa-github"></i></a>
+                        <a href="https://www.instagram.com/skflx/" target="_blank" class="btn-ghost"><i class="fab fa-instagram"></i></a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- ABOUT -->
+    <section id="about" class="section">
+        <div class="container">
+            <div class="section-title">About</div>
+            <div class="about-layout">
+                <div class="about-text">
+                    <p>My journey began in Nepal, spanning Michigan, Oregon, Nevada, and Connecticut before returning to the Pacific Northwest. With a background in neuroscience and personal experience with hearing loss, I bring a unique perspective to both clinical practice and research in hearing technologies.</p>
+                    <p>My research focuses on surgical outcomes in otolaryngology and emergent data technologies in medical education. I'm particularly interested in cognitive frameworks that enhance surgical learning.</p>
+                    <p>Beyond medicine, I'm an artist, musician, and outdoor enthusiast who values the balance between technical precision and creative expression.</p>
+                </div>
+                <div class="stat-pills">
+                    <div class="stat-pill">
+                        <div class="label">Residency</div>
+                        <div class="value">Yale School of Medicine</div>
+                    </div>
+                    <div class="stat-pill">
+                        <div class="label">Undergrad</div>
+                        <div class="value">UNR - Neuroscience</div>
+                    </div>
+                    <div class="stat-pill">
+                        <div class="label">Languages</div>
+                        <div class="value">Nepali, English, Spanish, Swiss German</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- WHAT I DO -->
+    <section class="section">
+        <div class="container">
+            <div class="section-title">What I Do</div>
+            <div class="chips">
+                <a href="#research" class="chip"><i class="fas fa-flask"></i> Research</a>
+                <a href="#projects" class="chip"><i class="fas fa-microchip"></i> Technology</a>
+                <span class="chip"><i class="fas fa-palette"></i> Art</span>
+                <span class="chip"><i class="fas fa-music"></i> Music</span>
+                <span class="chip"><i class="fas fa-mountain"></i> Outdoors</span>
+                <span class="chip"><i class="fas fa-dumbbell"></i> Fitness</span>
+            </div>
+        </div>
+    </section>
+
+    <!-- RESEARCH -->
+    <section id="research" class="section">
+        <div class="container">
+            <div class="section-title">Research</div>
+            <div class="research-list">
+                <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Trauma+OR+Fracture+OR+Injury)" target="_blank" class="research-item">
+                    <div class="research-icon"><i class="fas fa-skull"></i></div>
+                    <div>
+                        <h3>Craniofacial Trauma</h3>
+                        <p>Injury patterns in sports and surgical outcome factors</p>
+                    </div>
+                    <span class="arrow"><i class="fas fa-arrow-right"></i></span>
+                </a>
+                <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cancer+OR+Oncology)" target="_blank" class="research-item">
+                    <div class="research-icon"><i class="fas fa-ribbon"></i></div>
+                    <div>
+                        <h3>Head & Neck Oncology</h3>
+                        <p>Complications, risk factors, and survival outcomes</p>
+                    </div>
+                    <span class="arrow"><i class="fas fa-arrow-right"></i></span>
+                </a>
+                <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Education+OR+Training)" target="_blank" class="research-item">
+                    <div class="research-icon"><i class="fas fa-graduation-cap"></i></div>
+                    <div>
+                        <h3>Surgical Education</h3>
+                        <p>Innovative methods for surgical training and feedback systems</p>
+                    </div>
+                    <span class="arrow"><i class="fas fa-arrow-right"></i></span>
+                </a>
+                <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cochlear+OR+Hearing)" target="_blank" class="research-item">
+                    <div class="research-icon"><i class="fas fa-ear-listen"></i></div>
+                    <div>
+                        <h3>Otology & Hearing Sciences</h3>
+                        <p>Cortical adaptations in CI patients and speech processing</p>
+                    </div>
+                    <span class="arrow"><i class="fas fa-arrow-right"></i></span>
+                </a>
+            </div>
+            <div style="text-align:center;margin-top:20px;">
+                <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]" target="_blank" class="btn-fill" style="display:inline-flex;align-items:center;gap:6px;padding:8px 16px;border-radius:6px;font-size:0.85rem;text-decoration:none;">View All Papers <i class="fas fa-external-link-alt"></i></a>
+            </div>
+        </div>
+    </section>
+
+    <!-- TECH PROJECTS -->
+    <section id="projects" class="section">
+        <div class="container">
+            <div class="section-title">Technology</div>
+            <div class="project-grid">
+                <div class="project-card">
+                    <h3><i class="fas fa-wave-square" style="color:var(--accent);margin-right:6px;"></i>Speech-in-Noise Processing</h3>
+                    <p>Improving speech recognition in challenging environments for hearing devices.</p>
+                    <span class="tag">2022 - Present</span>
+                </div>
+                <div class="project-card">
+                    <h3><i class="fas fa-video" style="color:var(--accent);margin-right:6px;"></i>Surgical Livestreaming</h3>
+                    <p>System for livestreaming surgical procedures to medical students.</p>
+                    <span class="tag">2022 - Present</span>
+                </div>
+                <div class="project-card">
+                    <h3><i class="fas fa-terminal" style="color:var(--accent);margin-right:6px;"></i>ASCII Art Editor</h3>
+                    <p>Browser-based ASCII/Unicode diagram editor with templates.</p>
+                    <span class="tag">2025</span>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- CLINICAL -->
+    <section id="clinical" class="section">
+        <div class="container">
+            <div class="section-title">Clinical Experience</div>
+            <div class="mini-timeline">
+                <div class="mini-timeline-item">
+                    <div class="date">2022 - Now</div>
+                    <div>
+                        <h3>Surgery Livestreaming Elective</h3>
+                        <p>Designed curriculum for pre-clerkship students. Audio/video setup, exoscope mounting, team coordination.</p>
+                    </div>
+                </div>
+                <div class="mini-timeline-item">
+                    <div class="date">2020 - Now</div>
+                    <div>
+                        <h3>HAVEN Free Clinic</h3>
+                        <p>Primary care for uninsured patients. Senior Clinical Team Member.</p>
+                    </div>
+                </div>
+                <div class="mini-timeline-item">
+                    <div class="date">2021 - Now</div>
+                    <div>
+                        <h3>Point of Care Ultrasound Teaching</h3>
+                        <p>Hands-on training in essential ultrasound skills for medical students.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- CONTACT -->
+    <section id="contact" class="section">
+        <div class="container">
+            <div class="section-title">Contact</div>
+            <div class="contact-row">
+                <p>Interested in research collaborations, medical education, or just want to connect?</p>
+                <div class="contact-links">
+                    <a href="https://linkedin.com/in/skflx" target="_blank" class="contact-pill"><i class="fab fa-linkedin"></i> LinkedIn</a>
+                    <a href="https://www.instagram.com/skflx/" target="_blank" class="contact-pill"><i class="fab fa-instagram"></i> @skflx</a>
+                    <a href="https://github.com/skflx" target="_blank" class="contact-pill"><i class="fab fa-github"></i> GitHub</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- FOOTER -->
+    <footer class="footer">
+        <div class="container">
+            &copy; 2025 skflx.MD &middot; Portland, Oregon
+        </div>
+    </footer>
+</body>
+</html>

--- a/mockups/mockup-b-bento.html
+++ b/mockups/mockup-b-bento.html
@@ -1,0 +1,393 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mockup B: Bento Grid | skflx.MD</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <style>
+        /* ========================================================
+           MOCKUP B: BENTO GRID
+
+           Concept: Apple/Linear-inspired bento box layout.
+           Entire page is a visual grid of cards. No traditional
+           sections — everything is a "tile" in a masonry-like grid.
+           Highly visual, modern, trendy. Works beautifully dark.
+           ======================================================== */
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        :root {
+            --bg: #f5f5f7;
+            --card: #ffffff;
+            --text: #1d1d1f;
+            --text-secondary: #6e6e73;
+            --text-muted: #86868b;
+            --accent: #0071e3;
+            --accent-soft: #e3f0ff;
+            --border: #d2d2d7;
+            --font-body: 'Inter', -apple-system, sans-serif;
+            --font-display: 'DM Sans', -apple-system, sans-serif;
+            --radius: 16px;
+            --radius-sm: 10px;
+        }
+
+        [data-theme="dark"] {
+            --bg: #000000;
+            --card: #1c1c1e;
+            --text: #f5f5f7;
+            --text-secondary: #a1a1a6;
+            --text-muted: #6e6e73;
+            --accent: #2997ff;
+            --accent-soft: #0a2540;
+            --border: #38383a;
+        }
+
+        html { scroll-behavior: smooth; }
+        body {
+            font-family: var(--font-body);
+            color: var(--text);
+            background: var(--bg);
+            -webkit-font-smoothing: antialiased;
+        }
+
+        /* --- HEADER --- */
+        .header {
+            position: sticky; top: 0; z-index: 100;
+            background: color-mix(in srgb, var(--bg) 80%, transparent);
+            backdrop-filter: blur(20px) saturate(180%);
+            height: 48px; display: flex; align-items: center;
+            border-bottom: 0.5px solid var(--border);
+        }
+        .header-inner { max-width: 1200px; margin: 0 auto; padding: 0 24px; width: 100%; display: flex; justify-content: space-between; align-items: center; }
+        .logo { font-family: var(--font-display); font-weight: 700; font-size: 1rem; color: var(--text); text-decoration: none; }
+        .nav-links { list-style: none; display: flex; gap: 20px; }
+        .nav-links a { color: var(--text-muted); text-decoration: none; font-size: 0.8rem; transition: color 0.2s; }
+        .nav-links a:hover { color: var(--text); }
+        .theme-btn { background: none; border: none; cursor: pointer; color: var(--text-muted); font-size: 0.9rem; padding: 4px; }
+
+        /* --- BENTO GRID --- */
+        .bento-container { max-width: 1200px; margin: 0 auto; padding: 24px; }
+        .bento-grid {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 16px;
+            grid-auto-rows: minmax(160px, auto);
+        }
+
+        .bento-card {
+            background: var(--card);
+            border-radius: var(--radius);
+            padding: 28px;
+            display: flex; flex-direction: column; justify-content: space-between;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+            overflow: hidden; position: relative;
+        }
+        .bento-card:hover { transform: translateY(-2px); box-shadow: 0 8px 30px rgba(0,0,0,0.12); }
+
+        /* Sizing classes */
+        .span-2 { grid-column: span 2; }
+        .span-3 { grid-column: span 3; }
+        .span-4 { grid-column: span 4; }
+        .row-2 { grid-row: span 2; }
+
+        /* --- HERO CARD: Full width, large --- */
+        .card-hero {
+            grid-column: span 4;
+            min-height: 280px;
+            display: grid; grid-template-columns: 1fr auto;
+            gap: 32px; align-items: center;
+            background: linear-gradient(135deg, var(--card) 60%, var(--accent-soft) 100%);
+        }
+        .card-hero .hero-content { max-width: 560px; }
+        .card-hero h1 { font-family: var(--font-display); font-size: 2.5rem; font-weight: 700; line-height: 1.15; margin-bottom: 12px; }
+        .card-hero h1 .accent { color: var(--accent); }
+        .card-hero .subtitle { color: var(--accent); font-size: 0.88rem; font-weight: 500; margin-bottom: 12px; display: flex; align-items: center; gap: 6px; }
+        .card-hero p { color: var(--text-secondary); font-size: 0.95rem; line-height: 1.6; }
+        .card-hero .hero-photo {
+            width: 200px; height: 240px; border-radius: var(--radius-sm);
+            object-fit: cover;
+        }
+        .hero-ctas { display: flex; gap: 10px; margin-top: 16px; }
+        .hero-ctas a {
+            display: inline-flex; align-items: center; gap: 6px;
+            padding: 10px 20px; border-radius: 980px; font-size: 0.85rem; font-weight: 500; text-decoration: none;
+            transition: all 0.2s;
+        }
+        .cta-primary { background: var(--accent); color: #fff; }
+        .cta-primary:hover { filter: brightness(1.1); }
+        .cta-secondary { background: color-mix(in srgb, var(--text) 10%, transparent); color: var(--text); }
+        .cta-secondary:hover { background: color-mix(in srgb, var(--text) 18%, transparent); }
+
+        /* --- EDUCATION CARD --- */
+        .card-education .label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); margin-bottom: 14px; }
+        .edu-item { margin-bottom: 14px; }
+        .edu-item:last-child { margin-bottom: 0; }
+        .edu-item h3 { font-size: 0.95rem; font-weight: 600; margin-bottom: 2px; }
+        .edu-item p { font-size: 0.82rem; color: var(--text-muted); margin: 0; }
+
+        /* --- LANGUAGES CARD --- */
+        .lang-list { list-style: none; }
+        .lang-list li { display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 0.5px solid var(--border); font-size: 0.88rem; }
+        .lang-list li:last-child { border-bottom: none; }
+        .lang-level { color: var(--text-muted); font-size: 0.82rem; }
+
+        /* --- RESEARCH CARD --- */
+        .card-research { background: linear-gradient(135deg, var(--accent-soft), var(--card)); }
+        .research-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 12px; }
+        .research-tile {
+            padding: 14px; background: var(--card); border-radius: var(--radius-sm);
+            text-decoration: none; color: var(--text); transition: all 0.2s; display: block;
+        }
+        .research-tile:hover { transform: scale(1.02); }
+        .research-tile i { color: var(--accent); margin-bottom: 6px; display: block; font-size: 1.1rem; }
+        .research-tile h4 { font-size: 0.85rem; font-weight: 600; margin-bottom: 4px; }
+        .research-tile p { font-size: 0.75rem; color: var(--text-muted); margin: 0; }
+
+        /* --- INTERESTS: Icon grid --- */
+        .card-interests .label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); margin-bottom: 14px; }
+        .interest-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+        .interest-tile {
+            text-align: center; padding: 14px 8px;
+            background: color-mix(in srgb, var(--accent) 8%, transparent);
+            border-radius: var(--radius-sm);
+        }
+        .interest-tile i { font-size: 1.3rem; color: var(--accent); display: block; margin-bottom: 6px; }
+        .interest-tile span { font-size: 0.75rem; color: var(--text-secondary); }
+
+        /* --- TECH PROJECTS CARD --- */
+        .tech-list { display: flex; flex-direction: column; gap: 12px; margin-top: 12px; }
+        .tech-item {
+            display: flex; align-items: center; gap: 12px;
+            padding: 12px; background: color-mix(in srgb, var(--accent) 6%, transparent);
+            border-radius: var(--radius-sm);
+        }
+        .tech-item i { color: var(--accent); width: 20px; text-align: center; }
+        .tech-item .tech-info h4 { font-size: 0.88rem; font-weight: 600; }
+        .tech-item .tech-info p { font-size: 0.75rem; color: var(--text-muted); margin: 0; }
+
+        /* --- CLINICAL CARD --- */
+        .clinical-list { margin-top: 12px; }
+        .clinical-item { padding: 10px 0; border-bottom: 0.5px solid var(--border); }
+        .clinical-item:last-child { border-bottom: none; }
+        .clinical-item .year { font-size: 0.75rem; color: var(--accent); font-weight: 600; }
+        .clinical-item h4 { font-size: 0.88rem; font-weight: 600; margin: 2px 0; }
+        .clinical-item p { font-size: 0.78rem; color: var(--text-muted); margin: 0; }
+
+        /* --- CONNECT CARD --- */
+        .card-connect { background: linear-gradient(135deg, var(--accent), #5856d6); color: #fff; text-align: center; justify-content: center; align-items: center; }
+        .card-connect h3 { font-family: var(--font-display); font-size: 1.3rem; font-weight: 700; margin-bottom: 8px; }
+        .card-connect p { color: rgba(255,255,255,0.8); font-size: 0.88rem; margin-bottom: 16px; }
+        .connect-links { display: flex; gap: 10px; justify-content: center; }
+        .connect-links a {
+            width: 40px; height: 40px; display: flex; align-items: center; justify-content: center;
+            background: rgba(255,255,255,0.2); border-radius: 50%; color: #fff;
+            text-decoration: none; transition: background 0.2s; font-size: 1rem;
+        }
+        .connect-links a:hover { background: rgba(255,255,255,0.35); }
+
+        /* --- LOCATION CARD --- */
+        .card-location { justify-content: center; align-items: center; text-align: center; }
+        .card-location i { font-size: 1.5rem; color: var(--accent); margin-bottom: 8px; }
+        .card-location h4 { font-size: 0.95rem; font-weight: 600; margin-bottom: 2px; }
+        .card-location p { font-size: 0.82rem; color: var(--text-muted); margin: 0; }
+
+        /* --- FOOTER --- */
+        .footer { text-align: center; padding: 24px; font-size: 0.75rem; color: var(--text-muted); }
+
+        /* --- RESPONSIVE --- */
+        @media (max-width: 900px) {
+            .bento-grid { grid-template-columns: repeat(2, 1fr); }
+            .span-3, .span-4 { grid-column: span 2; }
+            .card-hero { grid-template-columns: 1fr; }
+            .card-hero .hero-photo { display: none; }
+            .research-grid { grid-template-columns: 1fr; }
+        }
+
+        @media (max-width: 600px) {
+            .bento-grid { grid-template-columns: 1fr; }
+            .span-2, .span-3, .span-4 { grid-column: span 1; }
+            .card-hero h1 { font-size: 1.8rem; }
+            .interest-grid { grid-template-columns: repeat(2, 1fr); }
+        }
+    </style>
+</head>
+<body>
+    <!-- HEADER -->
+    <header class="header">
+        <div class="header-inner">
+            <a href="#" class="logo">skflx.MD</a>
+            <nav style="display:flex;align-items:center;gap:16px;">
+                <ul class="nav-links">
+                    <li><a href="#">Home</a></li>
+                    <li><a href="#">Research</a></li>
+                    <li><a href="#">Contact</a></li>
+                </ul>
+                <button class="theme-btn" onclick="document.documentElement.dataset.theme = document.documentElement.dataset.theme === 'dark' ? '' : 'dark';">
+                    <i class="fas fa-circle-half-stroke"></i>
+                </button>
+            </nav>
+        </div>
+    </header>
+
+    <!-- BENTO LAYOUT -->
+    <div class="bento-container">
+        <div class="bento-grid">
+
+            <!-- ROW 1: Hero -->
+            <div class="bento-card card-hero">
+                <div class="hero-content">
+                    <div class="subtitle"><i class="fas fa-stethoscope"></i> PGY-2 Otolaryngology Resident</div>
+                    <h1>Hi, I'm <span class="accent">Samip.</span></h1>
+                    <p>Surgeon-scientist in the Pacific Northwest. Passionate about technology, surgical education, and the intersection of medicine and innovation.</p>
+                    <div class="hero-ctas">
+                        <a href="#" class="cta-primary"><i class="fas fa-paper-plane"></i> Get in Touch</a>
+                        <a href="#" class="cta-secondary"><i class="fas fa-file-pdf"></i> Download CV</a>
+                    </div>
+                </div>
+                <img src="../images/me_large.jpg" alt="Dr. Samipya Kafle" class="hero-photo">
+            </div>
+
+            <!-- ROW 2: Education + Languages + Interests -->
+            <div class="bento-card card-education">
+                <div class="label">Education</div>
+                <div>
+                    <div class="edu-item">
+                        <h3>Yale School of Medicine</h3>
+                        <p>Otolaryngology Residency</p>
+                    </div>
+                    <div class="edu-item">
+                        <h3>University of Nevada, Reno</h3>
+                        <p>B.S. Neuroscience</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="bento-card">
+                <div class="label" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-muted);margin-bottom:14px;">Languages</div>
+                <ul class="lang-list">
+                    <li>Nepali <span class="lang-level">Native</span></li>
+                    <li>English <span class="lang-level">Fluent</span></li>
+                    <li>Spanish <span class="lang-level">Intermediate</span></li>
+                    <li>Swiss German <span class="lang-level">Intermediate</span></li>
+                </ul>
+            </div>
+
+            <div class="bento-card card-interests span-2">
+                <div class="label">What I Do</div>
+                <div class="interest-grid">
+                    <div class="interest-tile"><i class="fas fa-flask"></i><span>Research</span></div>
+                    <div class="interest-tile"><i class="fas fa-microchip"></i><span>Technology</span></div>
+                    <div class="interest-tile"><i class="fas fa-palette"></i><span>Art</span></div>
+                    <div class="interest-tile"><i class="fas fa-music"></i><span>Music</span></div>
+                    <div class="interest-tile"><i class="fas fa-mountain"></i><span>Outdoors</span></div>
+                    <div class="interest-tile"><i class="fas fa-dumbbell"></i><span>Fitness</span></div>
+                </div>
+            </div>
+
+            <!-- ROW 3: Research (big card) -->
+            <div class="bento-card card-research span-4">
+                <div>
+                    <div class="label" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-muted);margin-bottom:4px;">Research</div>
+                    <h3 style="font-family:var(--font-display);font-size:1.15rem;font-weight:600;">Publications in Otolaryngology</h3>
+                </div>
+                <div class="research-grid">
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Trauma+OR+Fracture)" target="_blank" class="research-tile">
+                        <i class="fas fa-skull"></i>
+                        <h4>Craniofacial Trauma</h4>
+                        <p>Injury patterns in sports and surgical outcomes</p>
+                    </a>
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cancer+OR+Oncology)" target="_blank" class="research-tile">
+                        <i class="fas fa-ribbon"></i>
+                        <h4>Head & Neck Oncology</h4>
+                        <p>Complications, risk factors, survival outcomes</p>
+                    </a>
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Education+OR+Training)" target="_blank" class="research-tile">
+                        <i class="fas fa-graduation-cap"></i>
+                        <h4>Surgical Education</h4>
+                        <p>Live-streaming and automated feedback systems</p>
+                    </a>
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cochlear+OR+Hearing)" target="_blank" class="research-tile">
+                        <i class="fas fa-ear-listen"></i>
+                        <h4>Otology & Hearing Sciences</h4>
+                        <p>Cochlear implant adaptations and speech processing</p>
+                    </a>
+                </div>
+            </div>
+
+            <!-- ROW 4: Tech + Clinical + Connect -->
+            <div class="bento-card span-2">
+                <div class="label" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-muted);margin-bottom:4px;">Technology</div>
+                <h3 style="font-family:var(--font-display);font-size:1.05rem;font-weight:600;">Projects</h3>
+                <div class="tech-list">
+                    <div class="tech-item">
+                        <i class="fas fa-wave-square"></i>
+                        <div class="tech-info">
+                            <h4>Speech-in-Noise Processing</h4>
+                            <p>Hearing device enhancement &middot; 2022-Present</p>
+                        </div>
+                    </div>
+                    <div class="tech-item">
+                        <i class="fas fa-video"></i>
+                        <div class="tech-info">
+                            <h4>Surgical Livestreaming</h4>
+                            <p>Procedure streaming platform &middot; 2022-Present</p>
+                        </div>
+                    </div>
+                    <div class="tech-item">
+                        <i class="fas fa-terminal"></i>
+                        <div class="tech-info">
+                            <h4>ASCII Art Editor</h4>
+                            <p>Browser-based diagram tool &middot; 2025</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="bento-card">
+                <div class="label" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-muted);margin-bottom:4px;">Clinical</div>
+                <div class="clinical-list">
+                    <div class="clinical-item">
+                        <span class="year">2022-Now</span>
+                        <h4>Surgery Livestreaming</h4>
+                        <p>Pre-clerkship curriculum design</p>
+                    </div>
+                    <div class="clinical-item">
+                        <span class="year">2020-Now</span>
+                        <h4>HAVEN Free Clinic</h4>
+                        <p>Senior Clinical Team Member</p>
+                    </div>
+                    <div class="clinical-item">
+                        <span class="year">2021-Now</span>
+                        <h4>POCUS Teaching</h4>
+                        <p>Ultrasound skills training</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="bento-card card-connect">
+                <h3>Let's Connect</h3>
+                <p>Research, innovation, or just say hello.</p>
+                <div class="connect-links">
+                    <a href="https://linkedin.com/in/skflx" target="_blank"><i class="fab fa-linkedin"></i></a>
+                    <a href="https://www.instagram.com/skflx/" target="_blank"><i class="fab fa-instagram"></i></a>
+                    <a href="https://github.com/skflx" target="_blank"><i class="fab fa-github"></i></a>
+                </div>
+            </div>
+
+            <!-- ROW 5: Location -->
+            <div class="bento-card card-location">
+                <i class="fas fa-map-marker-alt"></i>
+                <h4>Portland, Oregon</h4>
+                <p>Pacific Northwest</p>
+            </div>
+
+        </div>
+    </div>
+
+    <footer class="footer">&copy; 2025 skflx.MD</footer>
+</body>
+</html>

--- a/mockups/mockup-c-editorial.html
+++ b/mockups/mockup-c-editorial.html
@@ -1,0 +1,401 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mockup C: Editorial | skflx.MD</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <style>
+        /* ========================================================
+           MOCKUP C: EDITORIAL / MAGAZINE
+
+           Concept: Typography-forward, content-dense, sophisticated.
+           Inspired by editorial magazines and academic CVs.
+           Uses serif headings + sans body. Columnar layouts.
+           Dense but readable. Very professional, very elegant.
+           ======================================================== */
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        :root {
+            --bg: #faf9f6;
+            --bg-alt: #f0efe8;
+            --text: #2c2c2c;
+            --text-secondary: #555;
+            --text-muted: #8a8a8a;
+            --accent: #b8860b;
+            --accent-soft: #f5ecd7;
+            --border: #ddd;
+            --card-bg: #fff;
+            --font-serif: 'Playfair Display', Georgia, serif;
+            --font-sans: 'Inter', -apple-system, sans-serif;
+        }
+
+        [data-theme="dark"] {
+            --bg: #1a1a1a;
+            --bg-alt: #222;
+            --text: #e8e6e0;
+            --text-secondary: #b0b0b0;
+            --text-muted: #777;
+            --accent: #d4a844;
+            --accent-soft: #2a2518;
+            --border: #333;
+            --card-bg: #242424;
+        }
+
+        html { scroll-behavior: smooth; }
+        body {
+            font-family: var(--font-sans);
+            color: var(--text);
+            background: var(--bg);
+            -webkit-font-smoothing: antialiased;
+            font-size: 15px;
+            line-height: 1.7;
+        }
+
+        /* --- HEADER: Editorial masthead --- */
+        .masthead {
+            text-align: center;
+            padding: 32px 24px 24px;
+            border-bottom: 2px solid var(--text);
+        }
+        .masthead-logo {
+            font-family: var(--font-serif); font-size: 2rem; font-weight: 700;
+            letter-spacing: 0.05em; color: var(--text); text-decoration: none;
+        }
+        .masthead-nav {
+            margin-top: 12px; display: flex; justify-content: center; gap: 32px;
+            list-style: none;
+        }
+        .masthead-nav a {
+            color: var(--text-muted); text-decoration: none; font-size: 0.8rem;
+            text-transform: uppercase; letter-spacing: 0.12em; font-weight: 500;
+            transition: color 0.2s;
+        }
+        .masthead-nav a:hover { color: var(--accent); }
+        .theme-btn {
+            position: fixed; top: 16px; right: 16px; z-index: 200;
+            background: var(--card-bg); border: 1px solid var(--border); border-radius: 50%;
+            width: 36px; height: 36px; cursor: pointer; color: var(--text-muted);
+        }
+
+        .page { max-width: 900px; margin: 0 auto; padding: 0 24px; }
+
+        /* --- HERO: Editorial style with large serif title --- */
+        .hero-editorial {
+            padding: 56px 0 40px;
+            display: grid; grid-template-columns: 180px 1fr; gap: 40px; align-items: start;
+            border-bottom: 1px solid var(--border);
+        }
+        .hero-photo {
+            width: 180px; height: 220px; object-fit: cover;
+            filter: grayscale(30%);
+            transition: filter 0.3s;
+        }
+        .hero-photo:hover { filter: grayscale(0%); }
+        .hero-text h1 {
+            font-family: var(--font-serif); font-size: 2.8rem; font-weight: 700;
+            line-height: 1.1; margin-bottom: 12px; letter-spacing: -0.01em;
+        }
+        .hero-text .role {
+            font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.1em;
+            color: var(--accent); font-weight: 500; margin-bottom: 14px;
+        }
+        .hero-text p { color: var(--text-secondary); font-size: 0.95rem; max-width: 480px; margin-bottom: 16px; }
+        .hero-meta {
+            display: flex; gap: 20px; font-size: 0.82rem; color: var(--text-muted);
+            border-top: 1px solid var(--border); padding-top: 14px; margin-top: 14px;
+        }
+        .hero-meta a { color: var(--text-muted); text-decoration: none; transition: color 0.2s; }
+        .hero-meta a:hover { color: var(--accent); }
+        .hero-meta i { margin-right: 4px; }
+
+        /* --- TWO-COLUMN BODY: Like a newspaper --- */
+        .two-col {
+            display: grid; grid-template-columns: 1fr 1fr; gap: 40px;
+            padding: 40px 0; border-bottom: 1px solid var(--border);
+        }
+
+        .section-label {
+            font-family: var(--font-serif); font-size: 0.7rem;
+            text-transform: uppercase; letter-spacing: 0.15em;
+            color: var(--accent); margin-bottom: 16px;
+            padding-bottom: 8px; border-bottom: 1px solid var(--accent);
+            display: inline-block;
+        }
+
+        /* --- ABOUT COLUMN --- */
+        .about-col p { font-size: 0.92rem; color: var(--text-secondary); margin-bottom: 10px; }
+
+        /* --- SIDEBAR COLUMN --- */
+        .sidebar-col h3 {
+            font-family: var(--font-serif); font-size: 1.05rem; font-weight: 600;
+            margin-bottom: 8px;
+        }
+        .sidebar-col .detail { margin-bottom: 16px; }
+        .sidebar-col .detail p { font-size: 0.85rem; color: var(--text-muted); margin: 0; }
+        .lang-inline { font-size: 0.85rem; color: var(--text-secondary); line-height: 1.8; }
+        .lang-inline strong { color: var(--text); font-weight: 500; }
+
+        /* --- RESEARCH SECTION: Dense, academic --- */
+        .research-section { padding: 40px 0; border-bottom: 1px solid var(--border); }
+        .research-entries { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+        .research-entry {
+            padding: 20px; border-left: 3px solid var(--accent);
+            background: var(--card-bg); transition: all 0.2s;
+            text-decoration: none; color: var(--text); display: block;
+        }
+        .research-entry:hover { background: var(--accent-soft); }
+        .research-entry h3 { font-family: var(--font-serif); font-size: 1rem; font-weight: 600; margin-bottom: 6px; }
+        .research-entry p { font-size: 0.82rem; color: var(--text-muted); margin: 0; }
+        .research-entry .pub-link { font-size: 0.78rem; color: var(--accent); margin-top: 8px; display: inline-block; }
+
+        /* --- PROJECTS SECTION --- */
+        .projects-section { padding: 40px 0; border-bottom: 1px solid var(--border); }
+        .project-list { list-style: none; }
+        .project-list li {
+            display: grid; grid-template-columns: 80px 1fr auto; gap: 16px;
+            padding: 16px 0; border-bottom: 1px solid var(--border); align-items: center;
+        }
+        .project-list li:last-child { border-bottom: none; }
+        .project-year { font-size: 0.82rem; color: var(--accent); font-weight: 600; }
+        .project-name { font-weight: 600; font-size: 0.92rem; }
+        .project-name span { display: block; font-weight: 400; font-size: 0.82rem; color: var(--text-muted); }
+        .project-tag {
+            font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.06em;
+            padding: 4px 10px; background: var(--accent-soft); color: var(--accent);
+            border-radius: 3px; font-weight: 500;
+        }
+
+        /* --- CLINICAL SECTION --- */
+        .clinical-section { padding: 40px 0; border-bottom: 1px solid var(--border); }
+        .cv-entry { margin-bottom: 20px; padding-left: 16px; border-left: 2px solid var(--border); }
+        .cv-entry:hover { border-left-color: var(--accent); }
+        .cv-entry .cv-date { font-size: 0.78rem; color: var(--accent); font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+        .cv-entry h3 { font-family: var(--font-serif); font-size: 0.95rem; font-weight: 600; margin: 4px 0; }
+        .cv-entry p { font-size: 0.82rem; color: var(--text-muted); margin: 0; }
+
+        /* --- INTERESTS: Inline paragraph style --- */
+        .interests-section { padding: 40px 0; border-bottom: 1px solid var(--border); }
+        .interests-prose { font-size: 0.92rem; color: var(--text-secondary); line-height: 1.8; }
+        .interests-prose .tag {
+            display: inline-flex; align-items: center; gap: 4px;
+            padding: 2px 10px; background: var(--accent-soft); border-radius: 3px;
+            font-size: 0.85rem; color: var(--accent); font-weight: 500; margin: 0 2px;
+        }
+
+        /* --- CONTACT: Minimal footer-style --- */
+        .contact-section { padding: 40px 0; text-align: center; }
+        .contact-section h2 {
+            font-family: var(--font-serif); font-size: 1.6rem; font-weight: 700;
+            margin-bottom: 8px;
+        }
+        .contact-section p { color: var(--text-muted); font-size: 0.88rem; margin-bottom: 20px; max-width: 400px; margin-left: auto; margin-right: auto; }
+        .contact-icons { display: flex; gap: 16px; justify-content: center; }
+        .contact-icons a {
+            width: 44px; height: 44px; display: flex; align-items: center; justify-content: center;
+            border: 1px solid var(--border); border-radius: 50%; color: var(--text-muted);
+            text-decoration: none; transition: all 0.2s; font-size: 1rem;
+        }
+        .contact-icons a:hover { border-color: var(--accent); color: var(--accent); }
+
+        /* --- FOOTER --- */
+        .footer {
+            text-align: center; padding: 20px; font-size: 0.75rem; color: var(--text-muted);
+            border-top: 2px solid var(--text);
+        }
+
+        /* --- RESPONSIVE --- */
+        @media (max-width: 768px) {
+            .hero-editorial { grid-template-columns: 1fr; text-align: center; }
+            .hero-photo { margin: 0 auto; width: 140px; height: 170px; }
+            .hero-text h1 { font-size: 2rem; }
+            .hero-meta { justify-content: center; }
+            .two-col { grid-template-columns: 1fr; }
+            .research-entries { grid-template-columns: 1fr; }
+            .project-list li { grid-template-columns: 60px 1fr; }
+            .project-list li .project-tag { display: none; }
+            .masthead-nav { gap: 20px; flex-wrap: wrap; }
+        }
+    </style>
+</head>
+<body>
+    <button class="theme-btn" onclick="document.documentElement.dataset.theme = document.documentElement.dataset.theme === 'dark' ? '' : 'dark';">
+        <i class="fas fa-circle-half-stroke"></i>
+    </button>
+
+    <!-- MASTHEAD -->
+    <header class="masthead">
+        <a href="#" class="masthead-logo">skflx.MD</a>
+        <nav>
+            <ul class="masthead-nav">
+                <li><a href="#about">About</a></li>
+                <li><a href="#research">Research</a></li>
+                <li><a href="#projects">Projects</a></li>
+                <li><a href="#clinical">Clinical</a></li>
+                <li><a href="#contact">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <div class="page">
+
+        <!-- HERO -->
+        <section class="hero-editorial">
+            <img src="../images/me_large.jpg" alt="Dr. Samipya Kafle" class="hero-photo">
+            <div class="hero-text">
+                <div class="role">PGY-2 Otolaryngology Resident</div>
+                <h1>Samipya Kafle, MD</h1>
+                <p>Surgeon-scientist in the Pacific Northwest. Passionate about technology, surgical education, and the intersection of medicine and innovation.</p>
+                <div class="hero-meta">
+                    <span><i class="fas fa-map-marker-alt"></i> Portland, OR</span>
+                    <a href="https://linkedin.com/in/skflx" target="_blank"><i class="fab fa-linkedin"></i> LinkedIn</a>
+                    <a href="https://github.com/skflx" target="_blank"><i class="fab fa-github"></i> GitHub</a>
+                    <a href="https://www.instagram.com/skflx/" target="_blank"><i class="fab fa-instagram"></i> @skflx</a>
+                </div>
+            </div>
+        </section>
+
+        <!-- TWO-COLUMN: About + Sidebar -->
+        <section id="about" class="two-col">
+            <div class="about-col">
+                <div class="section-label">About</div>
+                <p>My journey began in Nepal, spanning Michigan, Oregon, Nevada, and Connecticut before returning to the Pacific Northwest. With a background in neuroscience and personal experience with hearing loss, I bring a unique perspective to both clinical practice and research in hearing technologies.</p>
+                <p>My research focuses on surgical outcomes in otolaryngology and emergent data technologies in medical education and surgical training. I'm particularly interested in cognitive frameworks that enhance surgical learning.</p>
+                <p>Beyond medicine, I'm an artist, musician, and outdoor enthusiast who values the balance between technical precision and creative expression.</p>
+            </div>
+            <div class="sidebar-col">
+                <div class="section-label">Education</div>
+                <div class="detail">
+                    <h3>Yale School of Medicine</h3>
+                    <p>Otolaryngology Residency</p>
+                </div>
+                <div class="detail">
+                    <h3>University of Nevada, Reno</h3>
+                    <p>B.S. Neuroscience</p>
+                </div>
+
+                <div class="section-label" style="margin-top: 24px;">Languages</div>
+                <div class="lang-inline">
+                    <strong>Nepali</strong> (Native) &middot;
+                    <strong>English</strong> (Fluent) &middot;
+                    <strong>Spanish</strong> (Intermediate) &middot;
+                    <strong>Swiss German</strong> (Intermediate)
+                </div>
+            </div>
+        </section>
+
+        <!-- RESEARCH -->
+        <section id="research" class="research-section">
+            <div class="section-label">Research</div>
+            <div class="research-entries">
+                <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Trauma+OR+Fracture+OR+Injury)" target="_blank" class="research-entry">
+                    <h3>Craniofacial Trauma</h3>
+                    <p>Investigating injury patterns in sports and identifying factors associated with surgical outcomes.</p>
+                    <span class="pub-link">View on PubMed &rarr;</span>
+                </a>
+                <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cancer+OR+Oncology+OR+Laryngectomy)" target="_blank" class="research-entry">
+                    <h3>Head & Neck Oncology</h3>
+                    <p>Characterizing complications, risk factors, and survival outcomes in head and neck cancer surgeries.</p>
+                    <span class="pub-link">View on PubMed &rarr;</span>
+                </a>
+                <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Education+OR+Training+OR+Student)" target="_blank" class="research-entry">
+                    <h3>Surgical Education</h3>
+                    <p>Exploring innovative methods for surgical training, including live-streaming and automated feedback.</p>
+                    <span class="pub-link">View on PubMed &rarr;</span>
+                </a>
+                <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cochlear+OR+Hearing+OR+Otology)" target="_blank" class="research-entry">
+                    <h3>Otology & Hearing Sciences</h3>
+                    <p>Studying cortical adaptations in cochlear implant patients and improving speech processing.</p>
+                    <span class="pub-link">View on PubMed &rarr;</span>
+                </a>
+            </div>
+        </section>
+
+        <!-- PROJECTS -->
+        <section id="projects" class="projects-section">
+            <div class="section-label">Technology Projects</div>
+            <ul class="project-list">
+                <li>
+                    <span class="project-year">2022</span>
+                    <div class="project-name">
+                        Speech-in-Noise Processing
+                        <span>Improving speech recognition in hearing devices for challenging environments</span>
+                    </div>
+                    <span class="project-tag">Ongoing</span>
+                </li>
+                <li>
+                    <span class="project-year">2022</span>
+                    <div class="project-name">
+                        Surgical Livestreaming Platform
+                        <span>Technical system for livestreaming procedures to medical students</span>
+                    </div>
+                    <span class="project-tag">Ongoing</span>
+                </li>
+                <li>
+                    <span class="project-year">2025</span>
+                    <div class="project-name">
+                        ASCII Art Editor
+                        <span>Browser-based ASCII/Unicode diagram editor with templates and export</span>
+                    </div>
+                    <span class="project-tag">Shipped</span>
+                </li>
+            </ul>
+        </section>
+
+        <!-- CLINICAL -->
+        <section id="clinical" class="clinical-section">
+            <div class="section-label">Clinical Experience</div>
+            <div class="cv-entry">
+                <div class="cv-date">2022 &mdash; Present</div>
+                <h3>Surgery Livestreaming Elective</h3>
+                <p>Designed and organized curriculum for pre-clerkship medical students through live-streaming procedures. Audio/video setup and sterile exoscope mounting.</p>
+            </div>
+            <div class="cv-entry">
+                <div class="cv-date">2020 &mdash; Present</div>
+                <h3>HAVEN Free Clinic</h3>
+                <p>Primary care for uninsured and underinsured patients as Senior Clinical Team Member. Mentoring junior team members.</p>
+            </div>
+            <div class="cv-entry">
+                <div class="cv-date">2021 &mdash; Present</div>
+                <h3>Point of Care Ultrasound Teaching</h3>
+                <p>Hands-on training in essential ultrasound skills through weekly small-group lessons for MS1 curriculum.</p>
+            </div>
+        </section>
+
+        <!-- INTERESTS -->
+        <section class="interests-section">
+            <div class="section-label">Beyond Medicine</div>
+            <p class="interests-prose">
+                My life outside the hospital is just as full. I create
+                <span class="tag"><i class="fas fa-palette"></i> art</span>
+                in ink and graphite, play
+                <span class="tag"><i class="fas fa-music"></i> guitar & ukulele</span>,
+                spend time
+                <span class="tag"><i class="fas fa-mountain"></i> hiking</span>
+                the Pacific Northwest, and stay fit through
+                <span class="tag"><i class="fas fa-dumbbell"></i> powerlifting</span>.
+                I value the balance between technical precision and creative expression &mdash;
+                deadlifts are my favorite.
+            </p>
+        </section>
+
+        <!-- CONTACT -->
+        <section id="contact" class="contact-section">
+            <h2>Let's Connect</h2>
+            <p>Interested in research collaborations, medical education, or just want to say hello.</p>
+            <div class="contact-icons">
+                <a href="https://linkedin.com/in/skflx" target="_blank" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
+                <a href="https://www.instagram.com/skflx/" target="_blank" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
+                <a href="https://github.com/skflx" target="_blank" aria-label="GitHub"><i class="fab fa-github"></i></a>
+            </div>
+        </section>
+
+    </div>
+
+    <footer class="footer">&copy; 2025 skflx.MD &middot; Portland, Oregon</footer>
+</body>
+</html>


### PR DESCRIPTION
Three self-contained HTML mockups exploring condensed, aesthetic redesigns:
- Mockup A: Condensed single-page (compact hero, chip-style interests, list-based research)
- Mockup B: Bento grid (Apple/Linear-inspired tile layout, visually striking)
- Mockup C: Editorial/magazine (serif typography, newspaper columns, academic elegance)
All solve core issues: single-page, no hidden tabs, higher information density.

https://claude.ai/code/session_015CiaeMGMkcFzsMSehA92iv