### PR TITLE
Add bento-grid one-pager mockup

### DIFF
--- a/mockups/one-pager-editorial.html
+++ b/mockups/one-pager-editorial.html
@@ -1,0 +1,459 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Editorial &middot; Samipya Kafle, MD</title>
+
+    <!-- Set theme before paint to avoid flash -->
+    <script>
+        (function () {
+            try {
+                var stored = localStorage.getItem('sk_theme');
+                var theme = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+                document.documentElement.setAttribute('data-theme', theme);
+            } catch (e) {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        })();
+    </script>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <style>
+        /* ========================================================
+           MOCKUP C: EDITORIAL / MAGAZINE
+
+           Concept: Typography-forward, content-dense, sophisticated.
+           Inspired by editorial magazines and academic CVs.
+           Uses serif headings + sans body. Columnar layouts.
+           Dense but readable. Very professional, very elegant.
+           ======================================================== */
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        :root {
+            --bg: #faf9f6;
+            --bg-alt: #f0efe8;
+            --text: #2c2c2c;
+            --text-secondary: #555;
+            --text-muted: #8a8a8a;
+            --accent: #b8860b;
+            --accent-soft: #f5ecd7;
+            --border: #ddd;
+            --card-bg: #fff;
+            --font-serif: 'Playfair Display', Georgia, serif;
+            --font-sans: 'Inter', -apple-system, sans-serif;
+        }
+
+        [data-theme="dark"] {
+            --bg: #1a1a1a;
+            --bg-alt: #222;
+            --text: #e8e6e0;
+            --text-secondary: #b0b0b0;
+            --text-muted: #777;
+            --accent: #d4a844;
+            --accent-soft: #2a2518;
+            --border: #333;
+            --card-bg: #242424;
+        }
+
+        html { scroll-behavior: smooth; }
+        body {
+            font-family: var(--font-sans);
+            color: var(--text);
+            background: var(--bg);
+            -webkit-font-smoothing: antialiased;
+            font-size: 15px;
+            line-height: 1.7;
+        }
+
+        /* --- HEADER: Editorial masthead --- */
+        .masthead {
+            text-align: center;
+            padding: 32px 24px 24px;
+            border-bottom: 2px solid var(--text);
+        }
+        .masthead-logo {
+            font-family: var(--font-serif); font-size: 2rem; font-weight: 700;
+            letter-spacing: 0.05em; color: var(--text); text-decoration: none;
+        }
+        .masthead-nav {
+            margin-top: 12px; display: flex; justify-content: center; gap: 32px;
+            list-style: none;
+        }
+        .masthead-nav a {
+            color: var(--text-muted); text-decoration: none; font-size: 0.8rem;
+            text-transform: uppercase; letter-spacing: 0.12em; font-weight: 500;
+            transition: color 0.2s;
+        }
+        .masthead-nav a:hover { color: var(--accent); }
+        .theme-btn {
+            position: fixed; top: 16px; right: 16px; z-index: 200;
+            background: var(--card-bg); border: 1px solid var(--border); border-radius: 50%;
+            width: 36px; height: 36px; cursor: pointer; color: var(--text-muted);
+        }
+
+        .page { max-width: 900px; margin: 0 auto; padding: 0 24px; }
+
+        /* --- HERO: Editorial style with large serif title --- */
+        .hero-editorial {
+            padding: 56px 0 40px;
+            display: grid; grid-template-columns: 180px 1fr; gap: 40px; align-items: start;
+            border-bottom: 1px solid var(--border);
+        }
+        .hero-photo {
+            width: 180px; height: 220px; object-fit: cover;
+            filter: grayscale(30%);
+            transition: filter 0.3s;
+        }
+        .hero-photo:hover { filter: grayscale(0%); }
+        .hero-text h1 {
+            font-family: var(--font-serif); font-size: 2.8rem; font-weight: 700;
+            line-height: 1.1; margin-bottom: 12px; letter-spacing: -0.01em;
+        }
+        .hero-text .role {
+            font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.1em;
+            color: var(--accent); font-weight: 500; margin-bottom: 14px;
+        }
+        .hero-text p { color: var(--text-secondary); font-size: 0.95rem; max-width: 480px; margin-bottom: 16px; }
+        .hero-meta {
+            display: flex; gap: 20px; font-size: 0.82rem; color: var(--text-muted);
+            border-top: 1px solid var(--border); padding-top: 14px; margin-top: 14px;
+        }
+        .hero-meta a { color: var(--text-muted); text-decoration: none; transition: color 0.2s; }
+        .hero-meta a:hover { color: var(--accent); }
+        .hero-meta i { margin-right: 4px; }
+
+        /* --- TWO-COLUMN BODY: Like a newspaper --- */
+        .two-col {
+            display: grid; grid-template-columns: 1fr 1fr; gap: 40px;
+            padding: 40px 0; border-bottom: 1px solid var(--border);
+        }
+
+        .section-label {
+            font-family: var(--font-serif); font-size: 0.7rem;
+            text-transform: uppercase; letter-spacing: 0.15em;
+            color: var(--accent); margin-bottom: 16px;
+            padding-bottom: 8px; border-bottom: 1px solid var(--accent);
+            display: inline-block;
+        }
+
+        /* --- ABOUT COLUMN --- */
+        .about-col p { font-size: 0.92rem; color: var(--text-secondary); margin-bottom: 10px; }
+
+        /* --- SIDEBAR COLUMN --- */
+        .sidebar-col h3 {
+            font-family: var(--font-serif); font-size: 1.05rem; font-weight: 600;
+            margin-bottom: 8px;
+        }
+        .sidebar-col .detail { margin-bottom: 16px; }
+        .sidebar-col .detail p { font-size: 0.85rem; color: var(--text-muted); margin: 0; }
+        .lang-inline { font-size: 0.85rem; color: var(--text-secondary); line-height: 1.8; }
+        .lang-inline strong { color: var(--text); font-weight: 500; }
+
+        /* --- RESEARCH SECTION: Dense, academic --- */
+        .research-section { padding: 40px 0; border-bottom: 1px solid var(--border); }
+        .research-entries { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+        .research-entry {
+            padding: 20px; border-left: 3px solid var(--accent);
+            background: var(--card-bg); transition: all 0.2s;
+            text-decoration: none; color: var(--text); display: block;
+        }
+        .research-entry:hover { background: var(--accent-soft); }
+        .research-entry h3 { font-family: var(--font-serif); font-size: 1rem; font-weight: 600; margin-bottom: 6px; }
+        .research-entry p { font-size: 0.82rem; color: var(--text-muted); margin: 0; }
+        .research-entry .pub-link { font-size: 0.78rem; color: var(--accent); margin-top: 8px; display: inline-block; }
+
+        /* --- PROJECTS SECTION --- */
+        .projects-section { padding: 40px 0; border-bottom: 1px solid var(--border); }
+        .project-list { list-style: none; }
+        .project-list li {
+            display: grid; grid-template-columns: 80px 1fr auto; gap: 16px;
+            padding: 16px 0; border-bottom: 1px solid var(--border); align-items: center;
+        }
+        .project-list li:last-child { border-bottom: none; }
+        .project-year { font-size: 0.82rem; color: var(--accent); font-weight: 600; }
+        .project-name { font-weight: 600; font-size: 0.92rem; }
+        .project-name span { display: block; font-weight: 400; font-size: 0.82rem; color: var(--text-muted); }
+        .project-tag {
+            font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.06em;
+            padding: 4px 10px; background: var(--accent-soft); color: var(--accent);
+            border-radius: 3px; font-weight: 500;
+        }
+
+        /* --- CLINICAL SECTION --- */
+        .clinical-section { padding: 40px 0; border-bottom: 1px solid var(--border); }
+        .cv-entry { margin-bottom: 20px; padding-left: 16px; border-left: 2px solid var(--border); }
+        .cv-entry:hover { border-left-color: var(--accent); }
+        .cv-entry .cv-date { font-size: 0.78rem; color: var(--accent); font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+        .cv-entry h3 { font-family: var(--font-serif); font-size: 0.95rem; font-weight: 600; margin: 4px 0; }
+        .cv-entry p { font-size: 0.82rem; color: var(--text-muted); margin: 0; }
+
+        /* --- INTERESTS: Inline paragraph style --- */
+        .interests-section { padding: 40px 0; border-bottom: 1px solid var(--border); }
+        .interests-prose { font-size: 0.92rem; color: var(--text-secondary); line-height: 1.8; }
+        .interests-prose .tag {
+            display: inline-flex; align-items: center; gap: 4px;
+            padding: 2px 10px; background: var(--accent-soft); border-radius: 3px;
+            font-size: 0.85rem; color: var(--accent); font-weight: 500; margin: 0 2px;
+        }
+
+        /* --- CONTACT: Minimal footer-style --- */
+        .contact-section { padding: 40px 0; text-align: center; }
+        .contact-section h2 {
+            font-family: var(--font-serif); font-size: 1.6rem; font-weight: 700;
+            margin-bottom: 8px;
+        }
+        .contact-section p { color: var(--text-muted); font-size: 0.88rem; margin-bottom: 20px; max-width: 400px; margin-left: auto; margin-right: auto; }
+        .contact-icons { display: flex; gap: 16px; justify-content: center; }
+        .contact-icons a {
+            width: 44px; height: 44px; display: flex; align-items: center; justify-content: center;
+            border: 1px solid var(--border); border-radius: 50%; color: var(--text-muted);
+            text-decoration: none; transition: all 0.2s; font-size: 1rem;
+        }
+        .contact-icons a:hover { border-color: var(--accent); color: var(--accent); }
+
+        /* --- FOOTER --- */
+        .footer {
+            text-align: center; padding: 20px; font-size: 0.75rem; color: var(--text-muted);
+            border-top: 2px solid var(--text);
+        }
+
+        /* --- RESPONSIVE --- */
+        @media (max-width: 768px) {
+            .hero-editorial { grid-template-columns: 1fr; text-align: center; }
+            .hero-photo { margin: 0 auto; width: 140px; height: 170px; }
+            .hero-text h1 { font-size: 2rem; }
+            .hero-meta { justify-content: center; }
+            .two-col { grid-template-columns: 1fr; }
+            .research-entries { grid-template-columns: 1fr; }
+            .project-list li { grid-template-columns: 60px 1fr; }
+            .project-list li .project-tag { display: none; }
+            .masthead-nav { gap: 20px; flex-wrap: wrap; }
+        }
+    </style>
+</head>
+<body>
+    <button class="theme-btn" id="theme-toggle" aria-label="Toggle dark mode">
+        <i class="fas fa-circle-half-stroke"></i>
+    </button>
+
+    <!-- MASTHEAD -->
+    <header class="masthead">
+        <a href="#" class="masthead-logo">skflx.MD</a>
+        <nav>
+            <ul class="masthead-nav">
+                <li><a href="#about">About</a></li>
+                <li><a href="#research">Research</a></li>
+                <li><a href="#projects">Projects</a></li>
+                <li><a href="#clinical">Clinical</a></li>
+                <li><a href="#contact">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <div class="page">
+
+        <!-- HERO -->
+        <section class="hero-editorial">
+            <img src="../images/me_large.jpg" alt="Dr. Samipya Kafle" class="hero-photo">
+            <div class="hero-text">
+                <div class="role">PGY-2 Otolaryngology Resident</div>
+                <h1>Samipya Kafle, MD</h1>
+                <p>Surgeon-scientist in the Pacific Northwest. Passionate about technology, surgical education, and the intersection of medicine and innovation.</p>
+                <div class="hero-meta">
+                    <span><i class="fas fa-map-marker-alt"></i> Portland, OR</span>
+                    <a href="https://linkedin.com/in/skflx" target="_blank"><i class="fab fa-linkedin"></i> LinkedIn</a>
+                    <a href="https://github.com/skflx" target="_blank"><i class="fab fa-github"></i> GitHub</a>
+                    <a href="https://www.instagram.com/skflx/" target="_blank"><i class="fab fa-instagram"></i> @skflx</a>
+                </div>
+            </div>
+        </section>
+
+        <!-- TWO-COLUMN: About + Sidebar -->
+        <section id="about" class="two-col">
+            <div class="about-col">
+                <div class="section-label">About</div>
+                <p>My journey began in Nepal, spanning Michigan, Oregon, Nevada, and Connecticut before returning to the Pacific Northwest. With a background in neuroscience and personal experience with hearing loss, I bring a unique perspective to both clinical practice and research in hearing technologies.</p>
+                <p>My research focuses on surgical outcomes in otolaryngology and emergent data technologies in medical education and surgical training. I'm particularly interested in cognitive frameworks that enhance surgical learning.</p>
+                <p>Beyond medicine, I'm an artist, musician, and outdoor enthusiast who values the balance between technical precision and creative expression.</p>
+            </div>
+            <div class="sidebar-col">
+                <div class="section-label">Education</div>
+                <div class="detail">
+                    <h3>Yale School of Medicine</h3>
+                    <p>Otolaryngology Residency</p>
+                </div>
+                <div class="detail">
+                    <h3>University of Nevada, Reno</h3>
+                    <p>B.S. Neuroscience</p>
+                </div>
+
+                <div class="section-label" style="margin-top: 24px;">Languages</div>
+                <div class="lang-inline">
+                    <strong>Nepali</strong> (Native) &middot;
+                    <strong>English</strong> (Fluent) &middot;
+                    <strong>Spanish</strong> (Intermediate) &middot;
+                    <strong>Swiss German</strong> (Intermediate)
+                </div>
+            </div>
+        </section>
+
+        <!-- RESEARCH -->
+        <section id="research" class="research-section">
+            <div class="section-label">Research</div>
+            <div class="research-entries">
+                <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Trauma+OR+Fracture+OR+Injury)" target="_blank" class="research-entry">
+                    <h3>Craniofacial Trauma</h3>
+                    <p>Investigating injury patterns in sports and identifying factors associated with surgical outcomes.</p>
+                    <span class="pub-link">View on PubMed &rarr;</span>
+                </a>
+                <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cancer+OR+Oncology+OR+Laryngectomy)" target="_blank" class="research-entry">
+                    <h3>Head & Neck Oncology</h3>
+                    <p>Characterizing complications, risk factors, and survival outcomes in head and neck cancer surgeries.</p>
+                    <span class="pub-link">View on PubMed &rarr;</span>
+                </a>
+                <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Education+OR+Training+OR+Student)" target="_blank" class="research-entry">
+                    <h3>Surgical Education</h3>
+                    <p>Exploring innovative methods for surgical training, including live-streaming and automated feedback.</p>
+                    <span class="pub-link">View on PubMed &rarr;</span>
+                </a>
+                <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cochlear+OR+Hearing+OR+Otology)" target="_blank" class="research-entry">
+                    <h3>Otology & Hearing Sciences</h3>
+                    <p>Studying cortical adaptations in cochlear implant patients and improving speech processing.</p>
+                    <span class="pub-link">View on PubMed &rarr;</span>
+                </a>
+            </div>
+        </section>
+
+        <!-- PROJECTS -->
+        <section id="projects" class="projects-section">
+            <div class="section-label">Technology Projects</div>
+            <ul class="project-list">
+                <li>
+                    <span class="project-year">2022</span>
+                    <div class="project-name">
+                        Speech-in-Noise Processing
+                        <span>Improving speech recognition in hearing devices for challenging environments</span>
+                    </div>
+                    <span class="project-tag">Ongoing</span>
+                </li>
+                <li>
+                    <span class="project-year">2022</span>
+                    <div class="project-name">
+                        Surgical Livestreaming Platform
+                        <span>Technical system for livestreaming procedures to medical students</span>
+                    </div>
+                    <span class="project-tag">Ongoing</span>
+                </li>
+                <li>
+                    <span class="project-year">2025</span>
+                    <div class="project-name">
+                        ASCII Art Editor
+                        <span>Browser-based ASCII/Unicode diagram editor with templates and export</span>
+                    </div>
+                    <span class="project-tag">Shipped</span>
+                </li>
+            </ul>
+        </section>
+
+        <!-- TOOLS -->
+        <section id="tools" class="projects-section">
+            <div class="section-label">Tools</div>
+            <ul class="project-list">
+                <li>
+                    <span class="project-year"><i class="fas fa-diagram-project"></i></span>
+                    <div class="project-name">
+                        <a href="../kag.html" style="color: inherit; text-decoration: none;">Knowledge Atlas Graph</a>
+                        <span>Interactive OHNS knowledge map with self-testing</span>
+                    </div>
+                    <span class="project-tag">Live</span>
+                </li>
+                <li>
+                    <span class="project-year"><i class="fas fa-magnifying-glass"></i></span>
+                    <div class="project-name">
+                        <a href="../cpt-search.html" style="color: inherit; text-decoration: none;">CPT Code Search</a>
+                        <span>Fast CPT lookup for otolaryngology</span>
+                    </div>
+                    <span class="project-tag">Live</span>
+                </li>
+                <li>
+                    <span class="project-year"><i class="fas fa-terminal"></i></span>
+                    <div class="project-name">
+                        <a href="../ascii-editor.html" style="color: inherit; text-decoration: none;">ASCII Art Editor</a>
+                        <span>Browser-based ASCII/Unicode diagram editor</span>
+                    </div>
+                    <span class="project-tag">Live</span>
+                </li>
+            </ul>
+        </section>
+
+        <!-- CLINICAL -->
+        <section id="clinical" class="clinical-section">
+            <div class="section-label">Clinical Experience</div>
+            <div class="cv-entry">
+                <div class="cv-date">2022 &mdash; Present</div>
+                <h3>Surgery Livestreaming Elective</h3>
+                <p>Designed and organized curriculum for pre-clerkship medical students through live-streaming procedures. Audio/video setup and sterile exoscope mounting.</p>
+            </div>
+            <div class="cv-entry">
+                <div class="cv-date">2020 &mdash; Present</div>
+                <h3>HAVEN Free Clinic</h3>
+                <p>Primary care for uninsured and underinsured patients as Senior Clinical Team Member. Mentoring junior team members.</p>
+            </div>
+            <div class="cv-entry">
+                <div class="cv-date">2021 &mdash; Present</div>
+                <h3>Point of Care Ultrasound Teaching</h3>
+                <p>Hands-on training in essential ultrasound skills through weekly small-group lessons for MS1 curriculum.</p>
+            </div>
+        </section>
+
+        <!-- INTERESTS -->
+        <section class="interests-section">
+            <div class="section-label">Beyond Medicine</div>
+            <p class="interests-prose">
+                My life outside the hospital is just as full. I create
+                <span class="tag"><i class="fas fa-palette"></i> art</span>
+                in ink and graphite, play
+                <span class="tag"><i class="fas fa-music"></i> guitar & ukulele</span>,
+                spend time
+                <span class="tag"><i class="fas fa-mountain"></i> hiking</span>
+                the Pacific Northwest, and stay fit through
+                <span class="tag"><i class="fas fa-dumbbell"></i> powerlifting</span>.
+                I value the balance between technical precision and creative expression &mdash;
+                deadlifts are my favorite.
+            </p>
+        </section>
+
+        <!-- CONTACT -->
+        <section id="contact" class="contact-section">
+            <h2>Let's Connect</h2>
+            <p>Interested in research collaborations, medical education, or just want to say hello.</p>
+            <div class="contact-icons">
+                <a href="https://linkedin.com/in/skflx" target="_blank" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
+                <a href="https://www.instagram.com/skflx/" target="_blank" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
+                <a href="https://github.com/skflx" target="_blank" aria-label="GitHub"><i class="fab fa-github"></i></a>
+            </div>
+        </section>
+
+    </div>
+
+    <footer class="footer">&copy; 2025 skflx.MD &middot; Portland, Oregon</footer>
+
+    <script>
+        (function () {
+            var btn = document.getElementById('theme-toggle');
+            if (!btn) return;
+            btn.addEventListener('click', function () {
+                var current = document.documentElement.getAttribute('data-theme');
+                var next = current === 'dark' ? 'light' : 'dark';
+                document.documentElement.setAttribute('data-theme', next);
+                try { localStorage.setItem('sk_theme', next); } catch (e) {}
+            });
+        })();
+    </script>
+</body>
+</html>

--- a/mockups/one-pager-glass.html
+++ b/mockups/one-pager-glass.html
@@ -1,0 +1,501 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glass &middot; Samipya Kafle, MD</title>
+    <meta name="description" content="Dr. Samipya Kafle is an otolaryngology resident in the Pacific Northwest passionate about technology, surgical education, and the intersection of medicine and innovation.">
+
+    <!-- Set theme before paint to avoid flash -->
+    <script>
+        (function () {
+            try {
+                var stored = localStorage.getItem('sk_theme');
+                var theme = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+                document.documentElement.setAttribute('data-theme', theme);
+            } catch (e) {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        })();
+    </script>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <style>
+        /* ========================================================
+           ONE-PAGER — GLASS + GRADIENT (bento layout)
+           Frosted-glass tiles floating over a vibrant fixed gradient.
+           Bold color, soft glows, violet→blue accent. Statement-making.
+           ======================================================== */
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        :root {
+            --text: #1e1b2e;
+            --text-secondary: #4b4763;
+            --text-muted: #6b6788;
+            --accent: #7c3aed;
+            --accent-soft: rgba(124, 58, 237, 0.12);
+            --card: rgba(255, 255, 255, 0.5);
+            --border: rgba(255, 255, 255, 0.55);
+            --glass: rgba(255, 255, 255, 0.55);
+            --glass-strong: rgba(255, 255, 255, 0.7);
+            --page-gradient: linear-gradient(135deg, #c2e9fb 0%, #d4b8fc 45%, #fbc2eb 100%);
+            --font-body: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --font-display: 'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+            --radius: 18px;
+            --radius-sm: 12px;
+            --shadow-hover: 0 12px 40px rgba(80, 40, 160, 0.22);
+        }
+
+        [data-theme="dark"] {
+            --text: #f3f1ff;
+            --text-secondary: #c3bee0;
+            --text-muted: #908ab0;
+            --accent: #a78bfa;
+            --accent-soft: rgba(167, 139, 250, 0.16);
+            --card: rgba(255, 255, 255, 0.07);
+            --border: rgba(255, 255, 255, 0.12);
+            --glass: rgba(30, 27, 58, 0.5);
+            --glass-strong: rgba(40, 35, 70, 0.65);
+            --page-gradient: linear-gradient(135deg, #1e1b4b 0%, #312e81 45%, #4c1d6b 100%);
+            --shadow-hover: 0 12px 40px rgba(0, 0, 0, 0.5);
+        }
+
+        html { scroll-behavior: smooth; scroll-padding-top: 72px; }
+        body {
+            font-family: var(--font-body);
+            color: var(--text);
+            background-image: var(--page-gradient);
+            background-size: 100% 100%;
+            background-repeat: no-repeat;
+            -webkit-font-smoothing: antialiased;
+            min-height: 100vh;
+        }
+
+        a:focus-visible, button:focus-visible {
+            outline: 2px solid var(--accent);
+            outline-offset: 2px;
+            border-radius: 6px;
+        }
+
+        /* --- HEADER --- */
+        .header {
+            position: sticky; top: 0; z-index: 100;
+            background: var(--glass);
+            -webkit-backdrop-filter: blur(20px) saturate(180%);
+            backdrop-filter: blur(20px) saturate(180%);
+            height: 48px; display: flex; align-items: center;
+            border-bottom: 1px solid var(--border);
+        }
+        .header-inner { max-width: 1200px; margin: 0 auto; padding: 0 24px; width: 100%; display: flex; justify-content: space-between; align-items: center; }
+        .logo { font-family: var(--font-display); font-weight: 700; font-size: 1rem; color: var(--text); text-decoration: none; }
+        .nav { display: flex; align-items: center; gap: 16px; }
+        .nav-links { list-style: none; display: flex; gap: 20px; }
+        .nav-links a { color: var(--text-muted); text-decoration: none; font-size: 0.8rem; transition: color 0.2s; }
+        .nav-links a:hover { color: var(--text); }
+        .theme-btn {
+            background: none; border: none; cursor: pointer; color: var(--text-muted);
+            padding: 4px; display: inline-flex; align-items: center; justify-content: center;
+            transition: color 0.2s;
+        }
+        .theme-btn:hover { color: var(--text); }
+        .theme-btn svg { width: 18px; height: 18px; }
+        .theme-btn .icon-sun { display: none; }
+        .theme-btn .icon-moon { display: block; }
+        [data-theme="dark"] .theme-btn .icon-sun { display: block; }
+        [data-theme="dark"] .theme-btn .icon-moon { display: none; }
+
+        /* --- BENTO GRID --- */
+        .bento-container { max-width: 1200px; margin: 0 auto; padding: 24px; }
+        .bento-grid {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 16px;
+            grid-auto-rows: minmax(160px, auto);
+        }
+        .bento-card {
+            background: var(--glass);
+            -webkit-backdrop-filter: blur(18px) saturate(160%);
+            backdrop-filter: blur(18px) saturate(160%);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            padding: 28px;
+            display: flex; flex-direction: column; justify-content: space-between;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+            overflow: hidden; position: relative;
+            box-shadow: 0 4px 24px rgba(80, 40, 160, 0.10);
+        }
+        .bento-card:hover { transform: translateY(-2px); box-shadow: var(--shadow-hover); }
+
+        .span-2 { grid-column: span 2; }
+        .span-3 { grid-column: span 3; }
+        .span-4 { grid-column: span 4; }
+
+        .label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); margin-bottom: 14px; }
+        .card-title { font-family: var(--font-display); font-size: 1.1rem; font-weight: 600; }
+
+        /* --- HERO CARD --- */
+        .card-hero {
+            min-height: 280px;
+            display: grid; grid-template-columns: 1fr auto;
+            gap: 32px; align-items: center;
+            background: linear-gradient(135deg, var(--card) 60%, var(--accent-soft) 100%);
+        }
+        .card-hero .hero-content { max-width: 560px; }
+        .card-hero h1 { font-family: var(--font-display); font-size: 2.5rem; font-weight: 700; line-height: 1.15; margin-bottom: 12px; }
+        .card-hero h1 .accent { color: var(--accent); }
+        .card-hero .subtitle { color: var(--accent); font-size: 0.88rem; font-weight: 500; margin-bottom: 12px; display: flex; align-items: center; gap: 6px; }
+        .card-hero p { color: var(--text-secondary); font-size: 0.95rem; line-height: 1.6; }
+        .card-hero .hero-photo { width: 200px; height: 240px; border-radius: var(--radius-sm); object-fit: cover; }
+        .hero-ctas { display: flex; gap: 10px; margin-top: 16px; flex-wrap: wrap; }
+        .hero-ctas a {
+            display: inline-flex; align-items: center; gap: 6px;
+            padding: 10px 20px; border-radius: 980px; font-size: 0.85rem; font-weight: 500; text-decoration: none;
+            transition: all 0.2s;
+        }
+        .cta-primary { background: var(--accent); color: #fff; }
+        .cta-primary:hover { filter: brightness(1.1); }
+        .cta-secondary { background: color-mix(in srgb, var(--text) 10%, transparent); color: var(--text); }
+        .cta-secondary:hover { background: color-mix(in srgb, var(--text) 18%, transparent); }
+
+        /* --- EDUCATION CARD --- */
+        .edu-item { margin-bottom: 14px; }
+        .edu-item:last-child { margin-bottom: 0; }
+        .edu-item h3 { font-size: 0.95rem; font-weight: 600; margin-bottom: 2px; }
+        .edu-item p { font-size: 0.82rem; color: var(--text-muted); margin: 0; }
+
+        /* --- LANGUAGES CARD --- */
+        .lang-list { list-style: none; }
+        .lang-list li { display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 0.5px solid var(--border); font-size: 0.88rem; }
+        .lang-list li:last-child { border-bottom: none; }
+        .lang-level { color: var(--text-muted); font-size: 0.82rem; }
+
+        /* --- WHAT I DO: Icon grid --- */
+        .interest-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+        .interest-tile {
+            text-align: center; padding: 14px 8px;
+            background: color-mix(in srgb, var(--accent) 8%, transparent);
+            border-radius: var(--radius-sm);
+        }
+        .interest-tile i { font-size: 1.3rem; color: var(--accent); display: block; margin-bottom: 6px; }
+        .interest-tile span { font-size: 0.75rem; color: var(--text-secondary); }
+
+        /* --- RESEARCH CARD --- */
+        .card-research { background: linear-gradient(135deg, var(--accent-soft), var(--card)); }
+        .research-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; margin-top: 12px; }
+        .research-tile {
+            padding: 16px; background: var(--card); border-radius: var(--radius-sm);
+            text-decoration: none; color: var(--text); transition: transform 0.2s, box-shadow 0.2s; display: block;
+        }
+        .research-tile:hover { transform: scale(1.02); box-shadow: var(--shadow-hover); }
+        .research-tile i { color: var(--accent); margin-bottom: 6px; display: block; font-size: 1.1rem; }
+        .research-tile h4 { font-size: 0.85rem; font-weight: 600; margin-bottom: 4px; }
+        .research-tile p { font-size: 0.75rem; color: var(--text-muted); margin: 0; }
+        .research-all { margin-top: 14px; }
+        .research-all a { font-size: 0.8rem; color: var(--accent); text-decoration: none; font-weight: 500; }
+        .research-all a:hover { text-decoration: underline; }
+
+        /* --- ROW LIST CARDS (Tech / Tools) --- */
+        .row-list { display: flex; flex-direction: column; gap: 12px; margin-top: 12px; }
+        .row-item {
+            display: flex; align-items: center; gap: 12px;
+            padding: 12px; background: color-mix(in srgb, var(--accent) 6%, transparent);
+            border-radius: var(--radius-sm); text-decoration: none; color: var(--text);
+            transition: transform 0.2s;
+        }
+        a.row-item:hover { transform: translateX(3px); }
+        .row-item i { color: var(--accent); width: 20px; text-align: center; flex-shrink: 0; }
+        .row-item .row-info h4 { font-size: 0.88rem; font-weight: 600; }
+        .row-item .row-info p { font-size: 0.75rem; color: var(--text-muted); margin: 0; }
+        .row-item .row-arrow { margin-left: auto; color: var(--text-muted); font-size: 0.75rem; }
+
+        /* --- CLINICAL CARD --- */
+        .clinical-list { margin-top: 12px; }
+        .clinical-item { padding: 10px 0; border-bottom: 0.5px solid var(--border); }
+        .clinical-item:last-child { border-bottom: none; }
+        .clinical-item .year { font-size: 0.75rem; color: var(--accent); font-weight: 600; }
+        .clinical-item h4 { font-size: 0.88rem; font-weight: 600; margin: 2px 0; }
+        .clinical-item p { font-size: 0.78rem; color: var(--text-muted); margin: 0; }
+
+        /* --- CONNECT CARD --- */
+        .card-connect { background: linear-gradient(135deg, var(--accent), #5856d6); color: #fff; text-align: center; justify-content: center; align-items: center; }
+        .card-connect h3 { font-family: var(--font-display); font-size: 1.3rem; font-weight: 700; margin-bottom: 8px; }
+        .card-connect p { color: rgba(255, 255, 255, 0.85); font-size: 0.88rem; margin-bottom: 16px; }
+        .connect-links { display: flex; gap: 10px; justify-content: center; }
+        .connect-links a {
+            width: 40px; height: 40px; display: flex; align-items: center; justify-content: center;
+            background: rgba(255, 255, 255, 0.2); border-radius: 50%; color: #fff;
+            text-decoration: none; transition: background 0.2s; font-size: 1rem;
+        }
+        .connect-links a:hover { background: rgba(255, 255, 255, 0.35); }
+
+        /* --- LOCATION CARD --- */
+        .card-location { justify-content: center; align-items: center; text-align: center; }
+        .card-location i { font-size: 1.5rem; color: var(--accent); margin-bottom: 8px; }
+        .card-location h4 { font-size: 0.95rem; font-weight: 600; margin-bottom: 2px; }
+        .card-location p { font-size: 0.82rem; color: var(--text-muted); margin: 0; }
+
+        /* --- FOOTER --- */
+        .footer { text-align: center; padding: 24px; font-size: 0.75rem; color: var(--text-muted); }
+
+        /* --- RESPONSIVE --- */
+        @media (max-width: 900px) {
+            .bento-grid { grid-template-columns: repeat(2, 1fr); }
+            .span-3, .span-4 { grid-column: span 2; }
+            .card-hero { grid-template-columns: 1fr; }
+            .card-hero .hero-photo { display: none; }
+            .research-grid { grid-template-columns: 1fr; }
+        }
+        @media (max-width: 600px) {
+            .bento-grid { grid-template-columns: 1fr; }
+            .span-2, .span-3, .span-4 { grid-column: span 1; }
+            .card-hero h1 { font-size: 1.8rem; }
+            .interest-grid { grid-template-columns: repeat(2, 1fr); }
+            .nav-links { display: none; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            * { transition: none !important; }
+            html { scroll-behavior: auto; }
+            .bento-card:hover, .research-tile:hover, a.row-item:hover { transform: none; }
+        }
+    </style>
+</head>
+<body>
+    <!-- HEADER -->
+    <header class="header">
+        <div class="header-inner">
+            <a href="#top" class="logo">skflx.MD</a>
+            <nav class="nav">
+                <ul class="nav-links">
+                    <li><a href="#about">About</a></li>
+                    <li><a href="#research">Research</a></li>
+                    <li><a href="#projects">Projects</a></li>
+                    <li><a href="#clinical">Clinical</a></li>
+                    <li><a href="#connect">Connect</a></li>
+                </ul>
+                <button class="theme-btn" id="theme-toggle" aria-label="Toggle dark mode">
+                    <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </nav>
+        </div>
+    </header>
+
+    <!-- BENTO LAYOUT -->
+    <main class="bento-container">
+        <div class="bento-grid">
+
+            <!-- HERO -->
+            <section class="bento-card card-hero span-4" id="top">
+                <div class="hero-content">
+                    <div class="subtitle"><i class="fas fa-stethoscope"></i> PGY-2 Otolaryngology Resident</div>
+                    <h1>Hi, I'm <span class="accent">Samip.</span></h1>
+                    <p>Surgeon-scientist in training in the Pacific Northwest. Passionate about technology, surgical education, and the intersection of medicine and innovation.</p>
+                    <div class="hero-ctas">
+                        <a href="#connect" class="cta-primary"><i class="fas fa-paper-plane"></i> Get in Touch</a>
+                        <a href="../documents/cv.pdf" class="cta-secondary"><i class="fas fa-file-pdf"></i> Download CV</a>
+                    </div>
+                </div>
+                <img src="../images/me_large.jpg" alt="Dr. Samipya Kafle" class="hero-photo" loading="eager">
+            </section>
+
+            <!-- EDUCATION -->
+            <section class="bento-card" id="about">
+                <div class="label">Education</div>
+                <div>
+                    <div class="edu-item">
+                        <h3>Yale School of Medicine</h3>
+                        <p>Otolaryngology</p>
+                    </div>
+                    <div class="edu-item">
+                        <h3>University of Nevada, Reno</h3>
+                        <p>B.S. Neuroscience</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- LANGUAGES -->
+            <section class="bento-card">
+                <div class="label">Languages</div>
+                <ul class="lang-list">
+                    <li>Nepali <span class="lang-level">Native</span></li>
+                    <li>English <span class="lang-level">Fluent</span></li>
+                    <li>Spanish <span class="lang-level">Intermediate</span></li>
+                    <li>Swiss German <span class="lang-level">Intermediate</span></li>
+                </ul>
+            </section>
+
+            <!-- WHAT I DO -->
+            <section class="bento-card span-2">
+                <div class="label">What I Do</div>
+                <div class="interest-grid">
+                    <div class="interest-tile"><i class="fas fa-flask"></i><span>Research</span></div>
+                    <div class="interest-tile"><i class="fas fa-microchip"></i><span>Technology</span></div>
+                    <div class="interest-tile"><i class="fas fa-palette"></i><span>Art</span></div>
+                    <div class="interest-tile"><i class="fas fa-music"></i><span>Music</span></div>
+                    <div class="interest-tile"><i class="fas fa-mountain"></i><span>Outdoors</span></div>
+                    <div class="interest-tile"><i class="fas fa-dumbbell"></i><span>Fitness</span></div>
+                </div>
+            </section>
+
+            <!-- RESEARCH -->
+            <section class="bento-card card-research span-4" id="research">
+                <div>
+                    <div class="label" style="margin-bottom: 4px;">Research</div>
+                    <h3 class="card-title">Publications in Otolaryngology</h3>
+                </div>
+                <div class="research-grid">
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Trauma+OR+Fracture+OR+Injury)" target="_blank" rel="noopener" class="research-tile">
+                        <i class="fas fa-skull"></i>
+                        <h4>Craniofacial Trauma</h4>
+                        <p>Injury patterns in sports and surgical outcome factors</p>
+                    </a>
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cancer+OR+Oncology+OR+Laryngectomy)" target="_blank" rel="noopener" class="research-tile">
+                        <i class="fas fa-ribbon"></i>
+                        <h4>Head &amp; Neck Oncology</h4>
+                        <p>Complications, risk factors, and survival outcomes</p>
+                    </a>
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Education+OR+Training+OR+Student)" target="_blank" rel="noopener" class="research-tile">
+                        <i class="fas fa-graduation-cap"></i>
+                        <h4>Surgical Education</h4>
+                        <p>Live-streaming and automated feedback systems</p>
+                    </a>
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cochlear+OR+Hearing+OR+Otology)" target="_blank" rel="noopener" class="research-tile">
+                        <i class="fas fa-ear-listen"></i>
+                        <h4>Otology &amp; Hearing Sciences</h4>
+                        <p>Cortical adaptations in CI patients and speech processing</p>
+                    </a>
+                </div>
+                <div class="research-all">
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]" target="_blank" rel="noopener">View all papers on PubMed <i class="fas fa-external-link-alt" style="font-size:0.7rem;"></i></a>
+                </div>
+            </section>
+
+            <!-- TECHNOLOGY -->
+            <section class="bento-card span-2" id="projects">
+                <div class="label" style="margin-bottom: 4px;">Technology</div>
+                <h3 class="card-title">Projects</h3>
+                <div class="row-list">
+                    <div class="row-item">
+                        <i class="fas fa-wave-square"></i>
+                        <div class="row-info">
+                            <h4>Speech-in-Noise Processing</h4>
+                            <p>Hearing device enhancement &middot; 2022&ndash;Present</p>
+                        </div>
+                    </div>
+                    <div class="row-item">
+                        <i class="fas fa-video"></i>
+                        <div class="row-info">
+                            <h4>Surgical Livestreaming</h4>
+                            <p>Procedure streaming platform &middot; 2022&ndash;Present</p>
+                        </div>
+                    </div>
+                    <a href="../ascii-editor.html" class="row-item">
+                        <i class="fas fa-terminal"></i>
+                        <div class="row-info">
+                            <h4>ASCII Art Editor</h4>
+                            <p>Browser-based diagram tool &middot; 2025</p>
+                        </div>
+                        <span class="row-arrow"><i class="fas fa-arrow-right"></i></span>
+                    </a>
+                </div>
+            </section>
+
+            <!-- CLINICAL -->
+            <section class="bento-card" id="clinical">
+                <div class="label" style="margin-bottom: 4px;">Clinical</div>
+                <div class="clinical-list">
+                    <div class="clinical-item">
+                        <span class="year">2022&ndash;Now</span>
+                        <h4>Surgery Livestreaming</h4>
+                        <p>Pre-clerkship curriculum design</p>
+                    </div>
+                    <div class="clinical-item">
+                        <span class="year">2020&ndash;Now</span>
+                        <h4>HAVEN Free Clinic</h4>
+                        <p>Senior Clinical Team Member</p>
+                    </div>
+                    <div class="clinical-item">
+                        <span class="year">2021&ndash;Now</span>
+                        <h4>POCUS Teaching</h4>
+                        <p>Ultrasound skills training</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- CONNECT -->
+            <section class="bento-card card-connect" id="connect">
+                <h3>Let's Connect</h3>
+                <p>Research, innovation, or just say hello.</p>
+                <div class="connect-links">
+                    <a href="https://linkedin.com/in/skflx" target="_blank" rel="noopener" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
+                    <a href="https://www.instagram.com/skflx/" target="_blank" rel="noopener" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
+                    <a href="https://github.com/skflx" target="_blank" rel="noopener" aria-label="GitHub"><i class="fab fa-github"></i></a>
+                </div>
+            </section>
+
+            <!-- TOOLS -->
+            <section class="bento-card span-3" id="tools">
+                <div class="label">Tools</div>
+                <div class="row-list">
+                    <a href="../kag.html" class="row-item">
+                        <i class="fas fa-diagram-project"></i>
+                        <div class="row-info">
+                            <h4>Knowledge Atlas Graph</h4>
+                            <p>Interactive OHNS knowledge map with self-testing</p>
+                        </div>
+                        <span class="row-arrow"><i class="fas fa-arrow-right"></i></span>
+                    </a>
+                    <a href="../cpt-search.html" class="row-item">
+                        <i class="fas fa-magnifying-glass"></i>
+                        <div class="row-info">
+                            <h4>CPT Code Search</h4>
+                            <p>Fast CPT lookup for otolaryngology</p>
+                        </div>
+                        <span class="row-arrow"><i class="fas fa-arrow-right"></i></span>
+                    </a>
+                    <a href="../ascii-editor.html" class="row-item">
+                        <i class="fas fa-terminal"></i>
+                        <div class="row-info">
+                            <h4>ASCII Art Editor</h4>
+                            <p>Browser-based ASCII/Unicode diagram editor</p>
+                        </div>
+                        <span class="row-arrow"><i class="fas fa-arrow-right"></i></span>
+                    </a>
+                </div>
+            </section>
+
+            <!-- LOCATION -->
+            <section class="bento-card card-location">
+                <i class="fas fa-map-marker-alt"></i>
+                <h4>Portland, Oregon</h4>
+                <p>Pacific Northwest</p>
+            </section>
+
+        </div>
+    </main>
+
+    <footer class="footer">&copy; 2025 skflx.MD &middot; Portland, Oregon</footer>
+
+    <script>
+        (function () {
+            var btn = document.getElementById('theme-toggle');
+            if (!btn) return;
+            btn.addEventListener('click', function () {
+                var current = document.documentElement.getAttribute('data-theme');
+                var next = current === 'dark' ? 'light' : 'dark';
+                document.documentElement.setAttribute('data-theme', next);
+                try { localStorage.setItem('sk_theme', next); } catch (e) {}
+            });
+        })();
+    </script>
+</body>
+</html>

--- a/mockups/one-pager-matte.html
+++ b/mockups/one-pager-matte.html
@@ -1,0 +1,490 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Matte &middot; Samipya Kafle, MD</title>
+    <meta name="description" content="Dr. Samipya Kafle is an otolaryngology resident in the Pacific Northwest passionate about technology, surgical education, and the intersection of medicine and innovation.">
+
+    <!-- Set theme before paint to avoid flash -->
+    <script>
+        (function () {
+            try {
+                var stored = localStorage.getItem('sk_theme');
+                var theme = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+                document.documentElement.setAttribute('data-theme', theme);
+            } catch (e) {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        })();
+    </script>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <style>
+        /* ========================================================
+           ONE-PAGER — MATTE PROFESSIONAL (bento layout)
+           Desaturated slate palette echoing the live site's matte
+           philosophy. Understated, clinical, premium. Flat shadows,
+           restrained borders, muted steel-blue accent.
+           ======================================================== */
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        :root {
+            --bg: #eef1f5;
+            --card: #ffffff;
+            --text: #1a202c;
+            --text-secondary: #4a5568;
+            --text-muted: #718096;
+            --accent: #4c6079;
+            --accent-soft: #e7ecf2;
+            --border: #e2e8f0;
+            --font-body: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --font-display: 'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+            --radius: 14px;
+            --radius-sm: 10px;
+            --shadow-hover: 0 4px 16px rgba(15, 23, 42, 0.06);
+        }
+
+        [data-theme="dark"] {
+            --bg: #0f172a;
+            --card: #1e293b;
+            --text: #f1f5f9;
+            --text-secondary: #cbd5e1;
+            --text-muted: #94a3b8;
+            --accent: #8ea3c4;
+            --accent-soft: #1e2a3f;
+            --border: #334155;
+            --shadow-hover: 0 4px 16px rgba(0, 0, 0, 0.4);
+        }
+
+        html { scroll-behavior: smooth; scroll-padding-top: 72px; }
+        body {
+            font-family: var(--font-body);
+            color: var(--text);
+            background: var(--bg);
+            -webkit-font-smoothing: antialiased;
+        }
+
+        a:focus-visible, button:focus-visible {
+            outline: 2px solid var(--accent);
+            outline-offset: 2px;
+            border-radius: 6px;
+        }
+
+        /* --- HEADER --- */
+        .header {
+            position: sticky; top: 0; z-index: 100;
+            background: color-mix(in srgb, var(--bg) 80%, transparent);
+            backdrop-filter: blur(20px) saturate(180%);
+            height: 48px; display: flex; align-items: center;
+            border-bottom: 0.5px solid var(--border);
+        }
+        .header-inner { max-width: 1200px; margin: 0 auto; padding: 0 24px; width: 100%; display: flex; justify-content: space-between; align-items: center; }
+        .logo { font-family: var(--font-display); font-weight: 700; font-size: 1rem; color: var(--text); text-decoration: none; }
+        .nav { display: flex; align-items: center; gap: 16px; }
+        .nav-links { list-style: none; display: flex; gap: 20px; }
+        .nav-links a { color: var(--text-muted); text-decoration: none; font-size: 0.8rem; transition: color 0.2s; }
+        .nav-links a:hover { color: var(--text); }
+        .theme-btn {
+            background: none; border: none; cursor: pointer; color: var(--text-muted);
+            padding: 4px; display: inline-flex; align-items: center; justify-content: center;
+            transition: color 0.2s;
+        }
+        .theme-btn:hover { color: var(--text); }
+        .theme-btn svg { width: 18px; height: 18px; }
+        .theme-btn .icon-sun { display: none; }
+        .theme-btn .icon-moon { display: block; }
+        [data-theme="dark"] .theme-btn .icon-sun { display: block; }
+        [data-theme="dark"] .theme-btn .icon-moon { display: none; }
+
+        /* --- BENTO GRID --- */
+        .bento-container { max-width: 1200px; margin: 0 auto; padding: 24px; }
+        .bento-grid {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 16px;
+            grid-auto-rows: minmax(160px, auto);
+        }
+        .bento-card {
+            background: var(--card);
+            border-radius: var(--radius);
+            padding: 28px;
+            display: flex; flex-direction: column; justify-content: space-between;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+            overflow: hidden; position: relative;
+        }
+        .bento-card:hover { transform: translateY(-2px); box-shadow: var(--shadow-hover); }
+
+        .span-2 { grid-column: span 2; }
+        .span-3 { grid-column: span 3; }
+        .span-4 { grid-column: span 4; }
+
+        .label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); margin-bottom: 14px; }
+        .card-title { font-family: var(--font-display); font-size: 1.1rem; font-weight: 600; }
+
+        /* --- HERO CARD --- */
+        .card-hero {
+            min-height: 280px;
+            display: grid; grid-template-columns: 1fr auto;
+            gap: 32px; align-items: center;
+            background: linear-gradient(135deg, var(--card) 60%, var(--accent-soft) 100%);
+        }
+        .card-hero .hero-content { max-width: 560px; }
+        .card-hero h1 { font-family: var(--font-display); font-size: 2.5rem; font-weight: 700; line-height: 1.15; margin-bottom: 12px; }
+        .card-hero h1 .accent { color: var(--accent); }
+        .card-hero .subtitle { color: var(--accent); font-size: 0.88rem; font-weight: 500; margin-bottom: 12px; display: flex; align-items: center; gap: 6px; }
+        .card-hero p { color: var(--text-secondary); font-size: 0.95rem; line-height: 1.6; }
+        .card-hero .hero-photo { width: 200px; height: 240px; border-radius: var(--radius-sm); object-fit: cover; }
+        .hero-ctas { display: flex; gap: 10px; margin-top: 16px; flex-wrap: wrap; }
+        .hero-ctas a {
+            display: inline-flex; align-items: center; gap: 6px;
+            padding: 10px 20px; border-radius: 980px; font-size: 0.85rem; font-weight: 500; text-decoration: none;
+            transition: all 0.2s;
+        }
+        .cta-primary { background: var(--accent); color: #fff; }
+        .cta-primary:hover { filter: brightness(1.1); }
+        .cta-secondary { background: color-mix(in srgb, var(--text) 10%, transparent); color: var(--text); }
+        .cta-secondary:hover { background: color-mix(in srgb, var(--text) 18%, transparent); }
+
+        /* --- EDUCATION CARD --- */
+        .edu-item { margin-bottom: 14px; }
+        .edu-item:last-child { margin-bottom: 0; }
+        .edu-item h3 { font-size: 0.95rem; font-weight: 600; margin-bottom: 2px; }
+        .edu-item p { font-size: 0.82rem; color: var(--text-muted); margin: 0; }
+
+        /* --- LANGUAGES CARD --- */
+        .lang-list { list-style: none; }
+        .lang-list li { display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 0.5px solid var(--border); font-size: 0.88rem; }
+        .lang-list li:last-child { border-bottom: none; }
+        .lang-level { color: var(--text-muted); font-size: 0.82rem; }
+
+        /* --- WHAT I DO: Icon grid --- */
+        .interest-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+        .interest-tile {
+            text-align: center; padding: 14px 8px;
+            background: color-mix(in srgb, var(--accent) 8%, transparent);
+            border-radius: var(--radius-sm);
+        }
+        .interest-tile i { font-size: 1.3rem; color: var(--accent); display: block; margin-bottom: 6px; }
+        .interest-tile span { font-size: 0.75rem; color: var(--text-secondary); }
+
+        /* --- RESEARCH CARD --- */
+        .card-research { background: linear-gradient(135deg, var(--accent-soft), var(--card)); }
+        .research-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; margin-top: 12px; }
+        .research-tile {
+            padding: 16px; background: var(--card); border-radius: var(--radius-sm);
+            text-decoration: none; color: var(--text); transition: transform 0.2s, box-shadow 0.2s; display: block;
+        }
+        .research-tile:hover { transform: scale(1.02); box-shadow: var(--shadow-hover); }
+        .research-tile i { color: var(--accent); margin-bottom: 6px; display: block; font-size: 1.1rem; }
+        .research-tile h4 { font-size: 0.85rem; font-weight: 600; margin-bottom: 4px; }
+        .research-tile p { font-size: 0.75rem; color: var(--text-muted); margin: 0; }
+        .research-all { margin-top: 14px; }
+        .research-all a { font-size: 0.8rem; color: var(--accent); text-decoration: none; font-weight: 500; }
+        .research-all a:hover { text-decoration: underline; }
+
+        /* --- ROW LIST CARDS (Tech / Tools) --- */
+        .row-list { display: flex; flex-direction: column; gap: 12px; margin-top: 12px; }
+        .row-item {
+            display: flex; align-items: center; gap: 12px;
+            padding: 12px; background: color-mix(in srgb, var(--accent) 6%, transparent);
+            border-radius: var(--radius-sm); text-decoration: none; color: var(--text);
+            transition: transform 0.2s;
+        }
+        a.row-item:hover { transform: translateX(3px); }
+        .row-item i { color: var(--accent); width: 20px; text-align: center; flex-shrink: 0; }
+        .row-item .row-info h4 { font-size: 0.88rem; font-weight: 600; }
+        .row-item .row-info p { font-size: 0.75rem; color: var(--text-muted); margin: 0; }
+        .row-item .row-arrow { margin-left: auto; color: var(--text-muted); font-size: 0.75rem; }
+
+        /* --- CLINICAL CARD --- */
+        .clinical-list { margin-top: 12px; }
+        .clinical-item { padding: 10px 0; border-bottom: 0.5px solid var(--border); }
+        .clinical-item:last-child { border-bottom: none; }
+        .clinical-item .year { font-size: 0.75rem; color: var(--accent); font-weight: 600; }
+        .clinical-item h4 { font-size: 0.88rem; font-weight: 600; margin: 2px 0; }
+        .clinical-item p { font-size: 0.78rem; color: var(--text-muted); margin: 0; }
+
+        /* --- CONNECT CARD --- */
+        .card-connect { background: linear-gradient(135deg, #4c6079, #2d3e57); color: #fff; text-align: center; justify-content: center; align-items: center; }
+        .card-connect h3 { font-family: var(--font-display); font-size: 1.3rem; font-weight: 700; margin-bottom: 8px; }
+        .card-connect p { color: rgba(255, 255, 255, 0.85); font-size: 0.88rem; margin-bottom: 16px; }
+        .connect-links { display: flex; gap: 10px; justify-content: center; }
+        .connect-links a {
+            width: 40px; height: 40px; display: flex; align-items: center; justify-content: center;
+            background: rgba(255, 255, 255, 0.2); border-radius: 50%; color: #fff;
+            text-decoration: none; transition: background 0.2s; font-size: 1rem;
+        }
+        .connect-links a:hover { background: rgba(255, 255, 255, 0.35); }
+
+        /* --- LOCATION CARD --- */
+        .card-location { justify-content: center; align-items: center; text-align: center; }
+        .card-location i { font-size: 1.5rem; color: var(--accent); margin-bottom: 8px; }
+        .card-location h4 { font-size: 0.95rem; font-weight: 600; margin-bottom: 2px; }
+        .card-location p { font-size: 0.82rem; color: var(--text-muted); margin: 0; }
+
+        /* --- FOOTER --- */
+        .footer { text-align: center; padding: 24px; font-size: 0.75rem; color: var(--text-muted); }
+
+        /* --- RESPONSIVE --- */
+        @media (max-width: 900px) {
+            .bento-grid { grid-template-columns: repeat(2, 1fr); }
+            .span-3, .span-4 { grid-column: span 2; }
+            .card-hero { grid-template-columns: 1fr; }
+            .card-hero .hero-photo { display: none; }
+            .research-grid { grid-template-columns: 1fr; }
+        }
+        @media (max-width: 600px) {
+            .bento-grid { grid-template-columns: 1fr; }
+            .span-2, .span-3, .span-4 { grid-column: span 1; }
+            .card-hero h1 { font-size: 1.8rem; }
+            .interest-grid { grid-template-columns: repeat(2, 1fr); }
+            .nav-links { display: none; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            * { transition: none !important; }
+            html { scroll-behavior: auto; }
+            .bento-card:hover, .research-tile:hover, a.row-item:hover { transform: none; }
+        }
+    </style>
+</head>
+<body>
+    <!-- HEADER -->
+    <header class="header">
+        <div class="header-inner">
+            <a href="#top" class="logo">skflx.MD</a>
+            <nav class="nav">
+                <ul class="nav-links">
+                    <li><a href="#about">About</a></li>
+                    <li><a href="#research">Research</a></li>
+                    <li><a href="#projects">Projects</a></li>
+                    <li><a href="#clinical">Clinical</a></li>
+                    <li><a href="#connect">Connect</a></li>
+                </ul>
+                <button class="theme-btn" id="theme-toggle" aria-label="Toggle dark mode">
+                    <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </nav>
+        </div>
+    </header>
+
+    <!-- BENTO LAYOUT -->
+    <main class="bento-container">
+        <div class="bento-grid">
+
+            <!-- HERO -->
+            <section class="bento-card card-hero span-4" id="top">
+                <div class="hero-content">
+                    <div class="subtitle"><i class="fas fa-stethoscope"></i> PGY-2 Otolaryngology Resident</div>
+                    <h1>Hi, I'm <span class="accent">Samip.</span></h1>
+                    <p>Surgeon-scientist in training in the Pacific Northwest. Passionate about technology, surgical education, and the intersection of medicine and innovation.</p>
+                    <div class="hero-ctas">
+                        <a href="#connect" class="cta-primary"><i class="fas fa-paper-plane"></i> Get in Touch</a>
+                        <a href="../documents/cv.pdf" class="cta-secondary"><i class="fas fa-file-pdf"></i> Download CV</a>
+                    </div>
+                </div>
+                <img src="../images/me_large.jpg" alt="Dr. Samipya Kafle" class="hero-photo" loading="eager">
+            </section>
+
+            <!-- EDUCATION -->
+            <section class="bento-card" id="about">
+                <div class="label">Education</div>
+                <div>
+                    <div class="edu-item">
+                        <h3>Yale School of Medicine</h3>
+                        <p>Otolaryngology</p>
+                    </div>
+                    <div class="edu-item">
+                        <h3>University of Nevada, Reno</h3>
+                        <p>B.S. Neuroscience</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- LANGUAGES -->
+            <section class="bento-card">
+                <div class="label">Languages</div>
+                <ul class="lang-list">
+                    <li>Nepali <span class="lang-level">Native</span></li>
+                    <li>English <span class="lang-level">Fluent</span></li>
+                    <li>Spanish <span class="lang-level">Intermediate</span></li>
+                    <li>Swiss German <span class="lang-level">Intermediate</span></li>
+                </ul>
+            </section>
+
+            <!-- WHAT I DO -->
+            <section class="bento-card span-2">
+                <div class="label">What I Do</div>
+                <div class="interest-grid">
+                    <div class="interest-tile"><i class="fas fa-flask"></i><span>Research</span></div>
+                    <div class="interest-tile"><i class="fas fa-microchip"></i><span>Technology</span></div>
+                    <div class="interest-tile"><i class="fas fa-palette"></i><span>Art</span></div>
+                    <div class="interest-tile"><i class="fas fa-music"></i><span>Music</span></div>
+                    <div class="interest-tile"><i class="fas fa-mountain"></i><span>Outdoors</span></div>
+                    <div class="interest-tile"><i class="fas fa-dumbbell"></i><span>Fitness</span></div>
+                </div>
+            </section>
+
+            <!-- RESEARCH -->
+            <section class="bento-card card-research span-4" id="research">
+                <div>
+                    <div class="label" style="margin-bottom: 4px;">Research</div>
+                    <h3 class="card-title">Publications in Otolaryngology</h3>
+                </div>
+                <div class="research-grid">
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Trauma+OR+Fracture+OR+Injury)" target="_blank" rel="noopener" class="research-tile">
+                        <i class="fas fa-skull"></i>
+                        <h4>Craniofacial Trauma</h4>
+                        <p>Injury patterns in sports and surgical outcome factors</p>
+                    </a>
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cancer+OR+Oncology+OR+Laryngectomy)" target="_blank" rel="noopener" class="research-tile">
+                        <i class="fas fa-ribbon"></i>
+                        <h4>Head &amp; Neck Oncology</h4>
+                        <p>Complications, risk factors, and survival outcomes</p>
+                    </a>
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Education+OR+Training+OR+Student)" target="_blank" rel="noopener" class="research-tile">
+                        <i class="fas fa-graduation-cap"></i>
+                        <h4>Surgical Education</h4>
+                        <p>Live-streaming and automated feedback systems</p>
+                    </a>
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cochlear+OR+Hearing+OR+Otology)" target="_blank" rel="noopener" class="research-tile">
+                        <i class="fas fa-ear-listen"></i>
+                        <h4>Otology &amp; Hearing Sciences</h4>
+                        <p>Cortical adaptations in CI patients and speech processing</p>
+                    </a>
+                </div>
+                <div class="research-all">
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]" target="_blank" rel="noopener">View all papers on PubMed <i class="fas fa-external-link-alt" style="font-size:0.7rem;"></i></a>
+                </div>
+            </section>
+
+            <!-- TECHNOLOGY -->
+            <section class="bento-card span-2" id="projects">
+                <div class="label" style="margin-bottom: 4px;">Technology</div>
+                <h3 class="card-title">Projects</h3>
+                <div class="row-list">
+                    <div class="row-item">
+                        <i class="fas fa-wave-square"></i>
+                        <div class="row-info">
+                            <h4>Speech-in-Noise Processing</h4>
+                            <p>Hearing device enhancement &middot; 2022&ndash;Present</p>
+                        </div>
+                    </div>
+                    <div class="row-item">
+                        <i class="fas fa-video"></i>
+                        <div class="row-info">
+                            <h4>Surgical Livestreaming</h4>
+                            <p>Procedure streaming platform &middot; 2022&ndash;Present</p>
+                        </div>
+                    </div>
+                    <a href="../ascii-editor.html" class="row-item">
+                        <i class="fas fa-terminal"></i>
+                        <div class="row-info">
+                            <h4>ASCII Art Editor</h4>
+                            <p>Browser-based diagram tool &middot; 2025</p>
+                        </div>
+                        <span class="row-arrow"><i class="fas fa-arrow-right"></i></span>
+                    </a>
+                </div>
+            </section>
+
+            <!-- CLINICAL -->
+            <section class="bento-card" id="clinical">
+                <div class="label" style="margin-bottom: 4px;">Clinical</div>
+                <div class="clinical-list">
+                    <div class="clinical-item">
+                        <span class="year">2022&ndash;Now</span>
+                        <h4>Surgery Livestreaming</h4>
+                        <p>Pre-clerkship curriculum design</p>
+                    </div>
+                    <div class="clinical-item">
+                        <span class="year">2020&ndash;Now</span>
+                        <h4>HAVEN Free Clinic</h4>
+                        <p>Senior Clinical Team Member</p>
+                    </div>
+                    <div class="clinical-item">
+                        <span class="year">2021&ndash;Now</span>
+                        <h4>POCUS Teaching</h4>
+                        <p>Ultrasound skills training</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- CONNECT -->
+            <section class="bento-card card-connect" id="connect">
+                <h3>Let's Connect</h3>
+                <p>Research, innovation, or just say hello.</p>
+                <div class="connect-links">
+                    <a href="https://linkedin.com/in/skflx" target="_blank" rel="noopener" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
+                    <a href="https://www.instagram.com/skflx/" target="_blank" rel="noopener" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
+                    <a href="https://github.com/skflx" target="_blank" rel="noopener" aria-label="GitHub"><i class="fab fa-github"></i></a>
+                </div>
+            </section>
+
+            <!-- TOOLS -->
+            <section class="bento-card span-3" id="tools">
+                <div class="label">Tools</div>
+                <div class="row-list">
+                    <a href="../kag.html" class="row-item">
+                        <i class="fas fa-diagram-project"></i>
+                        <div class="row-info">
+                            <h4>Knowledge Atlas Graph</h4>
+                            <p>Interactive OHNS knowledge map with self-testing</p>
+                        </div>
+                        <span class="row-arrow"><i class="fas fa-arrow-right"></i></span>
+                    </a>
+                    <a href="../cpt-search.html" class="row-item">
+                        <i class="fas fa-magnifying-glass"></i>
+                        <div class="row-info">
+                            <h4>CPT Code Search</h4>
+                            <p>Fast CPT lookup for otolaryngology</p>
+                        </div>
+                        <span class="row-arrow"><i class="fas fa-arrow-right"></i></span>
+                    </a>
+                    <a href="../ascii-editor.html" class="row-item">
+                        <i class="fas fa-terminal"></i>
+                        <div class="row-info">
+                            <h4>ASCII Art Editor</h4>
+                            <p>Browser-based ASCII/Unicode diagram editor</p>
+                        </div>
+                        <span class="row-arrow"><i class="fas fa-arrow-right"></i></span>
+                    </a>
+                </div>
+            </section>
+
+            <!-- LOCATION -->
+            <section class="bento-card card-location">
+                <i class="fas fa-map-marker-alt"></i>
+                <h4>Portland, Oregon</h4>
+                <p>Pacific Northwest</p>
+            </section>
+
+        </div>
+    </main>
+
+    <footer class="footer">&copy; 2025 skflx.MD &middot; Portland, Oregon</footer>
+
+    <script>
+        (function () {
+            var btn = document.getElementById('theme-toggle');
+            if (!btn) return;
+            btn.addEventListener('click', function () {
+                var current = document.documentElement.getAttribute('data-theme');
+                var next = current === 'dark' ? 'light' : 'dark';
+                document.documentElement.setAttribute('data-theme', next);
+                try { localStorage.setItem('sk_theme', next); } catch (e) {}
+            });
+        })();
+    </script>
+</body>
+</html>

--- a/mockups/one-pager-personality.html
+++ b/mockups/one-pager-personality.html
@@ -1,0 +1,346 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Personality &middot; Samipya Kafle, MD</title>
+    <meta name="description" content="Dr. Samipya Kafle is an otolaryngology resident in the Pacific Northwest passionate about technology, surgical education, art, music, the outdoors, and the intersection of medicine and innovation.">
+
+    <!-- Set theme before paint to avoid flash -->
+    <script>
+        (function () {
+            try {
+                var stored = localStorage.getItem('sk_theme');
+                var theme = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+                document.documentElement.setAttribute('data-theme', theme);
+            } catch (e) {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        })();
+    </script>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Inter:wght@400;500;600&family=Caveat:wght@500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <style>
+        /* ========================================================
+           ONE-PAGER — PERSONALITY / WHOLE-PERSON BLEND
+           Warm paper + ink. Surgeon-scientist AND artist, musician,
+           outdoorsperson, lifter — medicine and life given equal
+           billing. Fraunces + Inter, handwritten Caveat accents,
+           paper grain + hand-drawn ink dividers.
+           ======================================================== */
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        :root {
+            --bg: #f6f1e7;
+            --card: #fffdf8;
+            --text: #2b2823;
+            --text-muted: #6f675a;
+            --accent: #2f6b4f;      /* forest green */
+            --accent-2: #c4663b;    /* terracotta */
+            --accent-soft: #e7ede4;
+            --border: #e3dccc;
+            --font-display: 'Fraunces', Georgia, serif;
+            --font-body: 'Inter', -apple-system, sans-serif;
+            --font-hand: 'Caveat', cursive;
+            --shadow: 0 10px 30px rgba(60, 50, 30, 0.10);
+        }
+        [data-theme="dark"] {
+            --bg: #1a1714;
+            --card: #221e1a;
+            --text: #efe9dd;
+            --text-muted: #b3a995;
+            --accent: #6bbf94;
+            --accent-2: #e08b5f;
+            --accent-soft: #26302a;
+            --border: #36302a;
+            --shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+        }
+
+        html { scroll-behavior: smooth; scroll-padding-top: 76px; }
+        body {
+            font-family: var(--font-body);
+            color: var(--text);
+            background-color: var(--bg);
+            line-height: 1.7;
+            -webkit-font-smoothing: antialiased;
+            position: relative;
+        }
+        /* paper grain */
+        body::before {
+            content: ""; position: fixed; inset: 0; z-index: 0; pointer-events: none;
+            opacity: 0.05; mix-blend-mode: overlay;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+        }
+        .page { position: relative; z-index: 1; }
+        a { color: var(--accent); }
+
+        a:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 4px; }
+
+        /* --- HEADER --- */
+        .header {
+            position: sticky; top: 0; z-index: 50;
+            background: color-mix(in srgb, var(--bg) 85%, transparent);
+            backdrop-filter: blur(10px);
+            border-bottom: 1px solid var(--border);
+        }
+        .header-inner { max-width: 1000px; margin: 0 auto; padding: 14px 24px; display: flex; justify-content: space-between; align-items: center; }
+        .logo { font-family: var(--font-display); font-weight: 600; font-size: 1.2rem; color: var(--text); text-decoration: none; }
+        .logo .dot { color: var(--accent-2); }
+        .nav-links { list-style: none; display: flex; gap: 24px; align-items: center; }
+        .nav-links a { color: var(--text-muted); text-decoration: none; font-size: 0.9rem; transition: color 0.2s; }
+        .nav-links a:hover { color: var(--accent); }
+        .theme-btn { background: none; border: 1px solid var(--border); border-radius: 50%; width: 34px; height: 34px; cursor: pointer; color: var(--text-muted); }
+        .theme-btn:hover { color: var(--accent); border-color: var(--accent); }
+
+        .container { max-width: 1000px; margin: 0 auto; padding: 0 24px; }
+        section { padding: 56px 0; }
+
+        /* --- HERO --- */
+        .hero { display: grid; grid-template-columns: 1fr 300px; gap: 48px; align-items: center; padding-top: 64px; }
+        .hero .eyebrow { color: var(--accent); font-weight: 600; font-size: 0.85rem; letter-spacing: 0.06em; text-transform: uppercase; margin-bottom: 12px; }
+        .hero h1 { font-family: var(--font-display); font-size: clamp(2.4rem, 5vw, 3.4rem); font-weight: 600; line-height: 1.08; letter-spacing: -0.01em; margin-bottom: 18px; }
+        .hero h1 em { font-style: italic; color: var(--accent); }
+        .hero p { color: var(--text-muted); font-size: 1.05rem; max-width: 46ch; }
+        .hero .hand { font-family: var(--font-hand); font-size: 1.5rem; color: var(--accent-2); margin-top: 18px; transform: rotate(-2deg); display: inline-block; }
+        .hero-photo-frame { justify-self: center; transform: rotate(2deg); }
+        .hero-photo {
+            width: 280px; height: 340px; object-fit: cover; border-radius: 6px;
+            border: 8px solid var(--card); box-shadow: var(--shadow);
+        }
+
+        /* --- INK DIVIDER --- */
+        .ink { display: block; margin: 8px auto; color: var(--border); width: 220px; height: 18px; }
+        .ink path { stroke: currentColor; stroke-width: 2.5; fill: none; stroke-linecap: round; }
+
+        /* --- SECTION HEADERS --- */
+        .sec-head { margin-bottom: 28px; }
+        .sec-head .label { font-family: var(--font-hand); font-size: 1.5rem; color: var(--accent-2); display: block; line-height: 1; }
+        .sec-head h2 { font-family: var(--font-display); font-size: 2rem; font-weight: 600; }
+
+        /* --- ABOUT + FACTS --- */
+        .about-grid { display: grid; grid-template-columns: 1.6fr 1fr; gap: 40px; align-items: start; }
+        .about-grid p { color: var(--text); margin-bottom: 14px; max-width: 60ch; }
+        .facts { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 24px; box-shadow: var(--shadow); }
+        .fact { margin-bottom: 16px; }
+        .fact:last-child { margin-bottom: 0; }
+        .fact .k { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent); margin-bottom: 3px; }
+        .fact .v { font-family: var(--font-display); font-size: 0.98rem; }
+        .fact .v small { display: block; font-family: var(--font-body); font-size: 0.82rem; color: var(--text-muted); font-weight: 400; }
+
+        /* --- MEDICINE: research / building / clinical --- */
+        .realm-cols { display: grid; grid-template-columns: 1fr 1fr; gap: 36px; }
+        .realm-block h3 { font-family: var(--font-display); font-size: 1.15rem; font-weight: 600; margin-bottom: 14px; }
+        .realm-block h3 i { color: var(--accent); margin-right: 8px; }
+        .entry { border-left: 3px solid var(--accent-soft); padding: 6px 0 6px 16px; margin-bottom: 14px; text-decoration: none; display: block; color: var(--text); transition: border-color 0.2s; }
+        .entry:hover { border-left-color: var(--accent); }
+        .entry h4 { font-size: 0.95rem; font-weight: 600; }
+        .entry p { font-size: 0.85rem; color: var(--text-muted); margin: 0; }
+        .entry .when { font-size: 0.78rem; color: var(--accent-2); font-weight: 600; }
+
+        /* --- BEYOND MEDICINE --- */
+        .life-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 20px; }
+        .life-card { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 26px; box-shadow: var(--shadow); position: relative; transition: transform 0.25s; }
+        .life-card:hover { transform: translateY(-3px); }
+        .life-card .ic { width: 46px; height: 46px; border-radius: 12px; background: var(--accent-soft); color: var(--accent); display: flex; align-items: center; justify-content: center; font-size: 1.3rem; margin-bottom: 14px; }
+        .life-card h3 { font-family: var(--font-display); font-size: 1.2rem; font-weight: 600; margin-bottom: 6px; }
+        .life-card p { color: var(--text-muted); font-size: 0.92rem; margin: 0; }
+        .life-card a { font-weight: 500; }
+        .life-card .note { font-family: var(--font-hand); color: var(--accent-2); font-size: 1.25rem; transform: rotate(-3deg); display: inline-block; margin-top: 10px; }
+
+        /* --- TOOLS strip --- */
+        .tools { display: flex; flex-wrap: wrap; gap: 12px; }
+        .tool { display: inline-flex; align-items: center; gap: 8px; background: var(--card); border: 1px solid var(--border); border-radius: 999px; padding: 9px 16px; text-decoration: none; color: var(--text); font-size: 0.88rem; transition: all 0.2s; }
+        .tool:hover { border-color: var(--accent); color: var(--accent); }
+        .tool i { color: var(--accent); }
+
+        /* --- CONNECT --- */
+        .connect { text-align: center; }
+        .connect h2 { font-family: var(--font-display); font-size: 2.2rem; font-weight: 600; margin-bottom: 8px; }
+        .connect .hand { font-family: var(--font-hand); color: var(--accent-2); font-size: 1.6rem; }
+        .connect p { color: var(--text-muted); max-width: 44ch; margin: 6px auto 22px; }
+        .connect-links { display: flex; justify-content: center; gap: 14px; }
+        .connect-links a { width: 50px; height: 50px; border-radius: 50%; border: 1px solid var(--border); display: flex; align-items: center; justify-content: center; color: var(--text-muted); font-size: 1.2rem; text-decoration: none; transition: all 0.2s; }
+        .connect-links a:hover { border-color: var(--accent); color: var(--accent); transform: translateY(-2px); }
+
+        .footer { text-align: center; padding: 28px; font-size: 0.82rem; color: var(--text-muted); border-top: 1px solid var(--border); }
+
+        @media (max-width: 820px) {
+            .hero { grid-template-columns: 1fr; text-align: center; }
+            .hero p { margin: 0 auto; }
+            .hero-photo-frame { order: -1; }
+            .about-grid, .realm-cols, .life-grid { grid-template-columns: 1fr; }
+        }
+        @media (max-width: 600px) {
+            .nav-links { gap: 14px; }
+            .nav-links li:not(:last-child) { display: none; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            * { transition: none !important; }
+            html { scroll-behavior: auto; }
+            .life-card:hover, .connect-links a:hover { transform: none; }
+        }
+    </style>
+</head>
+<body>
+    <div class="page">
+    <header class="header">
+        <div class="header-inner">
+            <a href="#top" class="logo">Samipya Kafle<span class="dot">.</span></a>
+            <nav>
+                <ul class="nav-links">
+                    <li><a href="#about">About</a></li>
+                    <li><a href="#medicine">In Medicine</a></li>
+                    <li><a href="#life">Beyond</a></li>
+                    <li><a href="#connect">Connect</a></li>
+                    <li>
+                        <button class="theme-btn" id="theme-toggle" aria-label="Toggle dark mode">
+                            <i class="fas fa-circle-half-stroke"></i>
+                        </button>
+                    </li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <main class="container">
+        <!-- HERO -->
+        <section class="hero" id="top">
+            <div>
+                <div class="eyebrow">PGY-2 Otolaryngology Resident &middot; Portland, OR</div>
+                <h1>I'm Samip — a surgeon-scientist who also <em>draws, plays, climbs, and lifts.</em></h1>
+                <p>From Nepal to the Pacific Northwest by way of Michigan, Nevada, and Connecticut. I work at the intersection of medicine, technology, and surgical education — and I believe the person matters as much as the CV.</p>
+                <div class="hand">nice to meet you ✦</div>
+            </div>
+            <div class="hero-photo-frame">
+                <img src="../images/me_large.jpg" alt="Dr. Samipya Kafle" class="hero-photo" loading="eager">
+            </div>
+        </section>
+
+        <svg class="ink" viewBox="0 0 220 18" aria-hidden="true"><path d="M3 11 C 40 3, 70 17, 110 9 S 185 3, 217 10"/></svg>
+
+        <!-- ABOUT -->
+        <section id="about">
+            <div class="sec-head">
+                <span class="label">the short version</span>
+                <h2>A bit about me</h2>
+            </div>
+            <div class="about-grid">
+                <div>
+                    <p>My background is in neuroscience, and my own experience with hearing loss shapes how I think about both clinical care and research in hearing technologies. Day to day I'm drawn to surgical outcomes in otolaryngology and to the data tools and cognitive frameworks that make surgical learning better.</p>
+                    <p>Outside the hospital I keep my hands busy — ink on paper, strings under my fingers, trails under my boots, and a barbell on the floor. I think the balance between technical precision and creative expression is the whole point.</p>
+                </div>
+                <aside class="facts">
+                    <div class="fact"><div class="k">Education</div><div class="v">Yale School of Medicine<small>Otolaryngology</small></div></div>
+                    <div class="fact"><div class="k"></div><div class="v">University of Nevada, Reno<small>B.S. Neuroscience</small></div></div>
+                    <div class="fact"><div class="k">Languages</div><div class="v" style="font-family:var(--font-body);font-size:0.9rem;font-weight:400;">Nepali (native), English (fluent), Spanish, Swiss German</div></div>
+                    <div class="fact"><div class="k">Home base</div><div class="v">Portland, Oregon</div></div>
+                </aside>
+            </div>
+        </section>
+
+        <svg class="ink" viewBox="0 0 220 18" aria-hidden="true"><path d="M3 9 C 45 16, 70 2, 110 10 S 180 16, 217 8"/></svg>
+
+        <!-- IN MEDICINE -->
+        <section id="medicine">
+            <div class="sec-head">
+                <span class="label">the work</span>
+                <h2>In medicine</h2>
+            </div>
+            <div class="realm-cols">
+                <div class="realm-block">
+                    <h3><i class="fas fa-flask"></i>Research</h3>
+                    <a class="entry" href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Trauma+OR+Fracture+OR+Injury)" target="_blank" rel="noopener"><h4>Craniofacial Trauma</h4><p>Injury patterns in sports and surgical outcome factors</p></a>
+                    <a class="entry" href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cancer+OR+Oncology+OR+Laryngectomy)" target="_blank" rel="noopener"><h4>Head &amp; Neck Oncology</h4><p>Complications, risk factors, and survival outcomes</p></a>
+                    <a class="entry" href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Education+OR+Training+OR+Student)" target="_blank" rel="noopener"><h4>Surgical Education</h4><p>Live-streaming and automated feedback systems</p></a>
+                    <a class="entry" href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cochlear+OR+Hearing+OR+Otology)" target="_blank" rel="noopener"><h4>Otology &amp; Hearing Sciences</h4><p>Cortical adaptations in CI patients and speech processing</p></a>
+                </div>
+                <div class="realm-block">
+                    <h3><i class="fas fa-microchip"></i>Building</h3>
+                    <div class="entry"><h4>Speech-in-Noise Processing</h4><p><span class="when">2022&ndash;now</span> &middot; Hearing device enhancement</p></div>
+                    <a class="entry" href="../ascii-editor.html"><h4>Surgical Livestreaming &amp; ASCII Editor</h4><p><span class="when">2022&ndash;25</span> &middot; Streaming platform and a browser diagram tool</p></a>
+
+                    <h3 style="margin-top:24px;"><i class="fas fa-user-md"></i>Clinical</h3>
+                    <div class="entry"><h4>Surgery Livestreaming Elective</h4><p><span class="when">2022&ndash;now</span> &middot; Pre-clerkship curriculum design</p></div>
+                    <div class="entry"><h4>HAVEN Free Clinic</h4><p><span class="when">2020&ndash;now</span> &middot; Senior Clinical Team Member</p></div>
+                    <div class="entry"><h4>POCUS Teaching</h4><p><span class="when">2021&ndash;now</span> &middot; Ultrasound skills for MS1s</p></div>
+                </div>
+            </div>
+            <div style="margin-top:24px;">
+                <div class="tools">
+                    <a class="tool" href="../kag.html"><i class="fas fa-diagram-project"></i> Knowledge Atlas Graph</a>
+                    <a class="tool" href="../cpt-search.html"><i class="fas fa-magnifying-glass"></i> CPT Code Search</a>
+                    <a class="tool" href="../ascii-editor.html"><i class="fas fa-terminal"></i> ASCII Art Editor</a>
+                </div>
+            </div>
+        </section>
+
+        <svg class="ink" viewBox="0 0 220 18" aria-hidden="true"><path d="M3 11 C 40 3, 70 17, 110 9 S 185 3, 217 10"/></svg>
+
+        <!-- BEYOND MEDICINE -->
+        <section id="life">
+            <div class="sec-head">
+                <span class="label">the rest of me</span>
+                <h2>Beyond medicine</h2>
+            </div>
+            <div class="life-grid">
+                <div class="life-card">
+                    <div class="ic"><i class="fas fa-palette"></i></div>
+                    <h3>Art</h3>
+                    <p>Ink &amp; graphite. I draw to slow down — anatomy, landscapes, and the occasional portrait. More on <a href="https://www.instagram.com/skflx/" target="_blank" rel="noopener">Instagram</a>.</p>
+                </div>
+                <div class="life-card">
+                    <div class="ic"><i class="fas fa-music"></i></div>
+                    <h3>Music</h3>
+                    <p>Guitar &amp; ukulele. I performed at the Yale 4th-Year Show (April 2023) and still play to unwind.</p>
+                </div>
+                <div class="life-card">
+                    <div class="ic"><i class="fas fa-mountain"></i></div>
+                    <h3>Outdoors</h3>
+                    <p>Hiking and exploring the Pacific Northwest — trails, alpine lakes, and a camera that comes along for the ride.</p>
+                </div>
+                <div class="life-card">
+                    <div class="ic"><i class="fas fa-dumbbell"></i></div>
+                    <h3>Fitness</h3>
+                    <p>Powerlifting and a slowly growing home gym.</p>
+                    <span class="note">deadlifts are my favorite</span>
+                </div>
+            </div>
+        </section>
+
+        <svg class="ink" viewBox="0 0 220 18" aria-hidden="true"><path d="M3 9 C 45 16, 70 2, 110 10 S 180 16, 217 8"/></svg>
+
+        <!-- CONNECT -->
+        <section id="connect" class="connect">
+            <span class="hand">say hello</span>
+            <h2>Let's connect</h2>
+            <p>Interested in research collaborations, medical education, or just want to talk shop (or guitars)?</p>
+            <div class="connect-links">
+                <a href="https://linkedin.com/in/skflx" target="_blank" rel="noopener" aria-label="LinkedIn"><i class="fab fa-linkedin-in"></i></a>
+                <a href="https://www.instagram.com/skflx/" target="_blank" rel="noopener" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
+                <a href="https://github.com/skflx" target="_blank" rel="noopener" aria-label="GitHub"><i class="fab fa-github"></i></a>
+                <a href="../documents/cv.pdf" aria-label="Download CV"><i class="fas fa-file-pdf"></i></a>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">&copy; 2025 Samipya Kafle, MD &middot; Portland, Oregon</footer>
+    </div>
+
+    <script>
+        (function () {
+            var btn = document.getElementById('theme-toggle');
+            if (!btn) return;
+            btn.addEventListener('click', function () {
+                var current = document.documentElement.getAttribute('data-theme');
+                var next = current === 'dark' ? 'light' : 'dark';
+                document.documentElement.setAttribute('data-theme', next);
+                try { localStorage.setItem('sk_theme', next); } catch (e) {}
+            });
+        })();
+    </script>
+</body>
+</html>

--- a/mockups/one-pager-terminal.html
+++ b/mockups/one-pager-terminal.html
@@ -1,0 +1,307 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terminal &middot; Samipya Kafle, MD</title>
+    <meta name="description" content="Dr. Samipya Kafle is an otolaryngology resident in the Pacific Northwest passionate about technology, surgical education, and the intersection of medicine and innovation.">
+
+    <!-- Set theme before paint to avoid flash (terminal defaults dark) -->
+    <script>
+        (function () {
+            try {
+                var stored = localStorage.getItem('sk_theme');
+                document.documentElement.setAttribute('data-theme', stored || 'dark');
+            } catch (e) {
+                document.documentElement.setAttribute('data-theme', 'dark');
+            }
+        })();
+    </script>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <style>
+        /* ========================================================
+           ONE-PAGER — TERMINAL / MONO (linear-scroll)
+           Monospace, dark-first, green accent, subtle grid lines.
+           Section headers are shell prompts. GitHub-README energy.
+           ======================================================== */
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        :root { /* dark (default) */
+            --bg: #0d1117;
+            --panel: #161b22;
+            --text: #c9d1d9;
+            --text-muted: #8b949e;
+            --accent: #3fb950;
+            --accent-2: #58a6ff;
+            --warn: #d29922;
+            --border: #30363d;
+            --grid: rgba(255, 255, 255, 0.025);
+            --font: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+        }
+        [data-theme="light"] {
+            --bg: #fbfdff;
+            --panel: #f3f6fa;
+            --text: #1f2328;
+            --text-muted: #57606a;
+            --accent: #1a7f37;
+            --accent-2: #0969da;
+            --warn: #9a6700;
+            --border: #d0d7de;
+            --grid: rgba(0, 0, 0, 0.03);
+        }
+
+        html { scroll-behavior: smooth; scroll-padding-top: 64px; }
+        body {
+            font-family: var(--font);
+            color: var(--text);
+            background-color: var(--bg);
+            background-image:
+                linear-gradient(var(--grid) 1px, transparent 1px),
+                linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+            background-size: 28px 28px;
+            line-height: 1.7;
+            font-size: 14px;
+            -webkit-font-smoothing: antialiased;
+        }
+        a { color: var(--accent-2); text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        a:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+        /* --- HEADER --- */
+        .header {
+            position: sticky; top: 0; z-index: 100;
+            background: color-mix(in srgb, var(--bg) 88%, transparent);
+            backdrop-filter: blur(8px);
+            border-bottom: 1px solid var(--border);
+            height: 48px; display: flex; align-items: center;
+        }
+        .header-inner { max-width: 860px; margin: 0 auto; padding: 0 24px; width: 100%; display: flex; justify-content: space-between; align-items: center; }
+        .logo { color: var(--text); font-weight: 700; font-size: 0.9rem; }
+        .logo .accent { color: var(--accent); }
+        .nav-links { list-style: none; display: flex; gap: 18px; }
+        .nav-links a { color: var(--text-muted); font-size: 0.8rem; }
+        .nav-links a:hover { color: var(--accent); text-decoration: none; }
+        .theme-btn { background: none; border: 1px solid var(--border); border-radius: 4px; color: var(--text-muted); cursor: pointer; padding: 4px 8px; font-family: var(--font); font-size: 0.75rem; }
+        .theme-btn:hover { color: var(--accent); border-color: var(--accent); }
+
+        /* --- LAYOUT --- */
+        .wrap { max-width: 860px; margin: 0 auto; padding: 40px 24px 64px; }
+        .prompt-line { color: var(--text-muted); margin-bottom: 14px; font-size: 0.85rem; }
+        .prompt-line .user { color: var(--accent); }
+        .prompt-line .path { color: var(--accent-2); }
+        .prompt-line .cmd { color: var(--text); }
+        section { margin-bottom: 44px; }
+        .divider { color: var(--border); white-space: nowrap; overflow: hidden; user-select: none; margin: 0 0 18px; letter-spacing: 1px; }
+        .comment { color: var(--text-muted); }
+        .comment::before { content: "# "; }
+
+        /* --- HERO --- */
+        .hero { margin-bottom: 48px; }
+        .hero h1 { font-size: 1.9rem; font-weight: 700; color: var(--text); margin: 6px 0 2px; }
+        .hero .role { color: var(--accent); font-size: 0.95rem; }
+        .hero .bio { color: var(--text-muted); max-width: 60ch; margin: 14px 0 18px; }
+        .cursor { display: inline-block; width: 9px; height: 1.05em; background: var(--accent); vertical-align: text-bottom; margin-left: 3px; animation: blink 1.1s step-end infinite; }
+        @keyframes blink { 50% { opacity: 0; } }
+        .hero-links { display: flex; flex-wrap: wrap; gap: 10px; }
+        .hero-links a {
+            border: 1px solid var(--border); border-radius: 4px; padding: 7px 12px;
+            color: var(--text); font-size: 0.8rem; display: inline-flex; align-items: center; gap: 7px;
+        }
+        .hero-links a:hover { border-color: var(--accent); color: var(--accent); text-decoration: none; }
+
+        /* --- KEY/VALUE (about) --- */
+        .kv { display: grid; grid-template-columns: 160px 1fr; gap: 6px 16px; font-size: 0.88rem; }
+        .kv dt { color: var(--accent); }
+        .kv dd { color: var(--text); }
+        .prose { color: var(--text); max-width: 70ch; }
+        .prose p { margin-bottom: 10px; }
+
+        /* --- LIST ROWS --- */
+        .rows { display: flex; flex-direction: column; gap: 4px; }
+        .row {
+            display: grid; grid-template-columns: 1.2em 1fr auto; gap: 12px; align-items: baseline;
+            padding: 10px 12px; border: 1px solid transparent; border-radius: 6px;
+            color: var(--text);
+        }
+        .row:hover { border-color: var(--border); background: var(--panel); text-decoration: none; }
+        .row .mark { color: var(--accent); }
+        .row .title { color: var(--text); font-weight: 500; }
+        .row .desc { color: var(--text-muted); display: block; font-weight: 400; }
+        .row .meta { color: var(--warn); font-size: 0.8rem; white-space: nowrap; }
+
+        /* --- CHIPS --- */
+        .chips { display: flex; flex-wrap: wrap; gap: 8px; }
+        .chip { border: 1px solid var(--border); border-radius: 4px; padding: 5px 10px; font-size: 0.8rem; color: var(--text); }
+        .chip i { color: var(--accent); margin-right: 6px; }
+
+        /* --- CONNECT --- */
+        .connect { border: 1px solid var(--border); border-radius: 8px; padding: 22px; background: var(--panel); }
+        .connect .out { color: var(--text-muted); margin-bottom: 12px; }
+        .connect-links { display: flex; flex-wrap: wrap; gap: 14px; }
+        .connect-links a { display: inline-flex; align-items: center; gap: 8px; color: var(--text); }
+        .connect-links a:hover { color: var(--accent); text-decoration: none; }
+        .connect-links i { color: var(--accent); }
+
+        .footer { border-top: 1px solid var(--border); color: var(--text-muted); font-size: 0.8rem; padding: 18px 24px; text-align: center; }
+
+        @media (max-width: 640px) {
+            .nav-links { display: none; }
+            .kv { grid-template-columns: 1fr; gap: 2px; }
+            .kv dt { margin-top: 8px; }
+            .row { grid-template-columns: 1.2em 1fr; }
+            .row .meta { grid-column: 2; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            * { transition: none !important; }
+            html { scroll-behavior: auto; }
+            .cursor { animation: none; }
+        }
+    </style>
+</head>
+<body>
+    <header class="header">
+        <div class="header-inner">
+            <a href="#top" class="logo">~/<span class="accent">skflx.MD</span></a>
+            <nav style="display:flex;align-items:center;gap:16px;">
+                <ul class="nav-links">
+                    <li><a href="#about">./about</a></li>
+                    <li><a href="#research">./research</a></li>
+                    <li><a href="#projects">./projects</a></li>
+                    <li><a href="#clinical">./clinical</a></li>
+                    <li><a href="#connect">./connect</a></li>
+                </ul>
+                <button class="theme-btn" id="theme-toggle" aria-label="Toggle dark mode">--theme</button>
+            </nav>
+        </div>
+    </header>
+
+    <main class="wrap">
+        <!-- HERO -->
+        <section class="hero" id="top">
+            <div class="prompt-line"><span class="user">samip@pnw</span>:<span class="path">~</span>$ <span class="cmd">whoami</span></div>
+            <div class="role">PGY-2 Otolaryngology Resident</div>
+            <h1>Samipya Kafle, MD<span class="cursor"></span></h1>
+            <p class="bio">Surgeon-scientist in training in the Pacific Northwest. Passionate about technology, surgical education, and the intersection of medicine and innovation.</p>
+            <div class="hero-links">
+                <a href="#connect"><i class="fas fa-paper-plane"></i> get_in_touch</a>
+                <a href="../documents/cv.pdf"><i class="fas fa-file-pdf"></i> cv.pdf</a>
+                <a href="https://linkedin.com/in/skflx" target="_blank" rel="noopener" aria-label="LinkedIn"><i class="fab fa-linkedin"></i> linkedin</a>
+                <a href="https://github.com/skflx" target="_blank" rel="noopener" aria-label="GitHub"><i class="fab fa-github"></i> github</a>
+                <a href="https://www.instagram.com/skflx/" target="_blank" rel="noopener" aria-label="Instagram"><i class="fab fa-instagram"></i> instagram</a>
+            </div>
+        </section>
+
+        <!-- ABOUT -->
+        <section id="about">
+            <div class="prompt-line"><span class="user">samip@pnw</span>:<span class="path">~/about</span>$ <span class="cmd">cat bio.md</span></div>
+            <div class="prose">
+                <p>My journey began in Nepal, spanning Michigan, Oregon, Nevada, and Connecticut before returning to the Pacific Northwest. With a background in neuroscience and personal experience with hearing loss, I bring a unique perspective to both clinical practice and research in hearing technologies.</p>
+                <p>My research focuses on surgical outcomes in otolaryngology and emergent data technologies in medical education. I'm particularly interested in cognitive frameworks that enhance surgical learning.</p>
+            </div>
+            <p class="divider">────────────────────────────────────────────────────────────</p>
+            <dl class="kv">
+                <dt>education</dt><dd>Yale School of Medicine &mdash; Otolaryngology</dd>
+                <dt></dt><dd>University of Nevada, Reno &mdash; B.S. Neuroscience</dd>
+                <dt>languages</dt><dd>Nepali (native), English (fluent), Spanish, Swiss German</dd>
+                <dt>location</dt><dd>Portland, Oregon &middot; Pacific Northwest</dd>
+            </dl>
+        </section>
+
+        <!-- WHAT I DO -->
+        <section id="interests">
+            <div class="prompt-line"><span class="user">samip@pnw</span>:<span class="path">~</span>$ <span class="cmd">ls interests/</span></div>
+            <div class="chips">
+                <span class="chip"><i class="fas fa-flask"></i>research</span>
+                <span class="chip"><i class="fas fa-microchip"></i>technology</span>
+                <span class="chip"><i class="fas fa-palette"></i>art</span>
+                <span class="chip"><i class="fas fa-music"></i>music</span>
+                <span class="chip"><i class="fas fa-mountain"></i>outdoors</span>
+                <span class="chip"><i class="fas fa-dumbbell"></i>fitness</span>
+            </div>
+        </section>
+
+        <!-- RESEARCH -->
+        <section id="research">
+            <div class="prompt-line"><span class="user">samip@pnw</span>:<span class="path">~/research</span>$ <span class="cmd">grep -r "Kafle" pubmed/</span></div>
+            <div class="rows">
+                <a class="row" href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Trauma+OR+Fracture+OR+Injury)" target="_blank" rel="noopener">
+                    <span class="mark">→</span><span><span class="title">Craniofacial Trauma</span><span class="desc">Injury patterns in sports and surgical outcome factors</span></span><span class="meta">PubMed</span>
+                </a>
+                <a class="row" href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cancer+OR+Oncology+OR+Laryngectomy)" target="_blank" rel="noopener">
+                    <span class="mark">→</span><span><span class="title">Head &amp; Neck Oncology</span><span class="desc">Complications, risk factors, and survival outcomes</span></span><span class="meta">PubMed</span>
+                </a>
+                <a class="row" href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Education+OR+Training+OR+Student)" target="_blank" rel="noopener">
+                    <span class="mark">→</span><span><span class="title">Surgical Education</span><span class="desc">Live-streaming and automated feedback systems</span></span><span class="meta">PubMed</span>
+                </a>
+                <a class="row" href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cochlear+OR+Hearing+OR+Otology)" target="_blank" rel="noopener">
+                    <span class="mark">→</span><span><span class="title">Otology &amp; Hearing Sciences</span><span class="desc">Cortical adaptations in CI patients and speech processing</span></span><span class="meta">PubMed</span>
+                </a>
+            </div>
+            <p class="comment" style="margin-top:12px;"><a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]" target="_blank" rel="noopener">view all papers &rarr;</a></p>
+        </section>
+
+        <!-- TECHNOLOGY -->
+        <section id="projects">
+            <div class="prompt-line"><span class="user">samip@pnw</span>:<span class="path">~/projects</span>$ <span class="cmd">ls tech/</span></div>
+            <div class="rows">
+                <div class="row"><span class="mark">→</span><span><span class="title">Speech-in-Noise Processing</span><span class="desc">Hearing device enhancement</span></span><span class="meta">2022&ndash;now</span></div>
+                <div class="row"><span class="mark">→</span><span><span class="title">Surgical Livestreaming</span><span class="desc">Procedure streaming platform</span></span><span class="meta">2022&ndash;now</span></div>
+                <a class="row" href="../ascii-editor.html"><span class="mark">→</span><span><span class="title">ASCII Art Editor</span><span class="desc">Browser-based diagram tool</span></span><span class="meta">2025</span></a>
+            </div>
+        </section>
+
+        <!-- CLINICAL -->
+        <section id="clinical">
+            <div class="prompt-line"><span class="user">samip@pnw</span>:<span class="path">~/clinical</span>$ <span class="cmd">cat experience.log</span></div>
+            <div class="rows">
+                <div class="row"><span class="mark">→</span><span><span class="title">Surgery Livestreaming Elective</span><span class="desc">Pre-clerkship curriculum design</span></span><span class="meta">2022&ndash;now</span></div>
+                <div class="row"><span class="mark">→</span><span><span class="title">HAVEN Free Clinic</span><span class="desc">Senior Clinical Team Member</span></span><span class="meta">2020&ndash;now</span></div>
+                <div class="row"><span class="mark">→</span><span><span class="title">Point of Care Ultrasound Teaching</span><span class="desc">Ultrasound skills training for MS1s</span></span><span class="meta">2021&ndash;now</span></div>
+            </div>
+        </section>
+
+        <!-- TOOLS -->
+        <section id="tools">
+            <div class="prompt-line"><span class="user">samip@pnw</span>:<span class="path">~/tools</span>$ <span class="cmd">./run</span></div>
+            <div class="rows">
+                <a class="row" href="../kag.html"><span class="mark">$</span><span><span class="title">Knowledge Atlas Graph</span><span class="desc">Interactive OHNS knowledge map with self-testing</span></span><span class="meta">launch</span></a>
+                <a class="row" href="../cpt-search.html"><span class="mark">$</span><span><span class="title">CPT Code Search</span><span class="desc">Fast CPT lookup for otolaryngology</span></span><span class="meta">launch</span></a>
+                <a class="row" href="../ascii-editor.html"><span class="mark">$</span><span><span class="title">ASCII Art Editor</span><span class="desc">Browser-based ASCII/Unicode diagram editor</span></span><span class="meta">launch</span></a>
+            </div>
+        </section>
+
+        <!-- CONNECT -->
+        <section id="connect">
+            <div class="prompt-line"><span class="user">samip@pnw</span>:<span class="path">~</span>$ <span class="cmd">./connect</span></div>
+            <div class="connect">
+                <p class="out">Research, innovation, or just say hello.</p>
+                <div class="connect-links">
+                    <a href="https://linkedin.com/in/skflx" target="_blank" rel="noopener"><i class="fab fa-linkedin"></i> linkedin.com/in/skflx</a>
+                    <a href="https://www.instagram.com/skflx/" target="_blank" rel="noopener"><i class="fab fa-instagram"></i> @skflx</a>
+                    <a href="https://github.com/skflx" target="_blank" rel="noopener"><i class="fab fa-github"></i> github.com/skflx</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">&copy; 2025 skflx.MD &middot; Portland, Oregon</footer>
+
+    <script>
+        (function () {
+            var btn = document.getElementById('theme-toggle');
+            if (!btn) return;
+            btn.addEventListener('click', function () {
+                var current = document.documentElement.getAttribute('data-theme');
+                var next = current === 'dark' ? 'light' : 'dark';
+                document.documentElement.setAttribute('data-theme', next);
+                try { localStorage.setItem('sk_theme', next); } catch (e) {}
+            });
+        })();
+    </script>
+</body>
+</html>

--- a/mockups/one-pager.html
+++ b/mockups/one-pager.html
@@ -1,0 +1,490 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Samipya Kafle, MD | Otolaryngology Resident</title>
+    <meta name="description" content="Dr. Samipya Kafle is an otolaryngology resident in the Pacific Northwest passionate about technology, surgical education, and the intersection of medicine and innovation.">
+
+    <!-- Set theme before paint to avoid flash -->
+    <script>
+        (function () {
+            try {
+                var stored = localStorage.getItem('sk_theme');
+                var theme = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+                document.documentElement.setAttribute('data-theme', theme);
+            } catch (e) {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        })();
+    </script>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <style>
+        /* ========================================================
+           ONE-PAGER — BENTO GRID
+           Single scrollable page. Every section is a tile in a
+           4-column bento grid. Apple/Linear-inspired. Fixed accent,
+           dark/light toggle with system-preference + persistence.
+           ======================================================== */
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        :root {
+            --bg: #f5f5f7;
+            --card: #ffffff;
+            --text: #1d1d1f;
+            --text-secondary: #6e6e73;
+            --text-muted: #86868b;
+            --accent: #0071e3;
+            --accent-soft: #e3f0ff;
+            --border: #d2d2d7;
+            --font-body: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --font-display: 'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+            --radius: 16px;
+            --radius-sm: 10px;
+            --shadow-hover: 0 8px 30px rgba(0, 0, 0, 0.12);
+        }
+
+        [data-theme="dark"] {
+            --bg: #000000;
+            --card: #1c1c1e;
+            --text: #f5f5f7;
+            --text-secondary: #a1a1a6;
+            --text-muted: #6e6e73;
+            --accent: #2997ff;
+            --accent-soft: #0a2540;
+            --border: #38383a;
+            --shadow-hover: 0 8px 30px rgba(0, 0, 0, 0.5);
+        }
+
+        html { scroll-behavior: smooth; scroll-padding-top: 72px; }
+        body {
+            font-family: var(--font-body);
+            color: var(--text);
+            background: var(--bg);
+            -webkit-font-smoothing: antialiased;
+        }
+
+        a:focus-visible, button:focus-visible {
+            outline: 2px solid var(--accent);
+            outline-offset: 2px;
+            border-radius: 6px;
+        }
+
+        /* --- HEADER --- */
+        .header {
+            position: sticky; top: 0; z-index: 100;
+            background: color-mix(in srgb, var(--bg) 80%, transparent);
+            backdrop-filter: blur(20px) saturate(180%);
+            height: 48px; display: flex; align-items: center;
+            border-bottom: 0.5px solid var(--border);
+        }
+        .header-inner { max-width: 1200px; margin: 0 auto; padding: 0 24px; width: 100%; display: flex; justify-content: space-between; align-items: center; }
+        .logo { font-family: var(--font-display); font-weight: 700; font-size: 1rem; color: var(--text); text-decoration: none; }
+        .nav { display: flex; align-items: center; gap: 16px; }
+        .nav-links { list-style: none; display: flex; gap: 20px; }
+        .nav-links a { color: var(--text-muted); text-decoration: none; font-size: 0.8rem; transition: color 0.2s; }
+        .nav-links a:hover { color: var(--text); }
+        .theme-btn {
+            background: none; border: none; cursor: pointer; color: var(--text-muted);
+            padding: 4px; display: inline-flex; align-items: center; justify-content: center;
+            transition: color 0.2s;
+        }
+        .theme-btn:hover { color: var(--text); }
+        .theme-btn svg { width: 18px; height: 18px; }
+        .theme-btn .icon-sun { display: none; }
+        .theme-btn .icon-moon { display: block; }
+        [data-theme="dark"] .theme-btn .icon-sun { display: block; }
+        [data-theme="dark"] .theme-btn .icon-moon { display: none; }
+
+        /* --- BENTO GRID --- */
+        .bento-container { max-width: 1200px; margin: 0 auto; padding: 24px; }
+        .bento-grid {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 16px;
+            grid-auto-rows: minmax(160px, auto);
+        }
+        .bento-card {
+            background: var(--card);
+            border-radius: var(--radius);
+            padding: 28px;
+            display: flex; flex-direction: column; justify-content: space-between;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+            overflow: hidden; position: relative;
+        }
+        .bento-card:hover { transform: translateY(-2px); box-shadow: var(--shadow-hover); }
+
+        .span-2 { grid-column: span 2; }
+        .span-3 { grid-column: span 3; }
+        .span-4 { grid-column: span 4; }
+
+        .label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); margin-bottom: 14px; }
+        .card-title { font-family: var(--font-display); font-size: 1.1rem; font-weight: 600; }
+
+        /* --- HERO CARD --- */
+        .card-hero {
+            min-height: 280px;
+            display: grid; grid-template-columns: 1fr auto;
+            gap: 32px; align-items: center;
+            background: linear-gradient(135deg, var(--card) 60%, var(--accent-soft) 100%);
+        }
+        .card-hero .hero-content { max-width: 560px; }
+        .card-hero h1 { font-family: var(--font-display); font-size: 2.5rem; font-weight: 700; line-height: 1.15; margin-bottom: 12px; }
+        .card-hero h1 .accent { color: var(--accent); }
+        .card-hero .subtitle { color: var(--accent); font-size: 0.88rem; font-weight: 500; margin-bottom: 12px; display: flex; align-items: center; gap: 6px; }
+        .card-hero p { color: var(--text-secondary); font-size: 0.95rem; line-height: 1.6; }
+        .card-hero .hero-photo { width: 200px; height: 240px; border-radius: var(--radius-sm); object-fit: cover; }
+        .hero-ctas { display: flex; gap: 10px; margin-top: 16px; flex-wrap: wrap; }
+        .hero-ctas a {
+            display: inline-flex; align-items: center; gap: 6px;
+            padding: 10px 20px; border-radius: 980px; font-size: 0.85rem; font-weight: 500; text-decoration: none;
+            transition: all 0.2s;
+        }
+        .cta-primary { background: var(--accent); color: #fff; }
+        .cta-primary:hover { filter: brightness(1.1); }
+        .cta-secondary { background: color-mix(in srgb, var(--text) 10%, transparent); color: var(--text); }
+        .cta-secondary:hover { background: color-mix(in srgb, var(--text) 18%, transparent); }
+
+        /* --- EDUCATION CARD --- */
+        .edu-item { margin-bottom: 14px; }
+        .edu-item:last-child { margin-bottom: 0; }
+        .edu-item h3 { font-size: 0.95rem; font-weight: 600; margin-bottom: 2px; }
+        .edu-item p { font-size: 0.82rem; color: var(--text-muted); margin: 0; }
+
+        /* --- LANGUAGES CARD --- */
+        .lang-list { list-style: none; }
+        .lang-list li { display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 0.5px solid var(--border); font-size: 0.88rem; }
+        .lang-list li:last-child { border-bottom: none; }
+        .lang-level { color: var(--text-muted); font-size: 0.82rem; }
+
+        /* --- WHAT I DO: Icon grid --- */
+        .interest-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+        .interest-tile {
+            text-align: center; padding: 14px 8px;
+            background: color-mix(in srgb, var(--accent) 8%, transparent);
+            border-radius: var(--radius-sm);
+        }
+        .interest-tile i { font-size: 1.3rem; color: var(--accent); display: block; margin-bottom: 6px; }
+        .interest-tile span { font-size: 0.75rem; color: var(--text-secondary); }
+
+        /* --- RESEARCH CARD --- */
+        .card-research { background: linear-gradient(135deg, var(--accent-soft), var(--card)); }
+        .research-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; margin-top: 12px; }
+        .research-tile {
+            padding: 16px; background: var(--card); border-radius: var(--radius-sm);
+            text-decoration: none; color: var(--text); transition: transform 0.2s, box-shadow 0.2s; display: block;
+        }
+        .research-tile:hover { transform: scale(1.02); box-shadow: var(--shadow-hover); }
+        .research-tile i { color: var(--accent); margin-bottom: 6px; display: block; font-size: 1.1rem; }
+        .research-tile h4 { font-size: 0.85rem; font-weight: 600; margin-bottom: 4px; }
+        .research-tile p { font-size: 0.75rem; color: var(--text-muted); margin: 0; }
+        .research-all { margin-top: 14px; }
+        .research-all a { font-size: 0.8rem; color: var(--accent); text-decoration: none; font-weight: 500; }
+        .research-all a:hover { text-decoration: underline; }
+
+        /* --- ROW LIST CARDS (Tech / Tools) --- */
+        .row-list { display: flex; flex-direction: column; gap: 12px; margin-top: 12px; }
+        .row-item {
+            display: flex; align-items: center; gap: 12px;
+            padding: 12px; background: color-mix(in srgb, var(--accent) 6%, transparent);
+            border-radius: var(--radius-sm); text-decoration: none; color: var(--text);
+            transition: transform 0.2s;
+        }
+        a.row-item:hover { transform: translateX(3px); }
+        .row-item i { color: var(--accent); width: 20px; text-align: center; flex-shrink: 0; }
+        .row-item .row-info h4 { font-size: 0.88rem; font-weight: 600; }
+        .row-item .row-info p { font-size: 0.75rem; color: var(--text-muted); margin: 0; }
+        .row-item .row-arrow { margin-left: auto; color: var(--text-muted); font-size: 0.75rem; }
+
+        /* --- CLINICAL CARD --- */
+        .clinical-list { margin-top: 12px; }
+        .clinical-item { padding: 10px 0; border-bottom: 0.5px solid var(--border); }
+        .clinical-item:last-child { border-bottom: none; }
+        .clinical-item .year { font-size: 0.75rem; color: var(--accent); font-weight: 600; }
+        .clinical-item h4 { font-size: 0.88rem; font-weight: 600; margin: 2px 0; }
+        .clinical-item p { font-size: 0.78rem; color: var(--text-muted); margin: 0; }
+
+        /* --- CONNECT CARD --- */
+        .card-connect { background: linear-gradient(135deg, var(--accent), #5856d6); color: #fff; text-align: center; justify-content: center; align-items: center; }
+        .card-connect h3 { font-family: var(--font-display); font-size: 1.3rem; font-weight: 700; margin-bottom: 8px; }
+        .card-connect p { color: rgba(255, 255, 255, 0.85); font-size: 0.88rem; margin-bottom: 16px; }
+        .connect-links { display: flex; gap: 10px; justify-content: center; }
+        .connect-links a {
+            width: 40px; height: 40px; display: flex; align-items: center; justify-content: center;
+            background: rgba(255, 255, 255, 0.2); border-radius: 50%; color: #fff;
+            text-decoration: none; transition: background 0.2s; font-size: 1rem;
+        }
+        .connect-links a:hover { background: rgba(255, 255, 255, 0.35); }
+
+        /* --- LOCATION CARD --- */
+        .card-location { justify-content: center; align-items: center; text-align: center; }
+        .card-location i { font-size: 1.5rem; color: var(--accent); margin-bottom: 8px; }
+        .card-location h4 { font-size: 0.95rem; font-weight: 600; margin-bottom: 2px; }
+        .card-location p { font-size: 0.82rem; color: var(--text-muted); margin: 0; }
+
+        /* --- FOOTER --- */
+        .footer { text-align: center; padding: 24px; font-size: 0.75rem; color: var(--text-muted); }
+
+        /* --- RESPONSIVE --- */
+        @media (max-width: 900px) {
+            .bento-grid { grid-template-columns: repeat(2, 1fr); }
+            .span-3, .span-4 { grid-column: span 2; }
+            .card-hero { grid-template-columns: 1fr; }
+            .card-hero .hero-photo { display: none; }
+            .research-grid { grid-template-columns: 1fr; }
+        }
+        @media (max-width: 600px) {
+            .bento-grid { grid-template-columns: 1fr; }
+            .span-2, .span-3, .span-4 { grid-column: span 1; }
+            .card-hero h1 { font-size: 1.8rem; }
+            .interest-grid { grid-template-columns: repeat(2, 1fr); }
+            .nav-links { display: none; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            * { transition: none !important; }
+            html { scroll-behavior: auto; }
+            .bento-card:hover, .research-tile:hover, a.row-item:hover { transform: none; }
+        }
+    </style>
+</head>
+<body>
+    <!-- HEADER -->
+    <header class="header">
+        <div class="header-inner">
+            <a href="#top" class="logo">skflx.MD</a>
+            <nav class="nav">
+                <ul class="nav-links">
+                    <li><a href="#about">About</a></li>
+                    <li><a href="#research">Research</a></li>
+                    <li><a href="#projects">Projects</a></li>
+                    <li><a href="#clinical">Clinical</a></li>
+                    <li><a href="#connect">Connect</a></li>
+                </ul>
+                <button class="theme-btn" id="theme-toggle" aria-label="Toggle dark mode">
+                    <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </nav>
+        </div>
+    </header>
+
+    <!-- BENTO LAYOUT -->
+    <main class="bento-container">
+        <div class="bento-grid">
+
+            <!-- HERO -->
+            <section class="bento-card card-hero span-4" id="top">
+                <div class="hero-content">
+                    <div class="subtitle"><i class="fas fa-stethoscope"></i> PGY-2 Otolaryngology Resident</div>
+                    <h1>Hi, I'm <span class="accent">Samip.</span></h1>
+                    <p>Surgeon-scientist in training in the Pacific Northwest. Passionate about technology, surgical education, and the intersection of medicine and innovation.</p>
+                    <div class="hero-ctas">
+                        <a href="#connect" class="cta-primary"><i class="fas fa-paper-plane"></i> Get in Touch</a>
+                        <a href="../documents/cv.pdf" class="cta-secondary"><i class="fas fa-file-pdf"></i> Download CV</a>
+                    </div>
+                </div>
+                <img src="../images/me_large.jpg" alt="Dr. Samipya Kafle" class="hero-photo" loading="eager">
+            </section>
+
+            <!-- EDUCATION -->
+            <section class="bento-card" id="about">
+                <div class="label">Education</div>
+                <div>
+                    <div class="edu-item">
+                        <h3>Yale School of Medicine</h3>
+                        <p>Otolaryngology</p>
+                    </div>
+                    <div class="edu-item">
+                        <h3>University of Nevada, Reno</h3>
+                        <p>B.S. Neuroscience</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- LANGUAGES -->
+            <section class="bento-card">
+                <div class="label">Languages</div>
+                <ul class="lang-list">
+                    <li>Nepali <span class="lang-level">Native</span></li>
+                    <li>English <span class="lang-level">Fluent</span></li>
+                    <li>Spanish <span class="lang-level">Intermediate</span></li>
+                    <li>Swiss German <span class="lang-level">Intermediate</span></li>
+                </ul>
+            </section>
+
+            <!-- WHAT I DO -->
+            <section class="bento-card span-2">
+                <div class="label">What I Do</div>
+                <div class="interest-grid">
+                    <div class="interest-tile"><i class="fas fa-flask"></i><span>Research</span></div>
+                    <div class="interest-tile"><i class="fas fa-microchip"></i><span>Technology</span></div>
+                    <div class="interest-tile"><i class="fas fa-palette"></i><span>Art</span></div>
+                    <div class="interest-tile"><i class="fas fa-music"></i><span>Music</span></div>
+                    <div class="interest-tile"><i class="fas fa-mountain"></i><span>Outdoors</span></div>
+                    <div class="interest-tile"><i class="fas fa-dumbbell"></i><span>Fitness</span></div>
+                </div>
+            </section>
+
+            <!-- RESEARCH -->
+            <section class="bento-card card-research span-4" id="research">
+                <div>
+                    <div class="label" style="margin-bottom: 4px;">Research</div>
+                    <h3 class="card-title">Publications in Otolaryngology</h3>
+                </div>
+                <div class="research-grid">
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Trauma+OR+Fracture+OR+Injury)" target="_blank" rel="noopener" class="research-tile">
+                        <i class="fas fa-skull"></i>
+                        <h4>Craniofacial Trauma</h4>
+                        <p>Injury patterns in sports and surgical outcome factors</p>
+                    </a>
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cancer+OR+Oncology+OR+Laryngectomy)" target="_blank" rel="noopener" class="research-tile">
+                        <i class="fas fa-ribbon"></i>
+                        <h4>Head &amp; Neck Oncology</h4>
+                        <p>Complications, risk factors, and survival outcomes</p>
+                    </a>
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Education+OR+Training+OR+Student)" target="_blank" rel="noopener" class="research-tile">
+                        <i class="fas fa-graduation-cap"></i>
+                        <h4>Surgical Education</h4>
+                        <p>Live-streaming and automated feedback systems</p>
+                    </a>
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]+AND+(Cochlear+OR+Hearing+OR+Otology)" target="_blank" rel="noopener" class="research-tile">
+                        <i class="fas fa-ear-listen"></i>
+                        <h4>Otology &amp; Hearing Sciences</h4>
+                        <p>Cortical adaptations in CI patients and speech processing</p>
+                    </a>
+                </div>
+                <div class="research-all">
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]" target="_blank" rel="noopener">View all papers on PubMed <i class="fas fa-external-link-alt" style="font-size:0.7rem;"></i></a>
+                </div>
+            </section>
+
+            <!-- TECHNOLOGY -->
+            <section class="bento-card span-2" id="projects">
+                <div class="label" style="margin-bottom: 4px;">Technology</div>
+                <h3 class="card-title">Projects</h3>
+                <div class="row-list">
+                    <div class="row-item">
+                        <i class="fas fa-wave-square"></i>
+                        <div class="row-info">
+                            <h4>Speech-in-Noise Processing</h4>
+                            <p>Hearing device enhancement &middot; 2022&ndash;Present</p>
+                        </div>
+                    </div>
+                    <div class="row-item">
+                        <i class="fas fa-video"></i>
+                        <div class="row-info">
+                            <h4>Surgical Livestreaming</h4>
+                            <p>Procedure streaming platform &middot; 2022&ndash;Present</p>
+                        </div>
+                    </div>
+                    <a href="../ascii-editor.html" class="row-item">
+                        <i class="fas fa-terminal"></i>
+                        <div class="row-info">
+                            <h4>ASCII Art Editor</h4>
+                            <p>Browser-based diagram tool &middot; 2025</p>
+                        </div>
+                        <span class="row-arrow"><i class="fas fa-arrow-right"></i></span>
+                    </a>
+                </div>
+            </section>
+
+            <!-- CLINICAL -->
+            <section class="bento-card" id="clinical">
+                <div class="label" style="margin-bottom: 4px;">Clinical</div>
+                <div class="clinical-list">
+                    <div class="clinical-item">
+                        <span class="year">2022&ndash;Now</span>
+                        <h4>Surgery Livestreaming</h4>
+                        <p>Pre-clerkship curriculum design</p>
+                    </div>
+                    <div class="clinical-item">
+                        <span class="year">2020&ndash;Now</span>
+                        <h4>HAVEN Free Clinic</h4>
+                        <p>Senior Clinical Team Member</p>
+                    </div>
+                    <div class="clinical-item">
+                        <span class="year">2021&ndash;Now</span>
+                        <h4>POCUS Teaching</h4>
+                        <p>Ultrasound skills training</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- CONNECT -->
+            <section class="bento-card card-connect" id="connect">
+                <h3>Let's Connect</h3>
+                <p>Research, innovation, or just say hello.</p>
+                <div class="connect-links">
+                    <a href="https://linkedin.com/in/skflx" target="_blank" rel="noopener" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
+                    <a href="https://www.instagram.com/skflx/" target="_blank" rel="noopener" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
+                    <a href="https://github.com/skflx" target="_blank" rel="noopener" aria-label="GitHub"><i class="fab fa-github"></i></a>
+                </div>
+            </section>
+
+            <!-- TOOLS -->
+            <section class="bento-card span-3" id="tools">
+                <div class="label">Tools</div>
+                <div class="row-list">
+                    <a href="../kag.html" class="row-item">
+                        <i class="fas fa-diagram-project"></i>
+                        <div class="row-info">
+                            <h4>Knowledge Atlas Graph</h4>
+                            <p>Interactive OHNS knowledge map with self-testing</p>
+                        </div>
+                        <span class="row-arrow"><i class="fas fa-arrow-right"></i></span>
+                    </a>
+                    <a href="../cpt-search.html" class="row-item">
+                        <i class="fas fa-magnifying-glass"></i>
+                        <div class="row-info">
+                            <h4>CPT Code Search</h4>
+                            <p>Fast CPT lookup for otolaryngology</p>
+                        </div>
+                        <span class="row-arrow"><i class="fas fa-arrow-right"></i></span>
+                    </a>
+                    <a href="../ascii-editor.html" class="row-item">
+                        <i class="fas fa-terminal"></i>
+                        <div class="row-info">
+                            <h4>ASCII Art Editor</h4>
+                            <p>Browser-based ASCII/Unicode diagram editor</p>
+                        </div>
+                        <span class="row-arrow"><i class="fas fa-arrow-right"></i></span>
+                    </a>
+                </div>
+            </section>
+
+            <!-- LOCATION -->
+            <section class="bento-card card-location">
+                <i class="fas fa-map-marker-alt"></i>
+                <h4>Portland, Oregon</h4>
+                <p>Pacific Northwest</p>
+            </section>
+
+        </div>
+    </main>
+
+    <footer class="footer">&copy; 2025 skflx.MD &middot; Portland, Oregon</footer>
+
+    <script>
+        (function () {
+            var btn = document.getElementById('theme-toggle');
+            if (!btn) return;
+            btn.addEventListener('click', function () {
+                var current = document.documentElement.getAttribute('data-theme');
+                var next = current === 'dark' ? 'light' : 'dark';
+                document.documentElement.setAttribute('data-theme', next);
+                try { localStorage.setItem('sk_theme', next); } catch (e) {}
+            });
+        })();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Single-page condensation of the site into a bento-style tile grid:
hero, about (education/languages/interests), research, technology,
clinical, connect, and tools tiles with in-page anchor nav. Dark/light
toggle with system-preference detection and persistence; social links
only. Standalone preview at mockups/one-pager.html; live pages untouched.

https://claude.ai/code/session_01ERYsUiWdp68HX6EodsnbFr