### PR TITLE
Fix MCQ study pages: replace missing lucide-react CDN with inline icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
                             </a>
                             <a class="item" href="occ.html">
                                 <span class="item-ic"><i class="fas fa-book-open"></i></span>
-                                <div class="item-main"><h4>OCC Study Modules</h4><p>MCQ study viewer — Pediatric Hearing Loss and OR Primer</p></div>
+                                <div class="item-main"><h4>MCQ Study Guides</h4><p>MCQ study viewer — Pediatric Hearing Loss and OR Primer</p></div>
                                 <span class="item-meta">Launch &rarr;</span>
                             </a>
                         </div>

--- a/occ-pediatrics.html
+++ b/occ-pediatrics.html
@@ -9,8 +9,6 @@
   <!-- React 18 -->
   <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
-  <!-- Lucide React icons -->
-  <script src="https://unpkg.com/lucide-react@0.344.0/dist/umd/lucide-react.min.js" crossorigin></script>
   <!-- Tailwind CSS -->
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Babel (JSX in browser) -->
@@ -42,7 +40,7 @@
 <body>
   <a id="occ-back" href="occ.html">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
-    OCC Study Modules
+    MCQ Study Guides
   </a>
   <div id="root"></div>
 
@@ -52,7 +50,28 @@
   <!-- StudyViewer + mount -->
   <script type="text/babel" data-presets="react">
     const { useState, useEffect, useMemo, useRef } = React;
-    const { ChevronLeft, ChevronRight, BookOpen, Check, X, ChevronDown, Sparkles, ArrowRight, Layers, Filter, Home, Shuffle, Eye } = LucideReact;
+
+    // Inline icon set (lucide geometry) — avoids dependency on an icon CDN.
+    const makeIcon = (paths) => ({ size = 24, style, className }) =>
+      React.createElement('svg', {
+        width: size, height: size, viewBox: '0 0 24 24', fill: 'none',
+        stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round',
+        strokeLinejoin: 'round', style, className, 'aria-hidden': true,
+      }, paths.map((d, i) => React.createElement('path', { key: i, d })));
+
+    const ChevronLeft = makeIcon(['m15 18-6-6 6-6']);
+    const ChevronRight = makeIcon(['m9 18 6-6-6-6']);
+    const BookOpen = makeIcon(['M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z', 'M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z']);
+    const Check = makeIcon(['M20 6 9 17l-5-5']);
+    const X = makeIcon(['M18 6 6 18', 'm6 6 12 12']);
+    const ChevronDown = makeIcon(['m6 9 6 6 6-6']);
+    const Sparkles = makeIcon(['M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .962 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.962 0z', 'M20 3v4', 'M22 5h-4', 'M4 17v2', 'M5 18H3']);
+    const ArrowRight = makeIcon(['M5 12h14', 'm12 5 7 7-7 7']);
+    const Layers = makeIcon(['M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z', 'M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12', 'M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17']);
+    const Filter = makeIcon(['M22 3H2l8 9.46V19l4 2v-8.54L22 3z']);
+    const Home = makeIcon(['m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z', 'M9 22V12h6v10']);
+    const Shuffle = makeIcon(['M2 18h1.4c1.3 0 2.5-.6 3.3-1.7l6.1-8.6c.7-1.1 2-1.7 3.3-1.7H22', 'm18 2 4 4-4 4', 'M2 6h1.9c1.5 0 2.9.9 3.6 2.2', 'M22 18h-5.9c-1.3 0-2.6-.7-3.3-1.8l-.5-.8', 'm18 14 4 4-4 4']);
+    const Eye = makeIcon(['M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z', 'M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z']);
 
     // ─────────────────────────────────────────────────────────────────────
     // StudyViewer — engine v0.2

--- a/occ-tatubes.html
+++ b/occ-tatubes.html
@@ -9,8 +9,6 @@
   <!-- React 18 -->
   <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
-  <!-- Lucide React icons -->
-  <script src="https://unpkg.com/lucide-react@0.344.0/dist/umd/lucide-react.min.js" crossorigin></script>
   <!-- Tailwind CSS -->
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Babel (JSX in browser) -->
@@ -42,7 +40,7 @@
 <body>
   <a id="occ-back" href="occ.html">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
-    OCC Study Modules
+    MCQ Study Guides
   </a>
   <div id="root"></div>
 
@@ -52,7 +50,28 @@
   <!-- StudyViewer + mount -->
   <script type="text/babel" data-presets="react">
     const { useState, useEffect, useMemo, useRef } = React;
-    const { ChevronLeft, ChevronRight, BookOpen, Check, X, ChevronDown, Sparkles, ArrowRight, Layers, Filter, Home, Shuffle, Eye } = LucideReact;
+
+    // Inline icon set (lucide geometry) — avoids dependency on an icon CDN.
+    const makeIcon = (paths) => ({ size = 24, style, className }) =>
+      React.createElement('svg', {
+        width: size, height: size, viewBox: '0 0 24 24', fill: 'none',
+        stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round',
+        strokeLinejoin: 'round', style, className, 'aria-hidden': true,
+      }, paths.map((d, i) => React.createElement('path', { key: i, d })));
+
+    const ChevronLeft = makeIcon(['m15 18-6-6 6-6']);
+    const ChevronRight = makeIcon(['m9 18 6-6-6-6']);
+    const BookOpen = makeIcon(['M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z', 'M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z']);
+    const Check = makeIcon(['M20 6 9 17l-5-5']);
+    const X = makeIcon(['M18 6 6 18', 'm6 6 12 12']);
+    const ChevronDown = makeIcon(['m6 9 6 6 6-6']);
+    const Sparkles = makeIcon(['M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .962 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.962 0z', 'M20 3v4', 'M22 5h-4', 'M4 17v2', 'M5 18H3']);
+    const ArrowRight = makeIcon(['M5 12h14', 'm12 5 7 7-7 7']);
+    const Layers = makeIcon(['M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z', 'M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12', 'M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17']);
+    const Filter = makeIcon(['M22 3H2l8 9.46V19l4 2v-8.54L22 3z']);
+    const Home = makeIcon(['m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z', 'M9 22V12h6v10']);
+    const Shuffle = makeIcon(['M2 18h1.4c1.3 0 2.5-.6 3.3-1.7l6.1-8.6c.7-1.1 2-1.7 3.3-1.7H22', 'm18 2 4 4-4 4', 'M2 6h1.9c1.5 0 2.9.9 3.6 2.2', 'M22 18h-5.9c-1.3 0-2.6-.7-3.3-1.8l-.5-.8', 'm18 14 4 4-4 4']);
+    const Eye = makeIcon(['M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z', 'M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z']);
 
     // ─────────────────────────────────────────────────────────────────────
     // StudyViewer — engine v0.2

--- a/occ.html
+++ b/occ.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>OCC Study Modules | skflx.MD</title>
+  <title>MCQ Study Guides | skflx.MD</title>
   <meta name="description" content="MCQ study modules for otolaryngology — Pediatric Hearing Loss and Pediatric OR Primer (Tubes, Tonsils & Neck).">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -191,11 +191,11 @@
 
     <div class="kicker">
       <hr>
-      <span>OCC · Study Modules</span>
+      <span>OCC · Otolaryngology</span>
       <hr>
     </div>
 
-    <h1>Study<br><em>Modules</em></h1>
+    <h1>MCQ<br><em>Study Guides</em></h1>
     <p class="subtitle">MCQ sets for operative and clinical knowledge review. Each module is self-contained — work through it linearly, jump to a concept, or use random mode.</p>
 
     <div class="modules">


### PR DESCRIPTION
lucide-react ships no UMD build, so the CDN <script> 404'd, leaving LucideReact undefined and crashing the destructuring assignment — the React tree never mounted (blank page). Replaced it with a tiny inline SVG icon set using lucide geometry, removing the external icon dependency entirely.

Also renamed the feature to "MCQ Study Guides" across the landing page, study-page back links, and the index.html Tools entry.

https://claude.ai/code/session_015xV3xsmjNxzpVwTdqVNMJc