### PR TITLE
Update portfolio: reorganize projects and update dates

### DIFF
--- a/css/onepager.css
+++ b/css/onepager.css
@@ -275,6 +275,18 @@ a.item:hover { border-color: var(--accent); transform: translateX(3px); }
    in matte/terminal it falls back to the body/mono font (still legible). */
 [data-style="matte"] .note, [data-style="terminal"] .note { font-style: italic; }
 
+/* --- PUBLICATION LIST --- */
+.pub-list { list-style: decimal inside; display: flex; flex-direction: column; gap: 8px; padding-top: 4px; }
+.pub-list li {
+    padding: 11px 14px; border: 1px solid var(--border); border-radius: var(--radius-sm);
+    background: var(--bg-2); font-size: 0.84rem; line-height: 1.6; color: var(--text);
+}
+.pub-list li a { color: inherit; text-decoration: none; display: block; }
+.pub-list li:hover { border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }
+.pub-list li a:hover { color: var(--accent); }
+.pub-list li em { font-style: italic; }
+.pub-list li strong { font-weight: 700; }
+
 /* =============================================================
    RESPONSIVE
    ============================================================= */

--- a/css/onepager.css
+++ b/css/onepager.css
@@ -275,18 +275,6 @@ a.item:hover { border-color: var(--accent); transform: translateX(3px); }
    in matte/terminal it falls back to the body/mono font (still legible). */
 [data-style="matte"] .note, [data-style="terminal"] .note { font-style: italic; }
 
-/* --- PUBLICATION LIST --- */
-.pub-list { list-style: decimal inside; display: flex; flex-direction: column; gap: 8px; padding-top: 4px; }
-.pub-list li {
-    padding: 11px 14px; border: 1px solid var(--border); border-radius: var(--radius-sm);
-    background: var(--bg-2); font-size: 0.84rem; line-height: 1.6; color: var(--text);
-}
-.pub-list li a { color: inherit; text-decoration: none; display: block; }
-.pub-list li:hover { border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }
-.pub-list li a:hover { color: var(--accent); }
-.pub-list li em { font-style: italic; }
-.pub-list li strong { font-weight: 700; }
-
 /* =============================================================
    RESPONSIVE
    ============================================================= */

--- a/index.html
+++ b/index.html
@@ -122,37 +122,36 @@
                         </div>
                     </div>
                     <div class="group">
-                        <div class="group-title">Technology projects</div>
+                        <div class="group-title">Past clinical projects</div>
                         <div class="items">
                             <div class="item">
                                 <span class="item-ic"><i class="fas fa-wave-square"></i></span>
-                                <div class="item-main"><h4>Bimodal Hearing Research</h4><p>Binaural pitch fusion as a pre-surgical predictor of bilateral CI candidacy</p></div>
-                                <span class="item-meta">2022&ndash;now</span>
+                                <div class="item-main">
+                                    <h4>Bimodal Hearing Research</h4>
+                                    <p>Binaural pitch fusion as a pre-surgical predictor of bilateral CI candidacy</p>
+                                    <p style="margin-top:3px;font-size:0.78rem;color:var(--accent);">2026 CORE Grant Resident Research Award recipient</p>
+                                </div>
+                                <span class="item-meta">2025&ndash;present</span>
                             </div>
                             <div class="item">
                                 <span class="item-ic"><i class="fas fa-video"></i></span>
                                 <div class="item-main"><h4>Surgical Livestreaming Platform</h4><p>Technical and A/V infrastructure for livestreaming OR procedures to pre-clerkship learners in real time</p></div>
-                                <span class="item-meta">2022&ndash;now</span>
+                                <span class="item-meta">2022&ndash;2024</span>
                             </div>
-                        </div>
-                    </div>
-                    <div class="group">
-                        <div class="group-title">Clinical experience</div>
-                        <div class="items">
                             <div class="item">
                                 <span class="item-ic"><i class="fas fa-chalkboard-user"></i></span>
                                 <div class="item-main"><h4>Surgery Livestreaming Elective</h4><p>Designed pre-clerkship curriculum; A/V setup and sterile exoscope mounting</p></div>
-                                <span class="item-meta">2022&ndash;now</span>
+                                <span class="item-meta">2022&ndash;2024</span>
                             </div>
                             <div class="item">
                                 <span class="item-ic"><i class="fas fa-hand-holding-medical"></i></span>
                                 <div class="item-main"><h4>HAVEN Free Clinic</h4><p>Primary care for uninsured patients; Senior Clinical Team Member</p></div>
-                                <span class="item-meta">2020&ndash;now</span>
+                                <span class="item-meta">2020&ndash;2024</span>
                             </div>
                             <div class="item">
-                                <span class="item-ic"><i class="fas fa-wave-square"></i></span>
+                                <span class="item-ic"><i class="fas fa-stethoscope"></i></span>
                                 <div class="item-main"><h4>Point of Care Ultrasound Teaching</h4><p>Hands-on ultrasound skills training for the MS1 curriculum</p></div>
-                                <span class="item-meta">2021&ndash;now</span>
+                                <span class="item-meta">2021&ndash;2024</span>
                             </div>
                         </div>
                     </div>
@@ -162,30 +161,68 @@
             <!-- 3 -->
             <details class="section" id="research">
                 <summary>
-                    <span class="sec-title" data-note="auditory neuroscience, cognition, and surgical education">I'm interested in machine and cognitive frameworks in surgical learning. My other research:</span>
+                    <span class="sec-title" data-note="peer-reviewed publications">My published work thus far:</span>
                     <span class="chev"><i class="fas fa-chevron-down"></i></span>
                 </summary>
                 <div class="section-body">
-                    <p class="lead">My research sits at two poles: auditory neuroscience — with personal stakes — and surgical education — with theoretical ones. My published work spans H&amp;N oncology and craniofacial trauma; my active work is in CI outcomes and how trainees learn to operate.</p>
-                    <div class="items">
-                        <div class="item">
-                            <span class="item-ic"><i class="fas fa-bone"></i></span>
-                            <div class="item-main"><h4>Craniofacial Trauma</h4><p>Injury patterns in sports and factors associated with surgical outcomes</p></div>
-                        </div>
-                        <div class="item">
-                            <span class="item-ic"><i class="fas fa-ribbon"></i></span>
-                            <div class="item-main"><h4>Head &amp; Neck Oncology</h4><p>Complications, risk factors, and survival outcomes in cancer surgery</p></div>
-                        </div>
-                        <div class="item">
-                            <span class="item-ic"><i class="fas fa-graduation-cap"></i></span>
-                            <div class="item-main"><h4>Surgical Education</h4><p>Live-streaming and automated feedback systems for training</p></div>
-                        </div>
-                        <div class="item">
-                            <span class="item-ic"><i class="fas fa-ear-listen"></i></span>
-                            <div class="item-main"><h4>Otology &amp; Hearing Sciences</h4><p>Binaural pitch fusion as a pre-surgical predictor of bilateral CI candidacy; CI outcomes in bimodal users</p></div>
-                        </div>
-                    </div>
-                    <a class="more-link" href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]" target="_blank" rel="noopener">View all papers on PubMed &rarr;</a>
+                    <ol class="pub-list">
+                        <li>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40616858/" target="_blank" rel="noopener">
+                                Richmond R, Kremer C, <strong>Kafle S</strong>, Lee JY, Lee YH. Automated Reminders Improve Feedback in Surgical Training. <em>J Surg Educ.</em> 2025;82(9):103591.
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/38053413/" target="_blank" rel="noopener">
+                                Williams LC, <strong>Kafle S</strong>, Lee YH. Trends in Head and Neck Injuries Related to Electric Versus Pedal Bicycle Use in the United States. <em>Laryngoscope.</em> 2024;134(6):2734-2740.
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37595108/" target="_blank" rel="noopener">
+                                Boyi T, Williams LC, <strong>Kafle S</strong>, Roche AM, Judson BL. Association of Age and Frailty with 30-Day Outcomes Among Patients Undergoing Oral Cavity Cancer Surgery. <em>Otolaryngol Head Neck Surg.</em> 2023.
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36280449/" target="_blank" rel="noopener">
+                                Shah HP, <strong>Kafle S</strong>, Lee JY, Cardella J, Alperovich M, Lee YH. Livestream surgeries enhance preclinical medical students' exposure to surgical specialties. <em>Am J Surg.</em> 2022.
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35859271/" target="_blank" rel="noopener">
+                                Muhonen EG, <strong>Kafle S</strong>, Torabi SJ, Abello EH, Bitner BF, Pham N. Surfing-Related Craniofacial Injuries: A NEISS Database Study. <em>J Craniofac Surg.</em> 2022;33(8):2383-2387.
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35817623/" target="_blank" rel="noopener">
+                                Bourdillon AT and <strong>Kafle S</strong> [co-first authors], Salehi PP, Steren B, Pei KY, Azizzadeh B, Lee YH. Characterization of Laryngotracheal Fractures and Repairs: A TQIP Study. <em>J Voice.</em> 2022.
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35106648/" target="_blank" rel="noopener">
+                                InciSioN Collaborative [incl. <strong>Kafle S</strong>]. International Survey of Medical Students Exposure to Relevant Global Surgery (ISOMERS): A Cross-Sectional Study. <em>World J Surg.</em> 2022;46(7):1577-1584.
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33614936/" target="_blank" rel="noopener">
+                                Jacobs D, <strong>Kafle S</strong>, Earles J, Rahmati R, Mehra S, Judson BL. Prolonged inpatient stay after upfront total laryngectomy is associated with overall survival. <em>Laryngoscope Investig Otolaryngol.</em> 2021;6(1):94-102.
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32956314/" target="_blank" rel="noopener">
+                                <strong>Kafle S</strong>, Torabi SJ, Salehi PP, Lee YH. Pediatric Otoplasty: Differences in Operative Time and Inpatient Stay Based on Surgical Specialty Training. <em>J Craniofac Surg.</em> 2021;32(1):367-369.
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32743892/" target="_blank" rel="noopener">
+                                Torabi SJ, Bourdillon A, Salehi PP, <strong>Kafle S</strong>, Mehra S, Rahmati R, Judson BL. The Epidemiology, Surgical Management, and Impact of Margins in Skull and Mandibular Osseous-Site Tumors. <em>Head Neck.</em> 2020;42(11):3352-3363.
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29630041/" target="_blank" rel="noopener">
+                                Clark DA, Kohler D, Mathis A, Slankster E, <strong>Kafle S</strong>, Odell SR, Mathew D. Tracking Drosophila Larval Behavior in Response to Optogenetic Stimulation of Olfactory Neurons. <em>J Vis Exp.</em> 2018;(133):57353.
+                            </a>
+                        </li>
+                    </ol>
+                    <a class="more-link" href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+S[au]+AND+otolaryngology[tiab]" target="_blank" rel="noopener">View on PubMed &rarr;</a>
                 </div>
             </details>
 

--- a/index.html
+++ b/index.html
@@ -135,12 +135,7 @@
                             </div>
                             <div class="item">
                                 <span class="item-ic"><i class="fas fa-video"></i></span>
-                                <div class="item-main"><h4>Surgical Livestreaming Platform</h4><p>Technical and A/V infrastructure for livestreaming OR procedures to pre-clerkship learners in real time</p></div>
-                                <span class="item-meta">2022&ndash;2024</span>
-                            </div>
-                            <div class="item">
-                                <span class="item-ic"><i class="fas fa-chalkboard-user"></i></span>
-                                <div class="item-main"><h4>Surgery Livestreaming Elective</h4><p>Designed pre-clerkship curriculum; A/V setup and sterile exoscope mounting</p></div>
+                                <div class="item-main"><h4>Surgical Livestreaming</h4><p>Pre-clerkship OR curriculum design, A/V infrastructure, and sterile exoscope setup for live-streamed procedures</p></div>
                                 <span class="item-meta">2022&ndash;2024</span>
                             </div>
                             <div class="item">
@@ -161,68 +156,30 @@
             <!-- 3 -->
             <details class="section" id="research">
                 <summary>
-                    <span class="sec-title" data-note="peer-reviewed publications">My published work thus far:</span>
+                    <span class="sec-title" data-note="auditory neuroscience, cognition, and surgical education">I'm interested in machine and cognitive frameworks in surgical learning. My other research:</span>
                     <span class="chev"><i class="fas fa-chevron-down"></i></span>
                 </summary>
                 <div class="section-body">
-                    <ol class="pub-list">
-                        <li>
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/40616858/" target="_blank" rel="noopener">
-                                Richmond R, Kremer C, <strong>Kafle S</strong>, Lee JY, Lee YH. Automated Reminders Improve Feedback in Surgical Training. <em>J Surg Educ.</em> 2025;82(9):103591.
-                            </a>
-                        </li>
-                        <li>
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/38053413/" target="_blank" rel="noopener">
-                                Williams LC, <strong>Kafle S</strong>, Lee YH. Trends in Head and Neck Injuries Related to Electric Versus Pedal Bicycle Use in the United States. <em>Laryngoscope.</em> 2024;134(6):2734-2740.
-                            </a>
-                        </li>
-                        <li>
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/37595108/" target="_blank" rel="noopener">
-                                Boyi T, Williams LC, <strong>Kafle S</strong>, Roche AM, Judson BL. Association of Age and Frailty with 30-Day Outcomes Among Patients Undergoing Oral Cavity Cancer Surgery. <em>Otolaryngol Head Neck Surg.</em> 2023.
-                            </a>
-                        </li>
-                        <li>
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/36280449/" target="_blank" rel="noopener">
-                                Shah HP, <strong>Kafle S</strong>, Lee JY, Cardella J, Alperovich M, Lee YH. Livestream surgeries enhance preclinical medical students' exposure to surgical specialties. <em>Am J Surg.</em> 2022.
-                            </a>
-                        </li>
-                        <li>
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/35859271/" target="_blank" rel="noopener">
-                                Muhonen EG, <strong>Kafle S</strong>, Torabi SJ, Abello EH, Bitner BF, Pham N. Surfing-Related Craniofacial Injuries: A NEISS Database Study. <em>J Craniofac Surg.</em> 2022;33(8):2383-2387.
-                            </a>
-                        </li>
-                        <li>
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/35817623/" target="_blank" rel="noopener">
-                                Bourdillon AT and <strong>Kafle S</strong> [co-first authors], Salehi PP, Steren B, Pei KY, Azizzadeh B, Lee YH. Characterization of Laryngotracheal Fractures and Repairs: A TQIP Study. <em>J Voice.</em> 2022.
-                            </a>
-                        </li>
-                        <li>
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/35106648/" target="_blank" rel="noopener">
-                                InciSioN Collaborative [incl. <strong>Kafle S</strong>]. International Survey of Medical Students Exposure to Relevant Global Surgery (ISOMERS): A Cross-Sectional Study. <em>World J Surg.</em> 2022;46(7):1577-1584.
-                            </a>
-                        </li>
-                        <li>
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/33614936/" target="_blank" rel="noopener">
-                                Jacobs D, <strong>Kafle S</strong>, Earles J, Rahmati R, Mehra S, Judson BL. Prolonged inpatient stay after upfront total laryngectomy is associated with overall survival. <em>Laryngoscope Investig Otolaryngol.</em> 2021;6(1):94-102.
-                            </a>
-                        </li>
-                        <li>
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/32956314/" target="_blank" rel="noopener">
-                                <strong>Kafle S</strong>, Torabi SJ, Salehi PP, Lee YH. Pediatric Otoplasty: Differences in Operative Time and Inpatient Stay Based on Surgical Specialty Training. <em>J Craniofac Surg.</em> 2021;32(1):367-369.
-                            </a>
-                        </li>
-                        <li>
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/32743892/" target="_blank" rel="noopener">
-                                Torabi SJ, Bourdillon A, Salehi PP, <strong>Kafle S</strong>, Mehra S, Rahmati R, Judson BL. The Epidemiology, Surgical Management, and Impact of Margins in Skull and Mandibular Osseous-Site Tumors. <em>Head Neck.</em> 2020;42(11):3352-3363.
-                            </a>
-                        </li>
-                        <li>
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/29630041/" target="_blank" rel="noopener">
-                                Clark DA, Kohler D, Mathis A, Slankster E, <strong>Kafle S</strong>, Odell SR, Mathew D. Tracking Drosophila Larval Behavior in Response to Optogenetic Stimulation of Olfactory Neurons. <em>J Vis Exp.</em> 2018;(133):57353.
-                            </a>
-                        </li>
-                    </ol>
-                    <a class="more-link" href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+S[au]+AND+otolaryngology[tiab]" target="_blank" rel="noopener">View on PubMed &rarr;</a>
+                    <p class="lead">My research sits at two poles: auditory neuroscience — with personal stakes — and surgical education — with theoretical ones. My published work spans H&amp;N oncology and craniofacial trauma; my active work is in CI outcomes and how trainees learn to operate.</p>
+                    <div class="items">
+                        <div class="item">
+                            <span class="item-ic"><i class="fas fa-bone"></i></span>
+                            <div class="item-main"><h4>Craniofacial Trauma</h4><p>Injury patterns in sports and factors associated with surgical outcomes</p></div>
+                        </div>
+                        <div class="item">
+                            <span class="item-ic"><i class="fas fa-ribbon"></i></span>
+                            <div class="item-main"><h4>Head &amp; Neck Oncology</h4><p>Complications, risk factors, and survival outcomes in cancer surgery</p></div>
+                        </div>
+                        <div class="item">
+                            <span class="item-ic"><i class="fas fa-graduation-cap"></i></span>
+                            <div class="item-main"><h4>Surgical Education</h4><p>Live-streaming and automated feedback systems for training</p></div>
+                        </div>
+                        <div class="item">
+                            <span class="item-ic"><i class="fas fa-ear-listen"></i></span>
+                            <div class="item-main"><h4>Otology &amp; Hearing Sciences</h4><p>Binaural pitch fusion as a pre-surgical predictor of bilateral CI candidacy; CI outcomes in bimodal users</p></div>
+                        </div>
+                    </div>
+                    <a class="more-link" href="https://pubmed.ncbi.nlm.nih.gov/?term=Kafle+Samipya[au]" target="_blank" rel="noopener">View all papers on PubMed &rarr;</a>
                 </div>
             </details>
 


### PR DESCRIPTION
## Summary
Reorganized the portfolio section to consolidate clinical and research projects under a single "Past clinical projects" category, updated project timelines to reflect completion dates, and enhanced project descriptions with additional details and awards.

## Key Changes
- Renamed "Technology projects" section to "Past clinical projects" to better reflect the nature of the work
- Merged the separate "Clinical experience" section into the main projects group, eliminating redundant categorization
- Updated project timelines:
  - Bimodal Hearing Research: 2022–now → 2025–present
  - Surgical Livestreaming: 2022–now → 2022–2024 (marked as completed)
  - HAVEN Free Clinic: 2020–now → 2020–2024 (marked as completed)
  - Point of Care Ultrasound Teaching: 2021–now → 2021–2024 (marked as completed)
- Enhanced Bimodal Hearing Research entry with award recognition: "2026 CORE Grant Resident Research Award recipient"
- Consolidated Surgical Livestreaming project description to be more concise and comprehensive
- Updated icon for Point of Care Ultrasound Teaching from `fa-wave-square` to `fa-stethoscope` for better semantic accuracy
- Improved HTML formatting for better readability and maintainability

## Notable Details
- The portfolio now clearly distinguishes between ongoing and completed projects through date ranges
- Award recognition is displayed inline with the project description using accent color styling
- All projects are now organized chronologically within a single cohesive section

https://claude.ai/code/session_018iAbmUTAnj6HN8yktymdFV