### PR TITLE
Add DTC risk-stratification self-test + per-reviewer SRS codes

### DIFF
--- a/css/mcq.css
+++ b/css/mcq.css
@@ -119,6 +119,17 @@ a:focus-visible, button:focus-visible, [role="radio"]:focus-visible, summary:foc
 [data-theme="dark"] .mcq-theme-toggle .i-sun { display: block; }
 [data-theme="dark"] .mcq-theme-toggle .i-moon { display: none; }
 
+/* Reviewer chip (viewer top bar) — who progress is being saved under. */
+.mcq-reviewer-chip {
+  flex: none; height: 30px; padding: 0 0.7rem;
+  border: 1px solid var(--mcq-border); border-radius: 999px;
+  background: var(--mcq-surface); color: var(--mcq-text-muted);
+  font-family: var(--mcq-font-ui); font-size: 11px; letter-spacing: 0.02em;
+  display: inline-flex; align-items: center; transition: all 0.2s;
+}
+.mcq-reviewer-chip:hover { color: var(--mcq-accent); border-color: var(--mcq-accent); }
+.mcq-reviewer-chip[hidden] { display: none; }
+
 /* ===== LAYOUT ===== */
 .mcq-root { min-height: 100vh; width: 100%; }
 .mcq-wrap { max-width: var(--mcq-maxw); margin: 0 auto; padding: 2.75rem 1.25rem 8rem; }
@@ -130,7 +141,11 @@ a:focus-visible, button:focus-visible, [role="radio"]:focus-visible, summary:foc
 .hub-kicker span { font-family: var(--mcq-font-ui); font-size: 10px; letter-spacing: 0.3em; text-transform: uppercase; font-weight: 500; white-space: nowrap; }
 .hub-title { font-family: var(--mcq-font-display); font-size: clamp(2rem, 6vw, 2.75rem); font-weight: 300; line-height: 1.15; margin-bottom: 0.75rem; }
 .hub-title em { font-style: italic; font-weight: 300; }
-.hub-subtitle { font-size: 1rem; line-height: 1.6; color: var(--mcq-text-muted); margin-bottom: 2.5rem; }
+.hub-subtitle { font-size: 1rem; line-height: 1.6; color: var(--mcq-text-muted); margin-bottom: 1rem; }
+.hub-reviewer { font-family: var(--mcq-font-ui); font-size: 12px; color: var(--mcq-text-faint); margin-bottom: 2.25rem; }
+.hub-reviewer strong { color: var(--mcq-ochre); font-weight: 600; }
+.hub-reviewer-btn { background: none; border: none; padding: 0; color: var(--mcq-accent); font: inherit; text-decoration: underline; text-underline-offset: 2px; }
+.hub-reviewer-btn:hover { opacity: 0.8; }
 .hub-modules { display: flex; flex-direction: column; gap: 1rem; }
 .module-card {
   display: flex; align-items: center; gap: 1.25rem; padding: 1.25rem 1.5rem;

--- a/docs/authoring-mcq.md
+++ b/docs/authoring-mcq.md
@@ -56,6 +56,23 @@ questions are found by shared concept tags).
 | `answer` | recall only | The text revealed for a recall card. |
 | `brief` | recommended | Short explanation shown after answering. |
 | `detailed` | optional | Longer explanation behind a "Read more" toggle. |
+
+`stem`, `answer`, `brief`, and `detailed` honor `\n` as a line break, so you can
+lay out short lists or text "tables" inside a field (see
+`js/mcq-modules/dtc-risk-stratification.js`, a fully recall/free-response set).
+
+### Recall (free-response) cards
+
+A `type: 'recall'` card shows the `stem`, a **Reveal answer** button, then the
+`answer` text. The learner self-grades on a four-point scale instead of a binary
+got-it / missed — each tier drives spaced repetition differently:
+
+| Grade (keys 1–4) | Counts as correct? | Leitner move |
+|---|---|---|
+| Didn't know | no | reset to box 1 |
+| Guessed | no | reset to box 1 |
+| Got it partially | yes | +1 box |
+| Knew it cold | yes | +2 boxes |
 | `concepts` | optional | Array of `CONCEPTS` keys; defaults to `[]`. |
 | `section` | optional | Small label above the question (e.g. `Embryology`). |
 | `difficulty` | optional | Small badge near the counter (e.g. `hard`). |
@@ -105,8 +122,12 @@ window.__MCQ_MODULE = { meta: { title: 'Otology Set' }, DOMAINS, CONCEPTS, ITEMS
 
 - Keep the manifest `count` in sync with the number of `ITEMS`.
 - Pair each domain's `color` (solid) with a matching translucent `hex`.
-- Progress and spaced-repetition state are stored per module in `localStorage`
-  under `mcq:progress:<slug>` and `mcq:srs:<slug>`; changing a question's `id`
-  resets its history.
+- Progress and spaced-repetition state are stored per module **and per
+  reviewer** in `localStorage` under `mcq:progress:<slug>:<code>` and
+  `mcq:srs:<slug>:<code>`. The reviewer `<code>` (e.g. `kafle`, `terry`) is
+  collected by `js/mcq-reviewer.js` — a small prompt shown on each study
+  session, with a typo failsafe that flags unknown codes and suggests the
+  closest existing one. This lets coresidents share one browser while keeping
+  separate progress. Changing a question's `id` resets its history.
 - Preview locally with no build step: `python3 -m http.server` then open
   `http://localhost:8000/mcq-study.html?m=<slug>`.

--- a/js/mcq-engine.js
+++ b/js/mcq-engine.js
@@ -50,6 +50,29 @@
     return d.toISOString().split('T')[0];
   };
 
+  /* Recall (free-response) self-grade tiers → Leitner movement.
+     `box` is a number (absolute) or fn(currentBox)→box; `correct`
+     feeds the "first attempt" accuracy stat. Keyboard 1–4 maps to order. */
+  const RECALL_GRADES = [
+    { id: 'unknown', label: "Didn't know", correct: false, color: 'incorrect', box: 1 },
+    { id: 'guessed', label: 'Guessed', correct: false, color: 'ochre', box: 1 },
+    { id: 'partial', label: 'Got it partially', correct: true, color: 'accent', box: (cur) => Math.min(cur + 1, 5) },
+    { id: 'cold', label: 'Knew it cold', correct: true, color: 'correct', box: (cur) => Math.min(cur + 2, 5) },
+  ];
+
+  /* Render free-text fields, honoring `\n` as a line break (module data
+     may carry lists / mini-tables). Single-line strings pass through. */
+  const renderText = (s) => {
+    const str = s == null ? '' : String(s);
+    if (str.indexOf('\n') === -1) return str;
+    return str.split('\n').map((ln, i) =>
+      React.createElement(React.Fragment, { key: i }, i ? React.createElement('br') : null, ln));
+  };
+
+  /* Reviewer code → storage namespace. Normalized so "Kafle ", "kafle",
+     "KAFLE" collapse to one bucket; empty falls back to "guest". */
+  const normCode = (c) => String(c || '').trim().toLowerCase().replace(/[^a-z0-9]/g, '') || 'guest';
+
   /* ---- Storage (namespaced, fail-safe) ---- */
   const load = (key, fallback) => {
     try { const raw = localStorage.getItem(key); return raw ? JSON.parse(raw) : fallback; }
@@ -62,11 +85,12 @@
   /* =========================================================
      STUDY VIEWER
      ========================================================= */
-  function StudyViewer({ module, entry }) {
+  function StudyViewer({ module, entry, code }) {
     const meta = module.meta || {};
     const DOMAINS = module.DOMAINS || {};
     const CONCEPTS = module.CONCEPTS || {};
     const slug = (entry && entry.slug) || meta.id || 'module';
+    const reviewer = normCode(code);
     const hasTaxonomy = Object.keys(DOMAINS).length > 0 && Object.keys(CONCEPTS).length > 0;
 
     // Normalize once: guarantee concepts[] and options[] on every item.
@@ -80,8 +104,8 @@
       }));
     }, [module]);
 
-    const PROGRESS_KEY = 'mcq:progress:' + slug;
-    const SRS_KEY = 'mcq:srs:' + slug;
+    const PROGRESS_KEY = 'mcq:progress:' + slug + ':' + reviewer;
+    const SRS_KEY = 'mcq:srs:' + slug + ':' + reviewer;
 
     const [view, setView] = useState('home');
     const [currentId, setCurrentId] = useState(ITEMS[0]?.id);
@@ -116,19 +140,23 @@
     const totalAnswered = Object.keys(answers).length;
     const totalCorrect = Object.values(firstCorrect).filter(Boolean).length;
 
-    const recordAnswer = (qId, value, correct) => {
+    const recordAnswer = (qId, value, correct, nextBox) => {
       if (answers[qId]) return;
       setAnswers((prev) => ({ ...prev, [qId]: value }));
       setFirstCorrect((prev) => ({ ...prev, [qId]: correct }));
       setSrs((prev) => {
         const cur = prev.items[qId] || { box: 1 };
-        const box = correct ? Math.min(cur.box + 1, 5) : 1;
+        let box;
+        if (typeof nextBox === 'function') box = nextBox(cur.box);
+        else if (typeof nextBox === 'number') box = nextBox;
+        else box = correct ? Math.min(cur.box + 1, 5) : 1;
+        box = Math.max(1, Math.min(box, 5));
         return { ...prev, items: { ...prev.items, [qId]: { box, nextReview: addDays(today(), LEITNER_INTERVALS[box]) } } };
       });
     };
 
     const handleSelect = (optionId) => recordAnswer(currentId, optionId, optionId === currentItem.correct);
-    const handleGrade = (gotIt) => recordAnswer(currentId, gotIt ? 'got' : 'missed', gotIt);
+    const handleGrade = (grade) => recordAnswer(currentId, grade.id, grade.correct, grade.box);
 
     const goToItem = (qId) => {
       setCurrentId(qId); setShowDetailed(false); setRevealed(false); setView('item');
@@ -201,10 +229,14 @@
         else opt = currentItem.options.find((o) => String(o.id).toLowerCase() === key.toLowerCase());
         if (opt) { e.preventDefault(); handleSelect(opt.id); return; }
       }
+      // Recall self-grade: 1–4 once the answer is revealed.
+      if (isRecall && revealed && !answered && /^[1-4]$/.test(key)) {
+        e.preventDefault(); handleGrade(RECALL_GRADES[parseInt(key, 10) - 1]); return;
+      }
       if (key === ' ' || key === 'Enter') {
         e.preventDefault();
         if (isRecall && !revealed && !answered) { setRevealed(true); return; }
-        if (answered || (isRecall && revealed)) handleNext();
+        if (answered) handleNext();
         return;
       }
     };
@@ -390,6 +422,8 @@
     }
     const answered = !!answer;
     const isRecall = item.type === 'recall';
+    const recallGrade = isRecall ? RECALL_GRADES.find((g) => g.id === answer) : null;
+    const passLike = recallGrade ? recallGrade.correct : isCorrect;
     const filterConcept = conceptFilter ? CONCEPTS[conceptFilter] : null;
     const filterDomain = filterConcept ? DOMAINS[filterConcept.domain] : null;
     const bannerStyle = filterDomain
@@ -430,7 +464,7 @@
           </div>` : null}
 
         <div className="mcq-card" style=${{ padding: '1.5rem', marginBottom: '1.25rem' }}>
-          <p className="display-font" style=${{ fontSize: 'clamp(1.15rem,3.2vw,1.4rem)', lineHeight: 1.35, color: C.text, fontVariationSettings: "'opsz' 100, 'wght' 400" }}>${item.stem}</p>
+          <p className="display-font" style=${{ fontSize: 'clamp(1.15rem,3.2vw,1.4rem)', lineHeight: 1.35, color: C.text, fontVariationSettings: "'opsz' 100, 'wght' 400" }}>${renderText(item.stem)}</p>
 
           ${!isRecall ? html`
             <div role="radiogroup" aria-label="Answer options" style=${{ display: 'flex', flexDirection: 'column', gap: '0.5rem', marginTop: '1.5rem' }}>
@@ -462,11 +496,17 @@
                 </button>` : html`
                 <div className="fade-up">
                   <div className="display-font" style=${{ fontSize: '11px', letterSpacing: '0.25em', textTransform: 'uppercase', marginBottom: '0.5rem', color: C.ochre, fontWeight: 600 }}>Answer</div>
-                  <div style=${{ padding: '1rem', borderRadius: '10px', lineHeight: 1.6, backgroundColor: C.bg, border: '1px solid ' + C.borderSoft, borderLeft: '3px solid ' + C.ochre, color: C.text, fontSize: '16px' }}>${item.answer || ''}</div>
+                  <div style=${{ padding: '1rem', borderRadius: '10px', lineHeight: 1.6, backgroundColor: C.bg, border: '1px solid ' + C.borderSoft, borderLeft: '3px solid ' + C.ochre, color: C.text, fontSize: '16px' }}>${renderText(item.answer)}</div>
                   ${!answered ? html`
-                    <div style=${{ display: 'flex', gap: '0.5rem', marginTop: '0.75rem' }}>
-                      <button className="mcq-btn mcq-btn--flex" onClick=${() => onGrade(false)} style=${{ backgroundColor: C.incorrectBg, borderColor: C.incorrect, color: C.incorrect }}><${X} size=${15} /><span className="display-font" style=${{ fontWeight: 600, fontSize: '0.9rem' }}>Missed</span></button>
-                      <button className="mcq-btn mcq-btn--flex" onClick=${() => onGrade(true)} style=${{ backgroundColor: C.correctBg, borderColor: C.correct, color: C.correct }}><${Check} size=${15} /><span className="display-font" style=${{ fontWeight: 600, fontSize: '0.9rem' }}>Got it</span></button>
+                    <div style=${{ marginTop: '0.85rem' }}>
+                      <div className="display-font" style=${{ fontSize: '10px', letterSpacing: '0.2em', textTransform: 'uppercase', color: C.textFaint, marginBottom: '0.45rem' }}>How did that go?</div>
+                      <div style=${{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.5rem' }}>
+                        ${RECALL_GRADES.map((g, i) => html`
+                          <button key=${g.id} className="mcq-btn" onClick=${() => onGrade(g)} style=${{ justifyContent: 'flex-start', gap: '0.5rem', borderColor: C[g.color], color: C[g.color] }}>
+                            <span className="display-font" style=${{ fontSize: '0.7rem', opacity: 0.6 }}>${i + 1}</span>
+                            <span className="display-font" style=${{ fontWeight: 600, fontSize: '0.85rem' }}>${g.label}</span>
+                          </button>`)}
+                      </div>
                     </div>` : null}
                 </div>`}
             </div>` : null}
@@ -474,13 +514,15 @@
 
         ${answered ? html`
           <div className="fade-up" aria-live="polite" style=${{ display: 'flex', flexDirection: 'column', gap: '1rem', marginBottom: '1.5rem' }}>
-            <div style=${{ padding: '1.25rem', borderRadius: '14px', backgroundColor: isCorrect ? C.correctBg : C.incorrectBg, border: '1px solid ' + (isCorrect ? C.correct : C.incorrect) }}>
+            <div style=${{ padding: '1.25rem', borderRadius: '14px', backgroundColor: passLike ? C.correctBg : C.incorrectBg, border: '1px solid ' + (passLike ? C.correct : C.incorrect) }}>
               <div style=${{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.5rem' }}>
-                ${isCorrect
-                  ? html`<${React.Fragment}><${Check} size=${16} style=${{ color: C.correct }} /><span className="display-font" style=${{ fontSize: '0.85rem', letterSpacing: '0.2em', textTransform: 'uppercase', color: C.correct, fontWeight: 600 }}>${isRecall ? 'Got It' : 'Correct'}</span></${React.Fragment}>`
-                  : html`<${React.Fragment}><${X} size=${16} style=${{ color: C.incorrect }} /><span className="display-font" style=${{ fontSize: '0.85rem', letterSpacing: '0.2em', textTransform: 'uppercase', color: C.incorrect, fontWeight: 600 }}>${isRecall ? 'Missed' : 'Not Quite'}</span>${!isRecall ? html`<span style=${{ fontSize: '0.75rem', marginLeft: '0.25rem', color: C.textMuted }}>· Answer: ${item.correct ? String(item.correct).toUpperCase() : '—'}</span>` : null}</${React.Fragment}>`}
+                ${isRecall
+                  ? html`<${React.Fragment}><${passLike ? Check : X} size=${16} style=${{ color: recallGrade ? C[recallGrade.color] : (passLike ? C.correct : C.incorrect) }} /><span className="display-font" style=${{ fontSize: '0.85rem', letterSpacing: '0.2em', textTransform: 'uppercase', color: recallGrade ? C[recallGrade.color] : (passLike ? C.correct : C.incorrect), fontWeight: 600 }}>${recallGrade ? recallGrade.label : (passLike ? 'Got It' : 'Missed')}</span></${React.Fragment}>`
+                  : isCorrect
+                  ? html`<${React.Fragment}><${Check} size=${16} style=${{ color: C.correct }} /><span className="display-font" style=${{ fontSize: '0.85rem', letterSpacing: '0.2em', textTransform: 'uppercase', color: C.correct, fontWeight: 600 }}>Correct</span></${React.Fragment}>`
+                  : html`<${React.Fragment}><${X} size=${16} style=${{ color: C.incorrect }} /><span className="display-font" style=${{ fontSize: '0.85rem', letterSpacing: '0.2em', textTransform: 'uppercase', color: C.incorrect, fontWeight: 600 }}>Not Quite</span><span style=${{ fontSize: '0.75rem', marginLeft: '0.25rem', color: C.textMuted }}>· Answer: ${item.correct ? String(item.correct).toUpperCase() : '—'}</span></${React.Fragment}>`}
               </div>
-              <p style=${{ lineHeight: 1.6, color: C.text, fontSize: '15.5px' }}>${item.brief || ''}</p>
+              <p style=${{ lineHeight: 1.6, color: C.text, fontSize: '15.5px' }}>${renderText(item.brief)}</p>
               ${item.reference ? html`<p className="ui-font" style=${{ marginTop: '0.6rem', fontSize: '0.72rem', color: C.textFaint }}>${item.reference}</p>` : null}
             </div>
 
@@ -491,7 +533,7 @@
               </button>` : null}
             ${item.detailed && showDetailed ? html`
               <div className="mcq-card fade-up" style=${{ padding: '1.25rem' }}>
-                <p style=${{ lineHeight: 1.6, color: C.text, fontSize: '16px' }}>${item.detailed}</p>
+                <p style=${{ lineHeight: 1.6, color: C.text, fontSize: '16px' }}>${renderText(item.detailed)}</p>
               </div>` : null}
 
             ${relatedItems.length ? html`
@@ -539,7 +581,7 @@
   }
 
   /* ---- Mount ---- */
-  window.mountMCQ = function (rootEl, module, entry) {
-    ReactDOM.createRoot(rootEl).render(html`<${StudyViewer} module=${module} entry=${entry} />`);
+  window.mountMCQ = function (rootEl, module, entry, code) {
+    ReactDOM.createRoot(rootEl).render(html`<${StudyViewer} module=${module} entry=${entry} code=${code} />`);
   };
 })();

--- a/js/mcq-manifest.js
+++ b/js/mcq-manifest.js
@@ -42,4 +42,13 @@ window.MCQ_MANIFEST = [
     desc: 'Facial nerve anatomy, aberrant regeneration and synkinesis, evaluation scales, Bell’s palsy workup, electrodiagnostics, nerve repair, transfers, free-muscle reconstruction, and conference cases.',
     data: 'js/mcq-modules/facial-reanimation.js',
   },
+  {
+    slug: 'dtc-risk-stratification',
+    title: 'Thyroid Cancer Risk Stratification',
+    kicker: 'Endocrine · 2025 ATA · Free-response',
+    count: 25,
+    accent: '#2C5454',
+    desc: 'A sequential self-test (reveal-and-grade) on the operative approach, completion thyroidectomy, histopathology, and the 2025 ATA Risk Stratification System — Recommendations 15, 16, 27, 28.',
+    data: 'js/mcq-modules/dtc-risk-stratification.js',
+  },
 ];

--- a/js/mcq-modules/dtc-risk-stratification.js
+++ b/js/mcq-modules/dtc-risk-stratification.js
@@ -1,0 +1,423 @@
+/* =============================================================
+   Differentiated Thyroid Cancer — 2025 ATA Guidelines
+   Socratic self-test (free-response / recall) on the operative
+   approach, completion, histopathology & risk stratification:
+   Recommendations 15, 16, 27, 28 with Tables 5–7 cross-refs.
+   Free-response module: every item is type 'recall' — read the
+   prompt, commit to an answer, reveal, then self-grade.
+   ============================================================= */
+const meta = {
+  id: 'dtc-risk-stratification',
+  title: 'Differentiated\nThyroid Cancer',
+  subtitle: 'A sequential-dependency self-test on operative approach, completion thyroidectomy, histopathology, and the 2025 ATA Risk Stratification System (Rec 15, 16, 27, 28). Each answer becomes load-bearing for the next.',
+  kicker: 'Self-Test · 2025 ATA Rec 15/16/27/28',
+};
+
+const DOMAINS = {
+  staging: { label: 'AJCC / TNM Staging', color: '#2C5454', hex: 'rgba(44,84,84,0.14)' },
+  operative: { label: 'Operative Approach (Rec 15)', color: '#A0635E', hex: 'rgba(160,99,94,0.14)' },
+  completion: { label: 'Completion (Rec 16)', color: '#5C4F7B', hex: 'rgba(92,79,123,0.14)' },
+  pathology: { label: 'Histopathology (Rec 27)', color: '#7B7B4A', hex: 'rgba(123,123,74,0.14)' },
+  riskStrat: { label: 'Risk Stratification (Rec 28)', color: '#7B5C3A', hex: 'rgba(123,92,58,0.14)' },
+  controversy: { label: 'Controversy Stress-Test', color: '#8B4513', hex: 'rgba(139,69,19,0.14)' },
+};
+
+const CONCEPTS = {
+  't-category': { label: 'T Categories', domain: 'staging' },
+  'age-pivot': { label: 'Age 55 Pivot', domain: 'staging' },
+  'downstaging': { label: '8th-Ed Downstaging', domain: 'staging' },
+  'nodal-class': { label: 'N1a vs N1b', domain: 'staging' },
+  'lobectomy': { label: 'Lobectomy', domain: 'operative' },
+  'total-thyroidectomy': { label: 'Total Thyroidectomy', domain: 'operative' },
+  'gross-ete': { label: 'Gross ETE', domain: 'operative' },
+  'rai': { label: 'RAI Rationale', domain: 'operative' },
+  'conversion-rate': { label: '~20% Conversion', domain: 'operative' },
+  'completion-indications': { label: 'Completion Indications', domain: 'completion' },
+  'rln': { label: 'RLN / Surgical Safety', domain: 'completion' },
+  'nodal-completion': { label: 'Nodes & Completion', domain: 'completion' },
+  'micro-ete': { label: 'Microscopic ETE', domain: 'pathology' },
+  'path-report': { label: 'Path Report Elements', domain: 'pathology' },
+  'subtype': { label: 'Histologic Subtypes', domain: 'pathology' },
+  'familial': { label: 'Familial Syndromes', domain: 'pathology' },
+  'niftp': { label: 'NIFTP / IEFVPTC', domain: 'pathology' },
+  'ata-system': { label: 'ATA vs AJCC', domain: 'riskStrat' },
+  'ata-tiers': { label: '3-Tier Recurrence', domain: 'riskStrat' },
+  'focality': { label: 'Multifocality', domain: 'riskStrat' },
+  'vascular-invasion': { label: 'Vascular Invasion', domain: 'riskStrat' },
+  'nodal-risk': { label: 'Nodal Risk Params', domain: 'riskStrat' },
+  'molecular': { label: 'Molecular Profiling', domain: 'riskStrat' },
+  'case': { label: 'Integrated Case', domain: 'riskStrat' },
+  'controversy': { label: 'Points of Contention', domain: 'controversy' },
+};
+
+const ITEMS = [
+  {
+    id: 'q1',
+    type: 'recall',
+    section: 'Foundations · AJCC',
+    stem: 'Foundation — the T-category cutoffs. For a tumor confined to the thyroid (no ETE), state the size boundaries separating T1a, T1b, T2, and T3a. Then add the two extension-defined categories (T3b / T4).',
+    answer: `Size-defined, intrathyroidal:
+• T1a — ≤1 cm, limited to thyroid
+• T1b — >1 cm but ≤2 cm, limited to thyroid
+• T2 — >2 cm but ≤4 cm, limited to thyroid
+• T3a — >4 cm, limited to thyroid (new 8th-edition category)
+
+Extension-defined (size-independent):
+• T3b — gross ETE invading ONLY strap muscles (sternohyoid, sternothyroid, thyrohyoid, omohyoid), any size (new category)
+• T4a — gross ETE into subcutaneous soft tissue, larynx, trachea, esophagus, or recurrent laryngeal nerve
+• T4b — gross ETE invading prevertebral fascia, or encasing carotid / mediastinal vessels`,
+    brief: 'The 8th edition split the old "T3" into a SIZE arm (T3a) and an EXTENSION arm (T3b). T3a is just a big intrathyroidal tumor — size alone is a weak driver of management compared with extension and nodal status.',
+    concepts: ['t-category'],
+  },
+  {
+    id: 'q2',
+    type: 'recall',
+    section: 'Foundations · AJCC',
+    stem: 'The age pivot with no analogue in other cancers. State (a) the old vs new age cutoff, (b) the maximum stage for a patient BELOW the cutoff regardless of T/N, and (c) why distant metastasis in an older patient lands at Stage IVB rather than IVC.',
+    answer: `(a) Age cutoff raised from 45 → 55 years (8th edition, Change A).
+
+(b) A patient <55 years can only ever be Stage I (M0) or Stage II (M1) — no T or N finding pushes them past Stage II. N1 disease does NOT upstage a young patient; in the <55 group, N1 is Stage I.
+
+(c) In DTC, distant mets in an OLDER patient = Stage IVB (Change G). Stage IVC is reserved for ANAPLASTIC distant mets — so the most advanced a differentiated cancer reaches is IVB.`,
+    brief: 'Stage predicts disease-specific SURVIVAL; it does NOT predict structural recurrence. Hold that distinction — it is the entire reason Rec 28 exists.',
+    detailed: '20–30% of patients are downstaged moving 7th → 8th edition; roughly half from the age change and half from tumor-characteristic changes (e.g., microscopic ETE no longer counting). Critically, patients downstaged because of tumor characteristics carried a HIGHER recurrence risk than those downstaged purely by age.',
+    concepts: ['age-pivot', 'downstaging'],
+  },
+  {
+    id: 'q3',
+    type: 'recall',
+    section: 'Foundations · AJCC',
+    stem: 'One nodal reclassification you will be asked about. Which level moved, what was it before, what is it now, and what is the N1a vs N1b distinction?',
+    answer: `Level VII nodes (superior mediastinal) were previously classified as lateral neck (N1b) and are now reclassified as central neck (N1a) (Change F).
+
+• N1a = metastasis to level VI or VII (pretracheal, paratracheal, prelaryngeal/Delphian, upper mediastinal); unilateral or bilateral.
+• N1b = metastasis to unilateral, bilateral, or contralateral lateral neck (levels I–V) or retropharyngeal nodes.`,
+    brief: '"Central compartment" now extends down into the superior mediastinum — it changes how you count compartments when reading an operative/path report.',
+    concepts: ['nodal-class'],
+  },
+  {
+    id: 'q4',
+    type: 'recall',
+    section: 'Rec 15 · Operative',
+    stem: 'Rec 15A — the small-tumor default. For thyroid cancer ≤2 cm without gross ETE (cT1) and without metastases (cN0M0), what is the initial procedure of choice, and what is the strength/certainty?',
+    answer: `Thyroid lobectomy is the initial procedure — unless there are bilateral cancers or other indications to remove the contralateral lobe.
+
+(Strong recommendation, Moderate-certainty evidence.)`,
+    brief: 'Why: for small, unifocal, intrathyroidal, node-negative tumors there is no meaningful survival difference between lobectomy and total thyroidectomy, while lobectomy carries significantly lower complication rates. "Does removing more tissue help?" → no, at this size.',
+    concepts: ['lobectomy'],
+  },
+  {
+    id: 'q5',
+    type: 'recall',
+    section: 'Rec 15 · Operative',
+    stem: 'Rec 15B — the contested middle zone (>2 to ≤4 cm, cT2N0M0). What is the preferred initial treatment, how does the recommendation strength differ from 15A, and what are the three categories of reasons a team might still choose total thyroidectomy?',
+    answer: `Thyroid lobectomy MAY be the preferred initial treatment (lower risk and side effects).
+(Conditional recommendation, Low–moderate-certainty evidence.)
+
+The strength downgrade is the teaching point: 15A (≤2 cm) is STRONG; 15B (2–4 cm) is only CONDITIONAL. The evidence is genuinely split — about half of meta-analyses show no recurrence difference (but higher complications with total), and about half show statistically lower recurrence with total.
+
+Three reasons a team may still elect total thyroidectomy:
+1. To enable RAI administration
+2. To enhance follow-up (e.g., facilitating Tg surveillance)
+3. Suspicious contralateral nodularity and/or patient preference`,
+    brief: 'Forcing function: when offering lobectomy for a 2–4 cm tumor, counsel the patient about the ~20% possibility of conversion to total thyroidectomy if higher-risk features emerge. Anchor that ~20% figure now — it recurs through Rec 15/16.',
+    concepts: ['lobectomy', 'conversion-rate'],
+  },
+  {
+    id: 'q6',
+    type: 'recall',
+    section: 'Rec 15 · Operative',
+    stem: 'Rec 15C — when the answer is unambiguously total thyroidectomy. List the qualifying scenarios (map them back to the T/N categories) and give the strength/certainty.',
+    answer: `Total thyroidectomy (with gross removal of all primary tumor + node dissection, absent contraindications) is indicated for:
+• Thyroid cancer >4 cm (cT3a)
+• Gross extrathyroidal extension — cT3b or cT4 (any size)
+• Clinically apparent nodal metastasis (cN1)
+• Distant metastasis (cM1)
+(Strong recommendation, Moderate-certainty evidence.)
+
+Extent of initial surgery (Table 5):
+• cT1N0M0 (unilateral) → Lobectomy
+• cT1(m)N0M0 (bilateral/multifocal) → Total thyroidectomy
+• cT2N0M0 (unilateral) → Lobectomy OR total thyroidectomy
+• cT2(m)N0M0 (bilateral) → Total thyroidectomy
+• cT3–4, or cN1, or cM1 → Total thyroidectomy`,
+    brief: 'The logic is NOT "bigger = more surgery." Extension, multifocality, nodal, and metastatic status force total thyroidectomy. A 4.5 cm purely intrathyroidal cN0 tumor (T3a) tips to total mainly because near-total/total is necessary if the plan includes post-op RAI.',
+    concepts: ['total-thyroidectomy', 't-category'],
+  },
+  {
+    id: 'q7',
+    type: 'recall',
+    section: 'Rec 15 · Operative',
+    stem: 'The "why RAI forces the hand" mechanism. Why does a plan to use post-operative RAI essentially mandate near-total or total thyroidectomy? And what is the corollary about the historical indications (contralateral nodules, prior radiation, FNMTC)?',
+    answer: `Mechanism: RAI remnant ablation/adjuvant therapy requires total thyroidectomy to work — residual normal thyroid avidly takes up iodine, so a large remnant (intact contralateral lobe) defeats ablation and obscures Tg-based surveillance. Whenever post-op RAI is part of the strategy, the surgery must be near-total/total.
+
+Corollary (the "RAI shadow"): prior guidelines recommended total thyroidectomy where post-op RAI was anticipated — DTC >4 cm (T3a), gross ETE (T3b/T4), cN1, or cM1. For 1–4 cm node-negative tumors, older guidance invoked age >45, contralateral nodules, prior head/neck radiation, or FNMTC as reasons to default to total BECAUSE of RAI plans.`,
+    brief: 'The 2025 framing pulls away from routine RAI for remnant ablation in low-risk disease — which in turn removes much of the historical justification for routine total thyroidectomy in those patients.',
+    concepts: ['rai', 'total-thyroidectomy'],
+  },
+  {
+    id: 'q8',
+    type: 'recall',
+    section: 'Rec 16 · Completion',
+    stem: 'Rec 16A — indications for completion thyroidectomy. Completion after initial lobectomy may be considered to address what three goals? Give the strength/certainty and the conceptual point about WHY completion is even on the table (the diagnostic gap).',
+    answer: `Completion thyroidectomy after initial lobectomy may be considered to:
+1. Ensure complete removal of persistent primary cancer after inadequate initial resection (R2 — gross residual)
+2. Address persistent primary malignancy with suspected bilateral cancers
+3. Facilitate RAI administration and/or enhance follow-up based on higher estimated recurrence risk identified post-operatively (accounting for RLN function)
+(Conditional recommendation, Low–moderate-certainty evidence.)
+
+The diagnostic gap: completion is indicated when DTC was not known/recognized pre- or intra-operatively. Most cytologically INDETERMINATE nodules that prove malignant turn out to be low-risk cancers adequately treated by lobectomy alone.`,
+    brief: 'Completion becomes desirable only when final histology reveals heightened recurrence risk — the explicit hand-off to Rec 28 / the Pathology section.',
+    concepts: ['completion-indications'],
+  },
+  {
+    id: 'q9',
+    type: 'recall',
+    section: 'Rec 16 · Completion',
+    stem: 'Rec 16B + the surgical-safety forcing functions. Before proceeding to completion, what functional assessment is mandatory, what should happen if it is abnormal, and what two bilateral-surgery risks drive this caution?',
+    answer: `Mandatory pre-completion assessment: evaluate the functional status of the recurrent laryngeal nerves (laryngeal exam). If an IPSILATERAL RLN injury is present, defer contralateral resection until the ipsilateral nerve has recovered.
+
+The two driving risks of two-stage / bilateral surgery:
+1. Bilateral RLN injury → necessitating tracheostomy (the catastrophic outcome)
+2. Hypoparathyroidism from removing/devascularizing remaining parathyroid tissue
+
+(Rec 16B extends completion to oncocytic thyroid carcinoma [OTC] on the same indications as other types — Conditional, Very-low-certainty.)`,
+    brief: 'If there is permanent ipsilateral RLN paralysis, contralateral completion should prompt referral to a high-volume thyroid surgeon (cross-ref Rec 6). Completion overall is roughly similar in complication profile to up-front total, though with somewhat higher transient hypoparathyroidism and readmission/return-to-OR rates.',
+    concepts: ['rln', 'completion-indications'],
+  },
+  {
+    id: 'q10',
+    type: 'recall',
+    section: 'Rec 16 / 28 · Hinge',
+    stem: 'The microscopic-vs-gross ETE distinction (high-yield trap). What changed about minimal/microscopic ETE in the 8th edition, and how does that change whether you pursue completion? Contrast the scenarios at the strap-muscle interface.',
+    answer: `Minimal/microscopic ETE no longer upstages to T3 (Change B) — removed from the T3 definition, no impact on T category or stage. Consequently microscopic ETE may NOT require completion, particularly for T1 and small T2 unifocal tumors — unless there is clinical concern for nerve, trachea, or esophagus involvement.
+
+The strap-muscle interface:
+• Gross ETE into strap muscle → higher recurrence → convert lobectomy to total, resect to a grossly free margin.
+• Microscopic ETE into strap musculature with a clearly negative margin → does NOT mandate completion.
+• Microscopically positive margin / tumor transgressing the capsule, absent clinical ETE concern → does NOT mandate completion, particularly anteriorly.`,
+    brief: 'Prudent judgment: when you cannot tell true tumor extension from scarring after needle biopsy, leaving a cuff of sternothyroid muscle at the area of concern and deferring to final histology beats reflexively pursuing total thyroidectomy.',
+    concepts: ['micro-ete', 'gross-ete'],
+  },
+  {
+    id: 'q11',
+    type: 'recall',
+    section: 'Rec 16 / 28 · Nodes',
+    stem: 'Which nodes seen at lobectomy change the plan? Distinguish the scenario that may prompt completion from the one that does not necessarily require it, and give the three nodal features that suggest higher recurrence (favoring completion).',
+    answer: `• Microscopic, pathologically involved central nodes (cN0 but pN1a) found incidentally → MAY prompt completion, but is not necessary for all patients.
+• Clinically evident nodal metastasis (cN1a) discovered DURING lobectomy → warrants conversion to total thyroidectomy with central neck dissection.
+
+Three features suggesting higher recurrence (→ favor completion):
+1. Larger number of nodes — more than 3 to 5 involved
+2. Higher lymph node ratio (LNR >0.3)
+3. Presence of extranodal extension`,
+    brief: 'Tool pearl: targeted frozen section of clinically suspicious nodes aids the intraoperative decision — letting you convert in one stage rather than returning for completion.',
+    concepts: ['nodal-completion', 'completion-indications'],
+  },
+  {
+    id: 'q12',
+    type: 'recall',
+    section: 'Rec 15 / 16 · Synthesis',
+    stem: 'Grand synthesis — the conversion-rate reality. For low-risk DTC managed with initial lobectomy, what conversion/completion number must the patient understand, and what does the evidence say about whether DEFERRING completion harms survival?',
+    answer: `The number: patients must be aware of a ≥20% possibility of conversion to total thyroidectomy — intraoperatively or as later completion. (Estimates range widely, ~5%–43% across studies, clustering near a meta-analytic 11–34%.)
+
+The corollary that makes lobectomy-first defensible: with appropriate follow-up, deferral of completion has little to no impact on survival. Most recurrences after lobectomy occur in the contralateral lobe and are successfully salvaged with completion if the patient is compliant with sonographic surveillance.`,
+    brief: 'Oral-exam distillation: lobectomy is the preferred initial operation for low-risk DTC (small, unifocal, intrathyroidal, no regional/distant mets) because of lower complications and better QoL — provided the patient accepts ~20% conversion and commits to surveillance.',
+    concepts: ['conversion-rate', 'lobectomy'],
+  },
+  {
+    id: 'q13',
+    type: 'recall',
+    section: 'Rec 27 · Pathology',
+    stem: 'Rec 27 (Part 1) — what the pathology report MUST contain. Beyond the essential AJCC staging features (including margin status), name the histopathologic features reports should include for risk assessment.',
+    answer: `Beyond essential AJCC staging features (and resection margin status), reports should additionally include:
+• Presence of vascular invasion — AND the number of invaded vessels
+• Number of lymph nodes examined and involved with tumor
+• Size of the largest metastatic focus to the lymph node
+• Presence or absence of extranodal extension of metastatic tumor
+(Good Practice Statement.)`,
+    brief: 'Vessel count, node number, metastatic-focus size, and extranodal extension are precisely the variables that move a patient between ATA recurrence-risk tiers. The path report is the raw data feed for Rec 28.',
+    concepts: ['path-report'],
+  },
+  {
+    id: 'q14',
+    type: 'recall',
+    section: 'Rec 27 · Pathology',
+    stem: 'Rec 27 (Parts 2 & 3) — the subtype-naming mandate. Sort the named subtypes into unfavorable vs favorable, and name the familial-syndrome association the pathologist must flag.',
+    answer: `Unfavorable subtypes to identify:
+• Tall cell, columnar cell, hobnail subtypes of PTC
+• Widely invasive FTC and OTC
+• High-grade follicular-cell–derived non-anaplastic carcinoma
+
+Favorable subtypes to identify:
+• IEFVPTC with minimal invasion (invasive encapsulated follicular variant of PTC)
+• Minimally invasive FTC
+
+Familial-syndrome flag (Part 3): cribriform-morular carcinoma — can be associated with familial adenomatous polyposis (FAP). Also flag PTEN hamartoma tumor syndrome (PHTS)–associated FTC or PTC.
+(Good Practice Statements.)`,
+    brief: 'Naming a subtype is not cosmetic — "cribriform-morular" on a path report can be the first clue to undiagnosed FAP, redirecting the whole patient (and family) toward colorectal screening.',
+    concepts: ['subtype', 'familial'],
+  },
+  {
+    id: 'q15',
+    type: 'recall',
+    section: 'Rec 27 / 28 · Pathology',
+    stem: 'The NIFTP / IEFVPTC nuclear-cytology fork (Figure 4). Using PTC nuclear cytology (present vs absent) and invasion (present vs absent) as the two axes, name the four entities (FA, FTC, NIFTP, IEFVPTC) by their position.',
+    answer: `Driven by PTC nuclear features first, then invasion:
+• Nuclei ABSENT + non-invasive → FA (follicular adenoma)
+• Nuclei ABSENT + invasive → FTC (follicular thyroid carcinoma)
+• Nuclei PRESENT + non-invasive → NIFTP (noninvasive follicular thyroid neoplasm w/ papillary-like nuclear features)
+• Nuclei PRESENT + invasive → IEFVPTC (invasive encapsulated follicular variant of PTC)`,
+    brief: 'NIFTP sits in the "PTC-nuclei present but non-invasive" box — exactly why it was reclassified OUT of carcinoma (it behaves indolently). Its malignant counterpart with the same nuclei but WITH invasion is IEFVPTC. On the follicular (no-PTC-nuclei) side, invasion separates benign FA from malignant FTC.',
+    concepts: ['niftp'],
+  },
+  {
+    id: 'q16',
+    type: 'recall',
+    section: 'Rec 28 · Risk Strat',
+    stem: 'Capstone — Rec 28A. State (a) the inputs the 2025 ATA Risk Stratification System integrates, (b) the outcome it predicts, (c) the timeframe, and (d) strength/certainty. Then state the crucial difference between what AJCC staging predicts vs what the ATA system predicts.',
+    answer: `(a) Inputs: histopathologic features of the tumor + number of cervical lymph nodes + AJCC staging + post-operative imaging + serum Tg and TgAb (if appropriate).
+(b) Predicts: risk of structural disease persistence/recurrence (locoregional and/or distant) and/or survival in DTC (PTC, FTC/IEFVPTC, OTC).
+(c) Timeframe: applied within ~3 months of surgery.
+(d) Strong recommendation, Moderate-certainty evidence.
+
+The pivotal distinction:
+• AJCC/UICC TNM staging predicts disease-SPECIFIC SURVIVAL (mortality).
+• The ATA Risk Stratification System predicts STRUCTURAL PERSISTENCE/RECURRENCE.`,
+    brief: 'A patient can be low STAGE (excellent survival) yet carry meaningful RECURRENCE risk — which is exactly why two parallel systems exist. Higher recurrence risk is usually dependent on co-existing factors rather than any single factor.',
+    detailed: 'Rec 28B: routine molecular profiling of histologic specimens post-operatively is NOT recommended routinely — but if such data already exist, they may be used to further refine recurrence risk. (Conditional, Low-certainty.)',
+    concepts: ['ata-system', 'molecular'],
+  },
+  {
+    id: 'q17',
+    type: 'recall',
+    section: 'Rec 28 · Risk Strat',
+    stem: 'Rec 28 — the three-tier recurrence percentages. The 2025 system builds on the 2015 low/intermediate/high framework. Anchor the approximate observed recurrence rates for low, intermediate, and high risk (multivariable PTC analysis).',
+    answer: `Multivariable analysis of the ATA Risk of Recurrence categories in PTC:
+• Low risk → ~1.5% recurrence
+• Intermediate risk → ~5.4% recurrence
+• High risk → ~25% recurrence
+
+(Similar for T1a PTC specifically: ~1.6% low / 7.4% intermediate / 22.7% high.)`,
+    brief: 'These percentages are why the tier label drives surveillance intensity and RAI decisions. Low → intermediate roughly triples-to-quadruples risk; high is an order of magnitude above low. The 2025 refinements (focality, vessel counts, ETE handling) exist to sort patients into the CORRECT tier more precisely.',
+    concepts: ['ata-tiers'],
+  },
+  {
+    id: 'q18',
+    type: 'recall',
+    section: 'Rec 28 · Features',
+    stem: 'Feature deep-dive — tumor focality. Where do unifocal T1a, multifocal T1a, and multifocal T1a with microscopic ETE land on risk?',
+    answer: `• Unifocal T1a PTC → LOW risk
+• Multifocal T1a PTC → still LOW risk (both were low in 2015)
+• Multifocal T1a PTC WITH microscopic ETE → INTERMEDIATE risk
+
+Multifocality in T1a PTC carries somewhat higher structural recurrence (~4–6% vs ~1–2% unifocal), though data are mixed. Multifocality is most reliably an independent predictor in tumors >1 cm (e.g., bilateral multifocality HR ~4); the signal is weaker within T1a PTC specifically.`,
+    brief: 'Focality alone rarely moves a tiny tumor — it is focality + a SECOND feature (here, microscopic ETE) that bumps the tier. Echoes the Rec 28 theme: recurrence risk is driven by co-existing factors, not single variables.',
+    concepts: ['focality'],
+  },
+  {
+    id: 'q19',
+    type: 'recall',
+    section: 'Rec 28 · Features',
+    stem: 'Feature deep-dive — vascular invasion (the vessel-count thresholds). Give the vascular-invasion risk mapping for PTC vs FTC, including the ≥4-vessel threshold and what "extensive" vs "focal" angioinvasion predicts.',
+    answer: `Definition: vascular invasion = tumor cells invading through a vessel wall WITH adherent fibrin thrombus (angioinvasion is the more reproducible term vs lymphatic invasion).
+
+PTC: vascular invasion → INTERMEDIATE risk (historically 15–30%); newer data suggest it more commonly predicts distant metastasis than locoregional recurrence.
+
+FTC — the vessel-count threshold is the key number:
+• Minimally invasive / <4 vessels (focal) → LOW risk (~2–3% recurrence; one series ~1%)
+• Extensive / ≥4 vessels → HIGH risk (~30–55% recurrence; ~26% in one series)
+
+Distant-met risk rises with vessel number: HR ~2.5 for <4 vessels, HR ~8 for ≥4 vessels. Extensive (≥4 foci) angioinvasion → OR ~26 for distant recurrence.`,
+    brief: '"≥4 vessels" is the canonical cutoff separating minimally from extensively/widely invasive follicular-pattern carcinoma — and the single most important reason the path report must COUNT, not just note presence/absence.',
+    concepts: ['vascular-invasion'],
+  },
+  {
+    id: 'q20',
+    type: 'recall',
+    section: 'Rec 28 · Features',
+    stem: 'Feature deep-dive — nodal metastasis parameters. Give the micrometastasis definition and its tier, the clinical N1 >3 cm tier, and the metastatic-focus size threshold (>2–3 mm) that signals higher recurrence.',
+    answer: `From the 2015 framework (carried forward):
+• ≤5 micrometastases, each <2 mm (<0.2 cm) → LOW risk
+• Clinical N1 with any node >3 cm → HIGH risk
+
+Refinements since 2015:
+• Metastatic focus >5 mm → ~25.9% recurrence
+• pN1 with node >3 mm → HR ~4.2, ~50% recurrence in one analysis
+• >5 involved nodes / LNR >0.3 / extranodal extension → all push toward higher recurrence (and toward completion, per Q11)
+• The traditional 3 cm "high risk" cutoff is challenged — N1b nodes >2 cm already carry elevated HR (~1.15), suggesting risk is more continuous than binary.`,
+    brief: 'Nodal risk is a function of how many, how big, and whether they breach the capsule — number, size, extranodal extension — exactly the trio Rec 27 mandates reporting.',
+    concepts: ['nodal-risk'],
+  },
+  {
+    id: 'q21',
+    type: 'recall',
+    section: 'Capstone · Integrated Case',
+    stem: 'End-to-end case. A 58-year-old with a 3.2 cm unifocal PTC, clinically node-negative, no gross ETE (cT2N0M0). Walk the chain: (1) initial operative options per Rec 15, (2) the intraoperative finding that forces conversion, (3) what the path report must contain per Rec 27, and (4) two final-path scenarios — one keeping the patient low risk, one pushing intermediate — and what each implies for completion.',
+    answer: `(1) Initial operation (Rec 15B, cT2N0M0, age >55): the conditional middle zone. Lobectomy OR total are both acceptable (Table 5). Lobectomy may be preferred (lower complications, better QoL) — provided the patient accepts ~20% conversion and commits to surveillance. Total is reasonable if the patient prefers to avoid a possible second operation, or there is suspicious contralateral nodularity / an RAI plan.
+
+(2) Intraoperative finding forcing conversion (Rec 15C / 16):
+• Grossly apparent nodal metastasis (cN1a) → convert to total + central neck dissection.
+• Gross ETE into strap muscle (T3b) → convert to total, resect to free margin.
+• Targeted frozen section of a suspicious node drives a one-stage conversion.
+
+(3) Path report must contain (Rec 27): essential AJCC features + margin status, vascular invasion WITH vessel count, nodes examined/involved, size of largest nodal focus, extranodal extension, and explicit subtype (flag tall-cell/columnar/hobnail; flag cribriform-morular → FAP).
+
+(4) Final-path scenarios (Rec 28):
+• Stays LOW: classic PTC, no vascular invasion, negative margins, no/limited nodal disease (≤5 micromets <2 mm), no aggressive subtype → completion NOT required; lobectomy adequate; surveillance only.
+• Pushes INTERMEDIATE: vascular invasion present, OR microscopic ETE + multifocality, OR pN1a with several involved nodes / focus >5 mm → completion MAY be considered (to facilitate RAI and/or enhance Tg follow-up) — after confirming RLN function (defer contralateral if ipsilateral nerve injured).`,
+    brief: 'One-line distillation: stage (age 58, 3.2 cm) sets survival expectations; the final pathology features set recurrence risk and decide whether lobectomy was definitive or whether completion + RAI earns its keep.',
+    concepts: ['case', 'lobectomy', 'total-thyroidectomy', 'nodal-risk'],
+  },
+  {
+    id: 'c1',
+    type: 'recall',
+    section: 'Controversy Stress-Test',
+    stem: 'Controversy 1 — lobectomy vs total for 2–4 cm (T2N0M0) DTC. Argue both sides and explain what the Conditional strength of Rec 15B is admitting.',
+    answer: `The evidence is split down the middle — about half of meta-analyses show no recurrence difference, half show lower recurrence with total. The Conditional strength of Rec 15B is an honest admission that the data do not resolve.
+
+Defensible to do either; indefensible to claim the question is settled.`,
+    brief: 'When the guideline grades a recommendation "Conditional," read it as a flag that the underlying evidence genuinely conflicts — not as a soft "total is better but we are hedging."',
+    concepts: ['controversy', 'lobectomy'],
+  },
+  {
+    id: 'c2',
+    type: 'recall',
+    section: 'Controversy Stress-Test',
+    stem: 'Controversy 2 — the 3 cm nodal cutoff for "high risk." Why is it contested?',
+    answer: `Carried from 2015 but actively challenged — N1b nodes >2 cm already show elevated HR, implying risk is CONTINUOUS, not a clean binary at 3 cm. The guideline reports the cutoff while citing its own counter-evidence.`,
+    brief: 'Binary cutoffs are administrative conveniences laid over continuous biology. Know the number for the exam, but know the guideline itself flags it as imperfect.',
+    concepts: ['controversy', 'nodal-risk'],
+  },
+  {
+    id: 'c3',
+    type: 'recall',
+    section: 'Controversy Stress-Test',
+    stem: 'Controversy 3 — lymphovascular vs true angioinvasion. Why does this distinction matter for whether "vascular invasion" holds up as a predictor?',
+    answer: `Pathologists cannot reliably distinguish small lymphatics from veins/arteries on H&E, so the two get lumped — which may explain why "lymphovascular invasion" sometimes fails as an independent predictor while vessel-COUNTED angioinvasion (with fibrin thrombus, ≥4-vessel threshold) holds up.
+
+The reporting standard is moving toward counted angioinvasion specifically.`,
+    brief: 'Reproducibility of the measurement, not just the biology, decides whether a "predictor" survives multivariable analysis. Counted angioinvasion with fibrin thrombus is the more reproducible — and more durable — variable.',
+    concepts: ['controversy', 'vascular-invasion'],
+  },
+  {
+    id: 'c4',
+    type: 'recall',
+    section: 'Rapid Recall',
+    stem: 'Speed round — rattle off the one-screen recall anchors for this whole module from memory, then reveal to check yourself.',
+    answer: `• T-categories: ≤1 (T1a) / ≤2 (T1b) / ≤4 (T2) / >4 (T3a) intrathyroidal; T3b/T4 = gross extension, size-independent.
+• Age pivot: 55; <55 caps at Stage II; DTC distant mets = IVB (IVC is anaplastic).
+• Rec 15 ladder: ≤2 cm → lobectomy (Strong); 2–4 cm → lobectomy preferred (Conditional); >4 cm / gross ETE / cN1 / cM1 → total (Strong).
+• The number: ~20% conversion/completion after low-risk lobectomy.
+• Rec 16: completion fills the diagnostic gap; check RLN function first; defer contralateral if ipsilateral nerve injured.
+• Micro ETE: no longer upstages, usually no completion (clean margin). Gross ETE: convert to total.
+• Rec 27 report quartet: vessel COUNT + nodes examined/involved + largest met focus size + extranodal extension + subtype.
+• NIFTP = PTC-nuclei present, non-invasive → out of carcinoma; IEFVPTC = same nuclei WITH invasion.
+• Rec 28: ATA predicts RECURRENCE; AJCC predicts SURVIVAL. Tiers ~1.5% / ~5% / ~25%. Applied <3 months post-op.
+• ≥4 vessels = the FTC minimally-vs-extensively-invasive cutoff (low → high risk).`,
+    brief: 'If you can produce this list cold, you own Rec 15/16/27/28. The two money-lines: (1) stage = survival, ATA = recurrence; (2) extension/nodal/multifocal status — not size alone — drives the extent of surgery.',
+    concepts: ['t-category', 'age-pivot', 'ata-tiers'],
+  },
+];
+
+window.__MCQ_MODULE = { meta, DOMAINS, CONCEPTS, ITEMS };

--- a/js/mcq-reviewer.js
+++ b/js/mcq-reviewer.js
@@ -1,0 +1,206 @@
+/* =============================================================
+   MCQ reviewer codes — shared across mcq.html and mcq-study.html.
+   Multiple residents share one browser, so progress + spaced
+   repetition are namespaced per reviewer code (e.g. "kafle",
+   "terry"): keys become mcq:progress:<slug>:<code> and
+   mcq:srs:<slug>:<code> (the engine appends the suffix).
+
+   This module owns the *identity*, not the storage:
+     • a registry of known codes (mcq:reviewers)
+     • the active code (mcq:reviewer)
+     • a small on-brand prompt with a typo failsafe — entering an
+       unknown code asks you to confirm (and suggests the closest
+       existing one), so "kaffle" doesn't silently fork "kafle".
+   Theme-reactive: the modal uses the same CSS variables as mcq.css.
+   ============================================================= */
+(function () {
+  var REVIEWER_KEY = 'mcq:reviewer';
+  var REGISTRY_KEY = 'mcq:reviewers';
+
+  function norm(c) {
+    return String(c || '').trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+  }
+  function loadJSON(key, fb) {
+    try { var r = localStorage.getItem(key); return r ? JSON.parse(r) : fb; }
+    catch (e) { return fb; }
+  }
+  function saveJSON(key, v) { try { localStorage.setItem(key, JSON.stringify(v)); } catch (e) {} }
+
+  function list() { var a = loadJSON(REGISTRY_KEY, []); return Array.isArray(a) ? a : []; }
+  function current() { try { return norm(localStorage.getItem(REVIEWER_KEY) || ''); } catch (e) { return ''; } }
+
+  function setActive(code) {
+    var c = norm(code);
+    if (!c) return '';
+    var a = list();
+    if (a.indexOf(c) === -1) { a.push(c); a.sort(); saveJSON(REGISTRY_KEY, a); }
+    try { localStorage.setItem(REVIEWER_KEY, c); } catch (e) {}
+    return c;
+  }
+
+  /* Levenshtein distance — for "did you mean?" typo suggestions. */
+  function lev(a, b) {
+    var m = a.length, n = b.length;
+    if (!m) return n; if (!n) return m;
+    var prev = [], cur = [], i, j;
+    for (j = 0; j <= n; j++) prev[j] = j;
+    for (i = 1; i <= m; i++) {
+      cur[0] = i;
+      for (j = 1; j <= n; j++) {
+        var cost = a.charAt(i - 1) === b.charAt(j - 1) ? 0 : 1;
+        cur[j] = Math.min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + cost);
+      }
+      for (j = 0; j <= n; j++) prev[j] = cur[j];
+    }
+    return prev[n];
+  }
+  function closest(code) {
+    var c = norm(code), best = null, bestD = 99;
+    list().forEach(function (x) {
+      if (x === c) return;
+      var d = lev(c, x);
+      if (d < bestD) { bestD = d; best = x; }
+    });
+    if (best && bestD <= 2 && Math.abs(best.length - c.length) <= 2) return best;
+    return null;
+  }
+
+  /* ---- The modal. Resolves to the chosen (and now-active) code. ---- */
+  function ask(opts) {
+    opts = opts || {};
+    return new Promise(function (resolve) {
+      var overlay = document.createElement('div');
+      overlay.setAttribute('role', 'dialog');
+      overlay.setAttribute('aria-modal', 'true');
+      overlay.style.cssText =
+        'position:fixed;inset:0;z-index:9999;display:flex;align-items:center;' +
+        'justify-content:center;padding:1.25rem;background:rgba(0,0,0,0.45);' +
+        'backdrop-filter:blur(2px);';
+
+      var card = document.createElement('div');
+      card.style.cssText =
+        'width:100%;max-width:24rem;border-radius:16px;padding:1.5rem;' +
+        'background:var(--mcq-surface,#fff);border:1px solid var(--mcq-border,#ddd);' +
+        'color:var(--mcq-text,#222);box-shadow:0 20px 60px rgba(0,0,0,0.25);' +
+        "font-family:'Crimson Pro',Georgia,serif;";
+      overlay.appendChild(card);
+
+      function close(val) {
+        window.removeEventListener('keydown', onKey, true);
+        if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+        resolve(val);
+      }
+      function onKey(e) { if (e.key === 'Escape') { e.preventDefault(); /* require a choice */ } }
+      window.addEventListener('keydown', onKey, true);
+
+      function btn(label, primary) {
+        var b = document.createElement('button');
+        b.textContent = label;
+        b.style.cssText =
+          'cursor:pointer;border-radius:10px;padding:0.6rem 0.9rem;font-size:0.9rem;' +
+          "font-family:'Fraunces',Georgia,serif;font-weight:500;letter-spacing:0.01em;" +
+          (primary
+            ? 'background:var(--mcq-accent,#2C5454);color:#fff;border:1px solid var(--mcq-accent,#2C5454);'
+            : 'background:transparent;color:var(--mcq-text,#222);border:1px solid var(--mcq-border,#ccc);');
+        return b;
+      }
+
+      /* --- Step 1: enter a code --- */
+      function renderEntry(prefill) {
+        card.innerHTML = '';
+        var kicker = document.createElement('div');
+        kicker.textContent = (opts.title || 'Who is reviewing?');
+        kicker.style.cssText =
+          "font-family:'Fraunces',Georgia,serif;font-size:1.25rem;margin-bottom:0.35rem;";
+        var sub = document.createElement('p');
+        sub.textContent = 'Enter your code so your progress and review schedule stay yours (e.g. kafle, terry).';
+        sub.style.cssText = 'margin:0 0 1rem;font-size:0.92rem;line-height:1.5;color:var(--mcq-text-muted,#666);';
+
+        var input = document.createElement('input');
+        input.type = 'text';
+        input.autocomplete = 'off';
+        input.spellcheck = false;
+        input.value = prefill != null ? prefill : current();
+        input.placeholder = 'your code';
+        input.style.cssText =
+          'width:100%;box-sizing:border-box;padding:0.7rem 0.85rem;border-radius:10px;' +
+          'font-size:1rem;background:var(--mcq-bg,#faf8f5);color:var(--mcq-text,#222);' +
+          'border:1px solid var(--mcq-border,#ccc);outline:none;';
+
+        var known = list();
+        var hint = document.createElement('div');
+        hint.style.cssText = 'min-height:1.1rem;margin:0.5rem 0 0.25rem;font-size:0.8rem;color:var(--mcq-text-faint,#999);';
+        hint.textContent = known.length ? ('Known: ' + known.join(', ')) : 'No reviewers yet — your code creates the first.';
+
+        var row = document.createElement('div');
+        row.style.cssText = 'display:flex;gap:0.5rem;margin-top:1rem;';
+        var go = btn('Continue', true);
+        go.style.flex = '1';
+        row.appendChild(go);
+
+        function submit() {
+          var c = norm(input.value);
+          if (!c) { hint.textContent = 'Please enter a code (letters/numbers).'; hint.style.color = 'var(--mcq-incorrect,#b00)'; input.focus(); return; }
+          if (known.indexOf(c) !== -1) { close(setActive(c)); return; }
+          renderConfirm(c);
+        }
+        go.addEventListener('click', submit);
+        input.addEventListener('keydown', function (e) { if (e.key === 'Enter') { e.preventDefault(); submit(); } });
+
+        card.appendChild(kicker);
+        card.appendChild(sub);
+        card.appendChild(input);
+        card.appendChild(hint);
+        card.appendChild(row);
+        setTimeout(function () { input.focus(); input.select(); }, 30);
+      }
+
+      /* --- Step 2: confirm an unknown code (typo failsafe) --- */
+      function renderConfirm(code) {
+        card.innerHTML = '';
+        var suggestion = closest(code);
+
+        var head = document.createElement('div');
+        head.textContent = 'New reviewer?';
+        head.style.cssText = "font-family:'Fraunces',Georgia,serif;font-size:1.2rem;margin-bottom:0.4rem;";
+
+        var msg = document.createElement('p');
+        msg.style.cssText = 'margin:0 0 1rem;font-size:0.95rem;line-height:1.5;color:var(--mcq-text-muted,#666);';
+        msg.innerHTML = 'There is no reviewer <strong>“' + code + '”</strong> yet.' +
+          (suggestion ? ' Did you mean <strong>“' + suggestion + '”</strong>?' : ' Create it as a new reviewer?');
+
+        var col = document.createElement('div');
+        col.style.cssText = 'display:flex;flex-direction:column;gap:0.5rem;';
+
+        if (suggestion) {
+          var useSug = btn('Use “' + suggestion + '”', true);
+          useSug.addEventListener('click', function () { close(setActive(suggestion)); });
+          col.appendChild(useSug);
+        }
+        var createBtn = btn('Create “' + code + '”', !suggestion);
+        createBtn.addEventListener('click', function () { close(setActive(code)); });
+        col.appendChild(createBtn);
+
+        var back = btn('Edit', false);
+        back.addEventListener('click', function () { renderEntry(code); });
+        col.appendChild(back);
+
+        card.appendChild(head);
+        card.appendChild(msg);
+        card.appendChild(col);
+      }
+
+      renderEntry(opts.prefill);
+      document.body.appendChild(overlay);
+    });
+  }
+
+  window.MCQReviewer = {
+    norm: norm,
+    list: list,
+    current: current,
+    setActive: setActive,
+    closest: closest,
+    ask: ask,
+  };
+})();

--- a/mcq-study.html
+++ b/mcq-study.html
@@ -28,10 +28,13 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
       MCQ Study Guides
     </a>
+    <div style="display:flex;align-items:center;gap:0.5rem;margin-left:auto">
+    <button type="button" class="mcq-reviewer-chip" id="reviewer-chip" title="Switch reviewer (reloads)" hidden></button>
     <button type="button" class="mcq-theme-toggle" id="theme-toggle" aria-label="Toggle day / night">
       <svg class="i-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
       <svg class="i-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
     </button>
+    </div>
   </nav>
 
   <div id="root" style="padding-top:42px"></div>
@@ -50,6 +53,7 @@
   <script src="https://unpkg.com/htm@3/dist/htm.umd.js" crossorigin></script>
 
   <script src="js/mcq-manifest.js"></script>
+  <script src="js/mcq-reviewer.js"></script>
   <script src="js/mcq-engine.js"></script>
 
   <script>
@@ -59,6 +63,17 @@
         root.innerHTML = '<div class="mcq-notice"><h1>' + title + '</h1><p>' + body +
           '</p><a href="mcq.html">&larr; Back to study guides</a></div>';
       }
+
+      // Switching reviewer mid-session reloads, which re-runs the prompt
+      // (pre-filled with the current code) so progress stays unambiguous.
+      var chip = document.getElementById('reviewer-chip');
+      function showChip(code) {
+        if (!chip) return;
+        chip.textContent = 'Reviewing: ' + code;
+        chip.hidden = false;
+        chip.onclick = function () { location.reload(); };
+      }
+
       var slug = new URLSearchParams(location.search).get('m');
       var manifest = window.MCQ_MANIFEST || [];
       var entry = manifest.filter(function (m) { return m.slug === slug; })[0];
@@ -71,7 +86,10 @@
         var mod = window.__MCQ_MODULE;
         try { delete window.__MCQ_MODULE; } catch (e) { window.__MCQ_MODULE = undefined; }
         if (!mod) { notice('Module failed to load', 'The data for “' + entry.title + '” did not register correctly.'); return; }
-        window.mountMCQ(root, mod, entry);
+        window.MCQReviewer.ask({ title: 'Who is reviewing?' }).then(function (code) {
+          showChip(code);
+          window.mountMCQ(root, mod, entry, code);
+        });
       };
       s.onerror = function () { notice('Module failed to load', 'Could not fetch the data file for “' + entry.title + '”.'); };
       document.body.appendChild(s);

--- a/mcq.html
+++ b/mcq.html
@@ -51,18 +51,37 @@
     });
   </script>
   <script src="js/mcq-manifest.js"></script>
+  <script src="js/mcq-reviewer.js"></script>
   <script>
     (function () {
       var today = new Date().toISOString().split('T')[0];
+      var reviewer = (window.MCQReviewer && MCQReviewer.current()) || 'guest';
+
       function dueCount(slug) {
         try {
-          var srs = JSON.parse(localStorage.getItem('mcq:srs:' + slug) || '{}');
+          var srs = JSON.parse(localStorage.getItem('mcq:srs:' + slug + ':' + reviewer) || '{}');
           var items = (srs && srs.items) || {};
           return Object.keys(items).filter(function (id) {
             var nr = items[id] && items[id].nextReview; return nr && nr <= today;
           }).length;
         } catch (e) { return 0; }
       }
+
+      // Reviewer control — who the due counts belong to, with a switch.
+      var sub = document.querySelector('.hub-subtitle');
+      if (sub && window.MCQReviewer) {
+        var bar = document.createElement('div');
+        bar.className = 'hub-reviewer';
+        var active = MCQReviewer.current();
+        bar.innerHTML = active
+          ? 'Reviewing as <strong>' + active + '</strong> · <button type="button" class="hub-reviewer-btn" id="reviewer-switch">change</button>'
+          : '<button type="button" class="hub-reviewer-btn" id="reviewer-switch">Set your reviewer code</button>';
+        sub.parentNode.insertBefore(bar, sub.nextSibling);
+        document.getElementById('reviewer-switch').addEventListener('click', function () {
+          MCQReviewer.ask({ title: 'Who is reviewing?' }).then(function () { location.reload(); });
+        });
+      }
+
       var wrap = document.getElementById('modules');
       (window.MCQ_MANIFEST || []).forEach(function (m) {
         var due = dueCount(m.slug);


### PR DESCRIPTION
New free-response (recall) module: "Thyroid Cancer Risk Stratification"
— a 25-card sequential self-test on the 2025 ATA operative approach,
completion thyroidectomy, histopathology, and risk stratification
(Rec 15, 16, 27, 28), with domain/concept taxonomy and controversy cards.

Engine + UX changes that support it:
- Recall cards now self-grade on a four-point scale (Didn't know /
  Guessed / Got it partially / Knew it cold) instead of binary, each
  mapped to distinct Leitner movement (reset, reset, +1 box, +2 boxes);
  keyboard 1-4 selects.
- Free-text fields (stem/answer/brief/detailed) honor `\n` as a line
  break so lists and text-tables stay readable.
- Spaced-repetition + progress are namespaced per reviewer code, so
  coresidents sharing one browser keep separate progress:
  mcq:{progress,srs}:<slug>:<code>.
- New shared js/mcq-reviewer.js prompts for a code each session (pre-
  filled with the last one) with a typo failsafe: unknown codes must be
  confirmed and the closest existing code is suggested. Hub shows the
  active reviewer and a switch; study page shows a reviewer chip.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018xjtNBfs93jCHJh7kXRuDG