### PR TITLE
Add Structural Anatomy Atlas and unify KAG data layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # Temporary Files
 *.tmp
 *.temp
+
+# Phase build scratch (shards merged into data/kag-graph.json, not committed raw)
+scratchpad*/

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn-error.log*
 
 # Phase build scratch (shards merged into data/kag-graph.json, not committed raw)
 scratchpad*/
+
+# Agent working directories (in-repo scratchpads)
+scratchpad_p*/

--- a/README.md
+++ b/README.md
@@ -61,10 +61,14 @@ tokens. Retheming or adding a style is a localized edit. Switching is driven by
 │   ├── oksat-atlas.js      # Atlas graph view (Cytoscape)
 │   ├── oksat-db.js         # Completion database read/merge/export/push
 │   ├── oksat-ai.js         # Gemini key mgmt + house-style question generation
+│   ├── kag-store.js        # KAG database read/merge/save/download/push (LOCAL WINS)
 │   └── mcq-modules/        # Question banks (one file per module)
 ├── data/oksat-db.json      # Shared per-reviewer completion database (dated entries)
+├── data/kag-graph.json     # Canonical KAG database (term web + structural atlas source)
 ├── kag.html                # Tool: Knowledge Atlas Graph
+├── atlas.html              # Tool: Structural anatomy atlas (filtered view of the KAG)
 ├── kag-extract.html        # Tool: KAG extractor
+├── tools/kag-validate.mjs  # Dev-only KAG shard validator + merger (Node, not shipped)
 ├── cpt-search.html         # Tool: CPT code search
 ├── ascii-editor.html       # Tool: ASCII/Unicode diagram editor
 ├── airway-jeopardy.html    # Tool: Airway Rounds team quiz
@@ -73,6 +77,9 @@ tokens. Retheming or adding a style is a localized edit. Switching is driven by
 ├── oksat-generate.html     # Tool: OKSAT Question Forge (Gemini)
 ├── mcq.html / mcq-study.html  # Redirect stubs to the OKSAT pages
 ├── docs/authoring-oksat.md # How to add / author an OKSAT module
+├── docs/authoring-kag.md   # How to author / enrich KAG nodes + edges (shards + validator)
+├── docs/kag-schema.md      # KAG v2 data model, enums, storage/merge contract
+├── docs/oto-kag-atlas-plan.md  # KAG term web + anatomy atlas master plan
 ├── docs/design-principles.md  # OKSAT design system
 ├── docs/oksat-plan.md      # OKSAT redesign plan / architecture
 ├── images/                 # Profile photo + derived hero/social crops (see images/list.txt)

--- a/WIP.md
+++ b/WIP.md
@@ -59,3 +59,39 @@ Gemini-powered question generator. Full plan: `docs/oksat-plan.md`.
 ## Next Steps
 Generate the first Forge module end-to-end with a real key; consider merging
 KAG node data into the Atlas (both are Cytoscape element models).
+
+---
+
+# WIP — KAG term web + structural anatomy atlas
+
+## Goal
+Turn the KAG from a 40-node localStorage seed into the site's canonical,
+committed knowledge graph, grown into a massive OHNS term web and wired
+bidirectionally to OKSAT. Full plan: `docs/oto-kag-atlas-plan.md`.
+
+## Actions Taken
+1. **Externalized the KAG** to a committed file `data/kag-graph.json`
+   (schema v2), read through a new store `js/kag-store.js` (fetch + merge where
+   LOCAL WINS on progress, download / Contents-API push write paths). `kag.html`
+   now boots from the store; `SEED_GRAPH` remains only as an offline fallback.
+2. **Schema v2 + bidirectional OKSAT↔KAG links** — nodes carry `oksat.{modules,
+   concepts,topics}`; concept links resolve to real module CONCEPTS keys.
+   `?node=<id>` deep links tie the graphs together both ways.
+3. **Term web** — expanded to ~656 nodes / ~929 edges across all 9
+   subspecialties, fanned out one authoring agent per subspecialty, each shard
+   validated + merged via `tools/kag-validate.mjs`.
+4. **Structural anatomy atlas** — new `atlas.html`, a filtered *view* of the KAG
+   (265 structural nodes, colored by `structure`, grouped by `region`); holds no
+   data of its own, so a new structural node appears with zero atlas-code
+   changes. Spatial seed (`laterality`, edge `direction`) captured for a future
+   3D layer.
+5. **Docs** — `docs/kag-schema.md` (v2 model + enums + merge contract),
+   `docs/authoring-kag.md` (shard/validator authoring contract).
+
+All authored (non-seed) content is DRAFT / `review:false`; only the vetted
+40-node temporal-bone seed is `review:true`.
+
+## Next Steps
+Owner (resident) curated-source verification pass over the `review:false` nodes
+to graduate DRAFT content. Phase 3 usage analytics is deferred (owner call,
+2026-07 — not needed for now).

--- a/airway-jeopardy.html
+++ b/airway-jeopardy.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Airway Rounds · Clinical Quiz | skflx.MD</title>
   <meta name="description" content="Team-based ENT/Head & Neck airway quiz game for nursing education. Topics, difficulty filters, steal mechanic, session history.">
+  <script>(function(){try{var t=localStorage.getItem('sk_theme');if(!t)t='light';document.documentElement.setAttribute('data-theme',t);}catch(e){document.documentElement.setAttribute('data-theme','light');}})();</script>
+  <link rel="stylesheet" href="css/site.css">
 
   <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
@@ -23,15 +25,23 @@
       color: #64748b; text-decoration: none;
     }
     #back-nav:hover { color: #e2e8f0; }
-    #root { padding-top: 34px; min-height: 100vh; }
+    #root { padding-top: 0; min-height: 100vh; }
     select option { background: #1e293b; color: #e2e8f0; }
   </style>
 </head>
 <body>
-  <a id="back-nav" href="index.html">
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
-    skflx.MD
-  </a>
+  <div class="site-topbar">
+    <a class="site-wordmark" href="index.html">skflx.MD</a>
+    <span class="site-topbar-title">Airway Rounds</span>
+    <span class="site-topbar-spacer"></span>
+    <div class="site-topbar-actions">
+      <a class="site-navlink" href="index.html">Home</a>
+      <button class="site-theme-toggle" type="button" aria-label="Toggle day / night">
+        <svg class="i-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        <svg class="i-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
+      </button>
+    </div>
+  </div>
   <div id="root"></div>
 
   <script type="text/babel" data-presets="react">
@@ -949,5 +959,6 @@
 
     ReactDOM.createRoot(document.getElementById('root')).render(<App />);
   </script>
+  <script src="js/site.js"></script>
 </body>
 </html>

--- a/ascii-editor.html
+++ b/ascii-editor.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ASCII Art Editor | skflx.MD</title>
     <meta name="description" content="Browser-based ASCII and Unicode diagram editor. Draw boxes, lines, arrows, and diagrams with Unicode box-drawing characters.">
+    <script>(function(){try{var t=localStorage.getItem('sk_theme');if(!t)t='light';document.documentElement.setAttribute('data-theme',t);}catch(e){document.documentElement.setAttribute('data-theme','light');}})();</script>
+    <link rel="stylesheet" href="css/site.css">
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -397,8 +399,9 @@
 <div class="editor-shell">
 
     <!-- ── Top Bar ──────────────────────────────────────── -->
-    <div class="topbar">
-        <span class="topbar-brand"><a href="index.html#work"><i class="fas fa-arrow-left" style="font-size:0.8rem;margin-right:0.25rem;"></i>ASCII Editor</a></span>
+    <div class="site-topbar">
+        <a class="site-wordmark" href="index.html">skflx.MD</a>
+        <span class="site-topbar-title">ASCII Editor</span>
         <div class="topbar-sep"></div>
 
         <!-- Edit actions -->
@@ -421,13 +424,22 @@
         <!-- Clear -->
         <button class="tb-btn" id="btn-clear" title="Clear canvas"><i class="fas fa-trash-alt"></i> Clear</button>
 
-        <div class="topbar-spacer"></div>
+        <span class="site-topbar-spacer"></span>
 
-        <!-- Dark mode -->
-        <button class="tb-btn" id="btn-theme" title="Toggle dark mode"><i class="fas fa-moon"></i></button>
+        <div class="site-topbar-actions">
+            <a class="site-navlink" href="index.html">Home</a>
 
-        <!-- Export -->
-        <button class="tb-btn" id="btn-export" title="Export / Copy"><i class="fas fa-download"></i> Export</button>
+            <!-- Dark mode (editor re-render) -->
+            <button class="site-btn site-btn-sm" id="btn-theme" title="Toggle dark mode" type="button"><i class="fas fa-moon"></i></button>
+
+            <!-- Export -->
+            <button class="site-btn site-btn-sm" id="btn-export" title="Export / Copy" type="button"><i class="fas fa-download"></i> Export</button>
+
+            <button class="site-theme-toggle" type="button" aria-label="Toggle day / night">
+                <svg class="i-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                <svg class="i-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
+            </button>
+        </div>
     </div>
 
     <!-- ── Main ─────────────────────────────────────────── -->
@@ -1256,5 +1268,6 @@
 
 })();
 </script>
+<script src="js/site.js"></script>
 </body>
 </html>

--- a/atlas.html
+++ b/atlas.html
@@ -386,6 +386,14 @@
             background: var(--hover)
         }
 
+        .rp-edge-ext {
+            text-decoration: none
+        }
+
+        .rp-edge-ext .rp-edge-target {
+            color: #4A9EFF
+        }
+
         .rp-edge-target {
             color: var(--txt)
         }
@@ -638,6 +646,8 @@
             let STRUCT_NODES = [];          // structural nodes only
             let STRUCT_EDGES = [];          // edges with both endpoints structural
             let nodeById = {};              // id -> structural node
+            let allNodeById = {};           // id -> ANY node (for non-structural relationship targets, e.g. transmitted nerves)
+            let ALL_EDGES = [];             // every edge (so the panel can show transmits→nerve, supplies→vessel, etc.)
             let cy = null;
             let activeStructures = new Set([...DEFAULT_ON]);   // which classes are shown
             let activeRegions = new Set();                     // empty = All
@@ -831,16 +841,20 @@
                         '<div class="rp-detail">' + escHtml(node.detail) + '</div></div>';
                 }
 
-                // Grouped relationships (structural neighbors only, so each item is clickable in-atlas)
+                // Grouped relationships from ALL edges. Structural targets are clickable
+                // in-atlas; non-structural targets (e.g. a nerve a foramen transmits) link
+                // out to the KAG so relationships like "Transmits → CN V3" are never hidden.
                 const groups = {};
-                STRUCT_EDGES.forEach(e => {
+                ALL_EDGES.forEach(e => {
                     if (e.source !== nodeId && e.target !== nodeId) return;
                     const outgoing = e.source === nodeId;
                     const otherId = outgoing ? e.target : e.source;
-                    if (!nodeById[otherId]) return;
+                    const other = allNodeById[otherId];
+                    if (!other) return;
                     const heading = EDGE_HEADINGS[e.type] ? e.type : 'Related';
                     (groups[heading] = groups[heading] || []).push({
-                        otherId, outgoing, direction: e.direction || '', type: e.type
+                        otherId, outgoing, direction: e.direction || '', type: e.type,
+                        label: other.label || otherId, structural: !!nodeById[otherId]
                     });
                 });
                 const orderedKeys = HEADING_ORDER.filter(k => groups[k]);
@@ -849,12 +863,15 @@
                     const title = EDGE_HEADINGS[k] || 'Related';
                     html += '<div class="rp-section"><div class="rp-section-title">' + escHtml(title) + '</div>';
                     groups[k].forEach(item => {
-                        const other = nodeById[item.otherId];
                         const arrow = item.outgoing ? '→' : '←';
-                        html += '<div class="rp-edge" data-node="' + escHtml(item.otherId) + '">' +
-                            '<span class="rp-edge-target">' + arrow + ' ' + escHtml(other ? other.label : item.otherId) + '</span>' +
-                            (item.direction ? '<span class="rp-edge-dir">' + escHtml(item.direction) + '</span>' : '') +
-                            '</div>';
+                        const dir = item.direction ? '<span class="rp-edge-dir">' + escHtml(item.direction) + '</span>' : '';
+                        if (item.structural) {
+                            html += '<div class="rp-edge" data-node="' + escHtml(item.otherId) + '">' +
+                                '<span class="rp-edge-target">' + arrow + ' ' + escHtml(item.label) + '</span>' + dir + '</div>';
+                        } else {
+                            html += '<a class="rp-edge rp-edge-ext" href="kag.html?node=' + encodeURIComponent(item.otherId) + '">' +
+                                '<span class="rp-edge-target">' + arrow + ' ' + escHtml(item.label) + ' ↗</span>' + dir + '</a>';
+                        }
                     });
                     html += '</div>';
                 });
@@ -884,7 +901,7 @@
                 rpBody.innerHTML = html;
                 rightPanel.classList.add('open');
 
-                rpBody.querySelectorAll('.rp-edge').forEach(el => {
+                rpBody.querySelectorAll('.rp-edge[data-node]').forEach(el => {
                     el.addEventListener('click', () => focusNode(el.dataset.node, true));
                 });
             }
@@ -926,6 +943,11 @@
                 STRUCT_NODES.forEach(n => { nodeById[n.id] = n; });
                 const shownIds = new Set(STRUCT_NODES.map(n => n.id));
                 STRUCT_EDGES = (graph.edges || []).filter(e => e && shownIds.has(e.source) && shownIds.has(e.target));
+                // Full-graph indexes so the detail panel can surface relationships to
+                // non-structural nodes (nerves/vessels a foramen transmits, etc.).
+                allNodeById = {};
+                graph.nodes.forEach(n => { if (n && n.id) allNodeById[n.id] = n; });
+                ALL_EDGES = graph.edges || [];
 
                 if (STRUCT_NODES.length === 0) { showEmpty(); return; }
 

--- a/atlas.html
+++ b/atlas.html
@@ -1,0 +1,961 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Structural Anatomy Atlas — KAG | skflx.MD</title>
+    <meta name="description" content="Draft structural-anatomy view over the OHNS Knowledge Atlas Graph. Bones, cartilage, ligaments, spaces and more — auto-generated from the KAG.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+        href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;600&display=swap"
+        rel="stylesheet">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.28.1/cytoscape.min.js"></script>
+    <!-- cose-bilkent's plain-script build expects layoutBase + coseBase globals -->
+    <script src="https://unpkg.com/layout-base@1.0.2/layout-base.js"></script>
+    <script src="https://unpkg.com/cose-base@1.0.3/cose-base.js"></script>
+    <script src="https://unpkg.com/cytoscape-cose-bilkent@4.1.0/cytoscape-cose-bilkent.js"></script>
+    <script src="js/oksat-manifest.js"></script>
+    <script src="js/kag-store.js"></script>
+    <style>
+        *,
+        *::before,
+        *::after {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0
+        }
+
+        :root {
+            --bg: #0D0F14;
+            --surface: #161920;
+            --elevated: #1E2029;
+            --hover: #262833;
+            --border: #2A2D3A;
+            --border-focus: #4A9EFF;
+            --accent: #4A9EFF;
+            --txt: #E8EAF0;
+            --txt2: #9CA3B0;
+            --txt3: #5C6370;
+            --font: 'IBM Plex Sans', sans-serif;
+            --mono: 'JetBrains Mono', monospace;
+            --rad: 8px;
+            --rad-lg: 12px;
+            --tr: 200ms ease;
+            /* Structure hues — legible on dark bg */
+            --s-bone: #E8D9B5;
+            --s-cartilage: #4A9EFF;
+            --s-ligament: #51CF66;
+            --s-fascia: #CC5DE8;
+            --s-joint: #FF922B;
+            --s-foramen: #FF6B6B;
+            --s-space: #868E96;
+            --s-membrane: #20C4B5;
+            --s-muscle: #C4614A;
+        }
+
+        html,
+        body {
+            height: 100%;
+            overflow: hidden
+        }
+
+        body {
+            font-family: var(--font);
+            background: var(--bg);
+            color: var(--txt);
+            display: flex;
+            flex-direction: column;
+            -webkit-font-smoothing: antialiased
+        }
+
+        body::before {
+            content: '';
+            position: fixed;
+            inset: 0;
+            pointer-events: none;
+            z-index: 0;
+            background-image: linear-gradient(rgba(74, 158, 255, 0.02) 1px, transparent 1px), linear-gradient(90deg, rgba(74, 158, 255, 0.02) 1px, transparent 1px);
+            background-size: 40px 40px
+        }
+
+        /* ── Topbar ─────────────────────────────── */
+        .topbar {
+            background: var(--surface);
+            border-bottom: 1px solid var(--border);
+            padding: 0 1rem;
+            height: 48px;
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            z-index: 20;
+            position: relative;
+            flex-shrink: 0
+        }
+
+        .logo {
+            font-family: var(--mono);
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: var(--accent);
+            text-decoration: none;
+            letter-spacing: -0.02em;
+            margin-right: 0.25rem
+        }
+
+        .draft-tag {
+            font-size: 0.6rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--s-joint);
+            border: 1px solid rgba(255, 146, 43, 0.4);
+            background: rgba(255, 146, 43, 0.1);
+            padding: 2px 7px;
+            border-radius: 10px;
+            margin-right: 0.5rem;
+            white-space: nowrap
+        }
+
+        .search-box {
+            position: relative;
+            margin-left: auto
+        }
+
+        .search-box input {
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: var(--rad);
+            color: var(--txt);
+            font-family: var(--font);
+            font-size: 0.8rem;
+            padding: 6px 10px 6px 28px;
+            width: 200px;
+            outline: none;
+            transition: border-color var(--tr)
+        }
+
+        .search-box input:focus {
+            border-color: var(--border-focus)
+        }
+
+        .search-box svg {
+            position: absolute;
+            left: 8px;
+            top: 50%;
+            transform: translateY(-50%);
+            width: 14px;
+            height: 14px;
+            color: var(--txt3);
+            pointer-events: none
+        }
+
+        .nav-link {
+            color: var(--txt3);
+            text-decoration: none;
+            font-size: 0.75rem;
+            padding: 4px 8px;
+            border-radius: var(--rad);
+            transition: all var(--tr)
+        }
+
+        .nav-link:hover {
+            color: var(--txt);
+            background: var(--hover)
+        }
+
+        /* ── Control bars ───────────────────────── */
+        .controlbar {
+            background: var(--surface);
+            border-bottom: 1px solid var(--border);
+            padding: 6px 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+            z-index: 18;
+            position: relative;
+            flex-shrink: 0
+        }
+
+        .ctrl-label {
+            font-size: 0.6rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: var(--txt3);
+            margin-right: 2px;
+            white-space: nowrap
+        }
+
+        .pill {
+            font-size: 0.68rem;
+            padding: 4px 10px;
+            border-radius: 20px;
+            border: 1px solid var(--border);
+            background: transparent;
+            color: var(--txt2);
+            cursor: pointer;
+            font-family: var(--font);
+            transition: all var(--tr);
+            white-space: nowrap;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px
+        }
+
+        .pill:hover {
+            border-color: var(--txt3);
+            color: var(--txt)
+        }
+
+        .pill.active {
+            background: var(--accent);
+            border-color: var(--accent);
+            color: #fff
+        }
+
+        /* structure toggle: colored dot doubles as legend swatch */
+        .swatch {
+            width: 9px;
+            height: 9px;
+            border-radius: 50%;
+            flex-shrink: 0;
+            display: inline-block
+        }
+
+        .struct-pill.off {
+            opacity: 0.45;
+            text-decoration: line-through
+        }
+
+        .struct-pill.on {
+            border-color: var(--txt3);
+            color: var(--txt)
+        }
+
+        /* ── Main area ──────────────────────────── */
+        .main-area {
+            flex: 1;
+            display: flex;
+            position: relative;
+            overflow: hidden;
+            z-index: 1
+        }
+
+        #cy {
+            flex: 1;
+            background: var(--bg)
+        }
+
+        .empty-state {
+            position: absolute;
+            inset: 0;
+            display: none;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            padding: 2rem;
+            gap: 0.5rem;
+            z-index: 5
+        }
+
+        .empty-state.show {
+            display: flex
+        }
+
+        .empty-state h2 {
+            font-size: 1.1rem;
+            font-weight: 600
+        }
+
+        .empty-state p {
+            font-size: 0.85rem;
+            color: var(--txt3);
+            max-width: 420px;
+            line-height: 1.6
+        }
+
+        /* ── Right panel ────────────────────────── */
+        .right-panel {
+            width: 380px;
+            background: var(--surface);
+            border-left: 1px solid var(--border);
+            display: flex;
+            flex-direction: column;
+            transform: translateX(100%);
+            transition: transform var(--tr);
+            position: absolute;
+            right: 0;
+            top: 0;
+            bottom: 0;
+            z-index: 15;
+            overflow: hidden
+        }
+
+        .right-panel.open {
+            transform: translateX(0)
+        }
+
+        .rp-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 1rem;
+            border-bottom: 1px solid var(--border);
+            flex-shrink: 0
+        }
+
+        .rp-close {
+            background: none;
+            border: none;
+            color: var(--txt3);
+            cursor: pointer;
+            padding: 4px
+        }
+
+        .rp-close:hover {
+            color: var(--txt)
+        }
+
+        .rp-body {
+            flex: 1;
+            overflow-y: auto;
+            padding: 1rem
+        }
+
+        .rp-label {
+            font-size: 1.2rem;
+            font-weight: 600;
+            font-family: var(--mono)
+        }
+
+        .badge {
+            display: inline-block;
+            font-size: 0.65rem;
+            font-weight: 600;
+            padding: 2px 8px;
+            border-radius: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            margin: 0 4px 4px 0
+        }
+
+        .badge-struct {
+            color: #0D0F14
+        }
+
+        .badge-sub {
+            background: var(--hover);
+            color: var(--txt2)
+        }
+
+        .rp-section {
+            margin-top: 1rem
+        }
+
+        .rp-section-title {
+            font-size: 0.7rem;
+            font-weight: 600;
+            color: var(--txt3);
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            margin-bottom: 0.5rem
+        }
+
+        .rp-detail {
+            font-size: 0.85rem;
+            line-height: 1.65;
+            color: var(--txt2)
+        }
+
+        .rp-edge {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 6px 8px;
+            border-radius: var(--rad);
+            cursor: pointer;
+            transition: background var(--tr);
+            font-size: 0.8rem
+        }
+
+        .rp-edge:hover {
+            background: var(--hover)
+        }
+
+        .rp-edge-target {
+            color: var(--txt)
+        }
+
+        .rp-edge-dir {
+            font-family: var(--mono);
+            font-size: 0.66rem;
+            color: var(--s-joint);
+            background: rgba(255, 146, 43, 0.12);
+            padding: 1px 6px;
+            border-radius: 8px;
+            margin-left: auto;
+            white-space: nowrap
+        }
+
+        .source-tag {
+            font-size: 0.72rem;
+            background: var(--elevated);
+            color: var(--txt2);
+            padding: 3px 8px;
+            border-radius: var(--rad);
+            display: inline-block;
+            margin: 2px
+        }
+
+        .ok-link {
+            display: inline-block;
+            margin: 3px 4px 0 0;
+            padding: 3px 10px;
+            border-radius: 999px;
+            background: rgba(74, 158, 255, 0.15);
+            color: #4A9EFF;
+            font-size: 0.72rem;
+            text-decoration: none;
+            border: 1px solid rgba(74, 158, 255, 0.35)
+        }
+
+        .ok-link:hover {
+            background: rgba(74, 158, 255, 0.28)
+        }
+
+        /* ── Bottom strip ───────────────────────── */
+        .bottom-strip {
+            background: var(--surface);
+            border-top: 1px solid var(--border);
+            min-height: 36px;
+            display: flex;
+            align-items: center;
+            padding: 0 1rem;
+            gap: 1rem;
+            flex-shrink: 0;
+            z-index: 10;
+            position: relative
+        }
+
+        .draft-note {
+            font-size: 0.7rem;
+            color: var(--txt3)
+        }
+
+        .draft-note strong {
+            color: var(--s-joint)
+        }
+
+        .node-count-info {
+            font-size: 0.72rem;
+            color: var(--txt3);
+            margin-left: auto;
+            font-family: var(--mono);
+            white-space: nowrap
+        }
+
+        /* ── Scrollbar ──────────────────────────── */
+        ::-webkit-scrollbar {
+            width: 5px
+        }
+
+        ::-webkit-scrollbar-track {
+            background: transparent
+        }
+
+        ::-webkit-scrollbar-thumb {
+            background: var(--border);
+            border-radius: 3px
+        }
+
+        ::-webkit-scrollbar-thumb:hover {
+            background: var(--txt3)
+        }
+
+        /* ── Toast ──────────────────────────────── */
+        .toast {
+            position: fixed;
+            bottom: 56px;
+            left: 50%;
+            transform: translateX(-50%) translateY(80px);
+            background: var(--elevated);
+            border: 1px solid var(--border);
+            color: var(--txt);
+            font-size: 0.78rem;
+            padding: 8px 18px;
+            border-radius: var(--rad-lg);
+            z-index: 60;
+            opacity: 0;
+            transition: all 300ms ease;
+            pointer-events: none
+        }
+
+        .toast.show {
+            transform: translateX(-50%) translateY(0);
+            opacity: 1
+        }
+
+        @media(max-width:768px) {
+            .right-panel {
+                width: 100%
+            }
+
+            .search-box input {
+                width: 130px
+            }
+
+            .draft-note {
+                display: none
+            }
+        }
+    </style>
+</head>
+
+<body>
+
+    <!-- Topbar -->
+    <div class="topbar">
+        <a href="kag.html" class="logo">KAG</a>
+        <span class="draft-tag">Atlas · Draft</span>
+        <span class="ctrl-label">Region</span>
+        <div class="controlbar" id="region-pills"
+            style="background:transparent;border:none;padding:0;flex:1;min-width:0;overflow:hidden;max-height:34px"></div>
+        <div class="search-box">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="11" cy="11" r="8" />
+                <line x1="21" y1="21" x2="16.65" y2="16.65" />
+            </svg>
+            <input type="text" id="search" placeholder="Search structures…" autocomplete="off">
+        </div>
+        <a href="kag.html" class="nav-link">Graph</a>
+        <a href="oksat.html" class="nav-link" title="OHNS Knowledge Self-Assessment Tool">OKSAT</a>
+        <a href="index.html" class="nav-link">Home</a>
+    </div>
+
+    <!-- Structure toggles + legend -->
+    <div class="controlbar">
+        <span class="ctrl-label">Structures / Legend</span>
+        <div id="struct-pills" style="display:flex;gap:6px;flex-wrap:wrap"></div>
+    </div>
+
+    <!-- Main -->
+    <div class="main-area">
+        <div id="cy"></div>
+
+        <!-- Empty-state (fallback safety) -->
+        <div class="empty-state" id="empty-state">
+            <h2>No structural data to display</h2>
+            <p id="empty-msg">The Knowledge Atlas Graph could not be loaded, or it contains no structural
+                nodes yet. This atlas is a view over <code>data/kag-graph.json</code> and holds no data of
+                its own.</p>
+        </div>
+
+        <!-- Right panel -->
+        <div class="right-panel" id="right-panel">
+            <div class="rp-header">
+                <span class="rp-label" id="rp-label"></span>
+                <button class="rp-close" id="rp-close"><svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+                        stroke="currentColor" stroke-width="2">
+                        <line x1="18" y1="6" x2="6" y2="18" />
+                        <line x1="6" y1="6" x2="18" y2="18" />
+                    </svg></button>
+            </div>
+            <div class="rp-body" id="rp-body"></div>
+        </div>
+    </div>
+
+    <!-- Bottom strip -->
+    <div class="bottom-strip">
+        <span class="draft-note"><strong>Draft structural view</strong> · auto-generated from the KAG. Spatial
+            fields (<code>laterality</code>, edge <code>direction</code>) are surfaced now for a future 3D layer —
+            3D rendering coming later.</span>
+        <span class="node-count-info" id="node-count-info"></span>
+    </div>
+
+    <!-- Toast -->
+    <div id="toast" class="toast"></div>
+
+    <script>
+        (function () {
+            'use strict';
+
+            /* ── Structural vocabulary ──────────────── */
+            // Only nodes whose `structure` is one of these are shown.
+            const STRUCTURE_META = {
+                bone: { label: 'Bone', color: '#E8D9B5' },
+                cartilage: { label: 'Cartilage', color: '#4A9EFF' },
+                ligament: { label: 'Ligament', color: '#51CF66' },
+                fascia: { label: 'Fascia', color: '#CC5DE8' },
+                joint: { label: 'Joint', color: '#FF922B' },
+                foramen: { label: 'Foramen', color: '#FF6B6B' },
+                space: { label: 'Space', color: '#868E96' },
+                membrane: { label: 'Membrane', color: '#20C4B5' },
+                muscle: { label: 'Muscle', color: '#C4614A' }
+            };
+            const STRUCTURE_KEYS = Object.keys(STRUCTURE_META);
+            // Default-ON structure classes (others toggleable but hidden at boot).
+            const DEFAULT_ON = new Set(['bone', 'cartilage', 'ligament', 'fascia', 'joint']);
+
+            // Canonical region order (only those actually present get a pill).
+            const REGION_ORDER = ['temporal-bone', 'skull-base', 'facial-skeleton', 'nasal-sinus',
+                'larynx', 'neck', 'oral-pharynx', 'cervical-spine-hyoid', 'external-ear'];
+            const REGION_LABELS = {
+                'temporal-bone': 'Temporal bone', 'skull-base': 'Skull base',
+                'facial-skeleton': 'Facial skeleton', 'nasal-sinus': 'Nasal / sinus',
+                'larynx': 'Larynx', 'neck': 'Neck', 'oral-pharynx': 'Oral / pharynx',
+                'cervical-spine-hyoid': 'Cervical spine / hyoid', 'external-ear': 'External ear'
+            };
+
+            // edge type -> friendly heading (unknown types fall to "Related")
+            const EDGE_HEADINGS = {
+                articulates_with: 'Articulates with',
+                attaches_to: 'Attaches to',
+                part_of: 'Part of',
+                bounded_by: 'Bounded by',
+                continuous_with: 'Continuous with',
+                transmits: 'Transmits',
+                passes_through: 'Passes through',
+                suspends: 'Suspends',
+                forms: 'Forms'
+            };
+            const HEADING_ORDER = ['part_of', 'articulates_with', 'attaches_to', 'bounded_by',
+                'continuous_with', 'forms', 'suspends', 'passes_through', 'transmits', 'Related'];
+
+            function escHtml(s) { return (s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
+
+            /* ── Toast ──────────────────────────────── */
+            const toastEl = document.getElementById('toast');
+            function toast(m) {
+                toastEl.textContent = m; toastEl.className = 'toast show';
+                clearTimeout(toastEl._t); toastEl._t = setTimeout(() => { toastEl.className = 'toast'; }, 2200);
+            }
+
+            /* ── State ──────────────────────────────── */
+            let STRUCT_NODES = [];          // structural nodes only
+            let STRUCT_EDGES = [];          // edges with both endpoints structural
+            let nodeById = {};              // id -> structural node
+            let cy = null;
+            let activeStructures = new Set([...DEFAULT_ON]);   // which classes are shown
+            let activeRegions = new Set();                     // empty = All
+
+            /* ── Empty-state fallback (never a blank crash) ── */
+            function showEmpty(msg) {
+                const el = document.getElementById('empty-state');
+                if (msg) document.getElementById('empty-msg').textContent = msg;
+                el.classList.add('show');
+                document.getElementById('node-count-info').textContent = '0 structures · 0 relationships';
+            }
+
+            /* ── Build cytoscape elements from active structures ── */
+            function buildElements() {
+                const shownNodes = STRUCT_NODES.filter(n => activeStructures.has(n.structure));
+                const shownIds = new Set(shownNodes.map(n => n.id));
+                const shownEdges = STRUCT_EDGES.filter(e => shownIds.has(e.source) && shownIds.has(e.target));
+                const degreeMap = {};
+                shownEdges.forEach(e => {
+                    degreeMap[e.source] = (degreeMap[e.source] || 0) + 1;
+                    degreeMap[e.target] = (degreeMap[e.target] || 0) + 1;
+                });
+                const maxDeg = Math.max(...Object.values(degreeMap), 1);
+                const nodes = shownNodes.map(n => {
+                    const deg = degreeMap[n.id] || 0;
+                    const size = 20 + Math.round((deg / maxDeg) * 40);
+                    return { data: { ...n, nodeSize: size } };
+                });
+                const edges = shownEdges.map(e => ({
+                    data: { ...e, id: e.source + '->' + e.target + '_' + e.type }
+                }));
+                return { elements: [...nodes, ...edges], count: shownNodes.length, edgeCount: shownEdges.length };
+            }
+
+            const LAYOUT = {
+                name: 'cose-bilkent', animate: false, nodeDimensionsIncludeLabels: true,
+                idealEdgeLength: 120, nodeRepulsion: 8000, gravity: 0.25, numIter: 2500
+            };
+
+            function structStyle() {
+                return STRUCTURE_KEYS.map(k => ({
+                    selector: 'node[structure="' + k + '"]',
+                    style: { 'background-color': STRUCTURE_META[k].color }
+                }));
+            }
+
+            function initCy() {
+                const built = buildElements();
+                cy = cytoscape({
+                    container: document.getElementById('cy'),
+                    elements: built.elements,
+                    style: [
+                        { selector: 'node', style: { 'label': 'data(label)', 'font-size': '10px', 'font-family': 'IBM Plex Sans, sans-serif', 'color': '#E8EAF0', 'text-valign': 'bottom', 'text-margin-y': 6, 'width': 'data(nodeSize)', 'height': 'data(nodeSize)', 'text-max-width': 100, 'text-wrap': 'ellipsis', 'border-width': 0, 'overlay-opacity': 0, 'background-color': '#868E96' } },
+                        ...structStyle(),
+                        { selector: 'edge', style: { 'line-color': '#333842', 'target-arrow-color': '#333842', 'target-arrow-shape': 'triangle', 'curve-style': 'bezier', 'width': 1.5, 'label': 'data(type)', 'font-size': '8px', 'font-family': 'JetBrains Mono, monospace', 'color': '#5C6370', 'text-rotation': 'autorotate', 'text-margin-y': -8, 'arrow-scale': 0.8 } },
+                        { selector: ':selected', style: { 'border-width': 3, 'border-color': '#fff' } },
+                        { selector: '.faded', style: { 'opacity': 0.1 } },
+                        { selector: '.highlighted', style: { 'border-width': 3, 'border-color': '#FFD43B', 'z-index': 10 } }
+                    ],
+                    layout: LAYOUT,
+                    wheelSensitivity: 0.3,
+                    minZoom: 0.15, maxZoom: 4
+                });
+
+                cy.on('tap', 'node', e => openNodePanel(e.target.id()));
+                cy.on('dbltap', 'node', e => {
+                    const n = e.target; const hood = n.neighborhood().add(n);
+                    cy.elements().addClass('faded'); hood.removeClass('faded');
+                });
+                cy.on('tap', e => {
+                    if (e.target === cy) {
+                        cy.elements().removeClass('faded highlighted');
+                        applyRegionFilter();
+                        document.getElementById('right-panel').classList.remove('open');
+                    }
+                });
+                updateCounts(built);
+            }
+
+            function rebuildCy() {
+                const built = buildElements();
+                cy.elements().remove();
+                cy.add(built.elements);
+                cy.layout(LAYOUT).run();
+                applyRegionFilter();
+                updateCounts(built);
+            }
+
+            function updateCounts(built) {
+                document.getElementById('node-count-info').textContent =
+                    built.count + ' structures · ' + built.edgeCount + ' relationships';
+            }
+
+            /* ── Region navigator (multi-select fade, like KAG pills) ── */
+            function applyRegionFilter() {
+                if (!cy) return;
+                if (activeRegions.size === 0) { cy.nodes().removeClass('faded'); return; }
+                cy.nodes().forEach(n => {
+                    if (activeRegions.has(n.data('region'))) n.removeClass('faded');
+                    else n.addClass('faded');
+                });
+            }
+
+            function buildRegionPills(presentRegions) {
+                const wrap = document.getElementById('region-pills');
+                wrap.innerHTML = '';
+                const allBtn = document.createElement('button');
+                allBtn.className = 'pill active'; allBtn.textContent = 'All';
+                allBtn.addEventListener('click', () => {
+                    activeRegions.clear();
+                    wrap.querySelectorAll('.pill').forEach(p => p.classList.remove('active'));
+                    allBtn.classList.add('active');
+                    applyRegionFilter();
+                });
+                wrap.appendChild(allBtn);
+                REGION_ORDER.filter(r => presentRegions.has(r)).forEach(r => {
+                    const b = document.createElement('button');
+                    b.className = 'pill'; b.textContent = REGION_LABELS[r] || r;
+                    b.addEventListener('click', () => {
+                        if (activeRegions.has(r)) { activeRegions.delete(r); b.classList.remove('active'); }
+                        else { activeRegions.add(r); b.classList.add('active'); }
+                        allBtn.classList.toggle('active', activeRegions.size === 0);
+                        applyRegionFilter();
+                    });
+                    wrap.appendChild(b);
+                });
+            }
+
+            /* ── Structure toggles (double as legend) ── */
+            function buildStructPills(presentStructures) {
+                const wrap = document.getElementById('struct-pills');
+                wrap.innerHTML = '';
+                STRUCTURE_KEYS.filter(k => presentStructures.has(k)).forEach(k => {
+                    const on = activeStructures.has(k);
+                    const b = document.createElement('button');
+                    b.className = 'pill struct-pill ' + (on ? 'on' : 'off');
+                    b.innerHTML = '<span class="swatch" style="background:' + STRUCTURE_META[k].color + '"></span>' +
+                        escHtml(STRUCTURE_META[k].label);
+                    b.addEventListener('click', () => {
+                        if (activeStructures.has(k)) { activeStructures.delete(k); b.className = 'pill struct-pill off'; }
+                        else { activeStructures.add(k); b.className = 'pill struct-pill on'; }
+                        rebuildCy();
+                    });
+                    wrap.appendChild(b);
+                });
+            }
+
+            /* ── Search: label OR aliases OR detail ── */
+            const searchInput = document.getElementById('search');
+            let searchTimeout;
+            searchInput.addEventListener('input', () => {
+                clearTimeout(searchTimeout);
+                searchTimeout = setTimeout(() => {
+                    if (!cy) return;
+                    const q = searchInput.value.trim().toLowerCase();
+                    cy.nodes().removeClass('highlighted faded');
+                    if (!q) { applyRegionFilter(); return; }
+                    cy.nodes().forEach(n => {
+                        const aliases = (n.data('aliases') || []).join(' ').toLowerCase();
+                        const match = (n.data('label') || '').toLowerCase().includes(q)
+                            || aliases.includes(q)
+                            || (n.data('detail') || '').toLowerCase().includes(q);
+                        if (match) n.addClass('highlighted'); else n.addClass('faded');
+                    });
+                }, 200);
+            });
+
+            /* ── Detail panel ───────────────────────── */
+            const rightPanel = document.getElementById('right-panel');
+            document.getElementById('rp-close').addEventListener('click', () => rightPanel.classList.remove('open'));
+
+            function openNodePanel(nodeId) {
+                const node = nodeById[nodeId];
+                if (!node) return;
+                document.getElementById('rp-label').textContent = node.label;
+                const meta = STRUCTURE_META[node.structure] || { label: node.structure, color: '#868E96' };
+
+                let html = '<div style="margin-bottom:0.75rem">';
+                html += '<span class="badge badge-struct" style="background:' + meta.color + '">' + escHtml(meta.label) + '</span>';
+                if (node.region) html += '<span class="badge badge-sub">' + escHtml(REGION_LABELS[node.region] || node.region) + '</span>';
+                if (node.laterality) html += '<span class="badge badge-sub">' + escHtml(node.laterality) + '</span>';
+                html += '</div>';
+
+                if (node.aliases && node.aliases.length) {
+                    html += '<div class="rp-section"><div class="rp-section-title">Also known as</div>' +
+                        '<div style="font-size:0.78rem;color:var(--txt2)">' + node.aliases.map(escHtml).join(' · ') + '</div></div>';
+                }
+
+                if (node.detail) {
+                    html += '<div class="rp-section"><div class="rp-section-title">Detail</div>' +
+                        '<div class="rp-detail">' + escHtml(node.detail) + '</div></div>';
+                }
+
+                // Grouped relationships (structural neighbors only, so each item is clickable in-atlas)
+                const groups = {};
+                STRUCT_EDGES.forEach(e => {
+                    if (e.source !== nodeId && e.target !== nodeId) return;
+                    const outgoing = e.source === nodeId;
+                    const otherId = outgoing ? e.target : e.source;
+                    if (!nodeById[otherId]) return;
+                    const heading = EDGE_HEADINGS[e.type] ? e.type : 'Related';
+                    (groups[heading] = groups[heading] || []).push({
+                        otherId, outgoing, direction: e.direction || '', type: e.type
+                    });
+                });
+                const orderedKeys = HEADING_ORDER.filter(k => groups[k]);
+                Object.keys(groups).forEach(k => { if (!orderedKeys.includes(k)) orderedKeys.push(k); });
+                orderedKeys.forEach(k => {
+                    const title = EDGE_HEADINGS[k] || 'Related';
+                    html += '<div class="rp-section"><div class="rp-section-title">' + escHtml(title) + '</div>';
+                    groups[k].forEach(item => {
+                        const other = nodeById[item.otherId];
+                        const arrow = item.outgoing ? '→' : '←';
+                        html += '<div class="rp-edge" data-node="' + escHtml(item.otherId) + '">' +
+                            '<span class="rp-edge-target">' + arrow + ' ' + escHtml(other ? other.label : item.otherId) + '</span>' +
+                            (item.direction ? '<span class="rp-edge-dir">' + escHtml(item.direction) + '</span>' : '') +
+                            '</div>';
+                    });
+                    html += '</div>';
+                });
+
+                // OKSAT practice chips + Open in KAG
+                const ok = node.oksat || {};
+                const okLinks = [];
+                (ok.concepts || []).forEach(c => {
+                    if (c && c.module && c.concept) okLinks.push({
+                        href: 'oksat-study.html?m=' + encodeURIComponent(c.module) + '&c=' + encodeURIComponent(c.concept),
+                        label: 'Practice · ' + c.concept
+                    });
+                });
+                (ok.modules || []).forEach(m => { if (m) okLinks.push({ href: 'oksat-study.html?m=' + encodeURIComponent(m), label: 'Module · ' + m }); });
+                html += '<div class="rp-section"><div class="rp-section-title">Study &amp; open</div>';
+                okLinks.forEach(l => { html += '<a class="ok-link" href="' + l.href + '">' + escHtml(l.label) + ' ↗</a>'; });
+                html += '<a class="ok-link" href="kag.html?node=' + encodeURIComponent(node.id) + '">Open in KAG ↗</a>';
+                html += '</div>';
+
+                if (node.sources && node.sources.length) {
+                    html += '<div class="rp-section"><div class="rp-section-title">Sources</div>';
+                    node.sources.forEach(s => { html += '<span class="source-tag">' + escHtml(s) + '</span>'; });
+                    html += '</div>';
+                }
+
+                const rpBody = document.getElementById('rp-body');
+                rpBody.innerHTML = html;
+                rightPanel.classList.add('open');
+
+                rpBody.querySelectorAll('.rp-edge').forEach(el => {
+                    el.addEventListener('click', () => focusNode(el.dataset.node, true));
+                });
+            }
+
+            /* ── Deep-link / focus: isolate neighborhood + open panel ── */
+            function focusNode(id, keepPanel) {
+                const node = nodeById[id];
+                if (!node) { toast('Unknown structure: ' + id); return; }
+                // If a hidden structure class holds this node, reveal it first.
+                if (!activeStructures.has(node.structure)) {
+                    activeStructures.add(node.structure);
+                    const built = buildElements();
+                    cy.elements().remove(); cy.add(built.elements);
+                    cy.layout(LAYOUT).run(); updateCounts(built);
+                    buildStructPills(new Set(STRUCT_NODES.map(n => n.structure)));
+                }
+                const n = cy.getElementById(id);
+                openNodePanel(id);
+                if (!n || n.empty()) return;
+                const hood = n.neighborhood().add(n);
+                cy.elements().addClass('faded');
+                hood.removeClass('faded');
+                n.select();
+                setTimeout(() => cy.animate({ fit: { eles: hood, padding: 80 } }, { duration: 400 }), 60);
+            }
+
+            function bootDeepLink() {
+                try {
+                    const id = new URLSearchParams(location.search).get('node');
+                    if (id && nodeById[id]) focusNode(id, true);
+                } catch (e) { /* no-op */ }
+            }
+
+            /* ── Render (called once with merged graph) ── */
+            function render(graph) {
+                if (!graph || !Array.isArray(graph.nodes)) { showEmpty(); return; }
+                STRUCT_NODES = graph.nodes.filter(n => n && n.structure && STRUCTURE_META[n.structure]);
+                nodeById = {};
+                STRUCT_NODES.forEach(n => { nodeById[n.id] = n; });
+                const shownIds = new Set(STRUCT_NODES.map(n => n.id));
+                STRUCT_EDGES = (graph.edges || []).filter(e => e && shownIds.has(e.source) && shownIds.has(e.target));
+
+                if (STRUCT_NODES.length === 0) { showEmpty(); return; }
+
+                const presentStructures = new Set(STRUCT_NODES.map(n => n.structure));
+                const presentRegions = new Set(STRUCT_NODES.map(n => n.region).filter(Boolean));
+                // Don't leave a default-ON class active if it isn't present, and never keep an
+                // active class that has no nodes; keeps toggles honest.
+                activeStructures = new Set([...activeStructures].filter(k => presentStructures.has(k)));
+                if (activeStructures.size === 0) presentStructures.forEach(k => activeStructures.add(k));
+
+                buildStructPills(presentStructures);
+                buildRegionPills(presentRegions);
+                initCy();
+                bootDeepLink();
+            }
+
+            /* ── Boot via the store, guarded (never a blank crash) ── */
+            if (window.KAGStore && typeof KAGStore.fetch === 'function') {
+                KAGStore.fetch().then(function (file) {
+                    try { render(KAGStore.merge(file)); }
+                    catch (e) { showEmpty('Could not render the structural atlas: ' + (e && e.message ? e.message : e)); }
+                }).catch(function () {
+                    showEmpty('The Knowledge Atlas Graph could not be loaded.');
+                });
+            } else {
+                showEmpty('Data layer (KAGStore) is unavailable — cannot load data/kag-graph.json.');
+            }
+
+        })();
+    </script>
+</body>
+
+</html>

--- a/atlas.html
+++ b/atlas.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Structural Anatomy Atlas — KAG | skflx.MD</title>
     <meta name="description" content="Draft structural-anatomy view over the OHNS Knowledge Atlas Graph. Bones, cartilage, ligaments, spaces and more — auto-generated from the KAG.">
+    <script>(function(){try{var t=localStorage.getItem('sk_theme');if(!t)t='dark';document.documentElement.setAttribute('data-theme',t);}catch(e){document.documentElement.setAttribute('data-theme','dark');}})();</script>
+    <link rel="stylesheet" href="css/site.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link
@@ -526,8 +528,9 @@
 <body>
 
     <!-- Topbar -->
-    <div class="topbar">
-        <a href="kag.html" class="logo">KAG</a>
+    <div class="site-topbar">
+        <a class="site-wordmark" href="index.html">skflx.MD</a>
+        <span class="site-topbar-title">Structural Anatomy Atlas</span>
         <span class="draft-tag">Atlas · Draft</span>
         <span class="ctrl-label">Region</span>
         <div class="controlbar" id="region-pills"
@@ -539,9 +542,16 @@
             </svg>
             <input type="text" id="search" placeholder="Search structures…" autocomplete="off">
         </div>
-        <a href="kag.html" class="nav-link">Graph</a>
-        <a href="oksat.html" class="nav-link" title="OHNS Knowledge Self-Assessment Tool">OKSAT</a>
-        <a href="index.html" class="nav-link">Home</a>
+        <span class="site-topbar-spacer"></span>
+        <div class="site-topbar-actions">
+            <a class="site-navlink" href="kag.html">Graph</a>
+            <a class="site-navlink" href="oksat.html" title="OHNS Knowledge Self-Assessment Tool">OKSAT</a>
+            <a class="site-navlink" href="index.html">Home</a>
+            <button class="site-theme-toggle" type="button" aria-label="Toggle day / night">
+                <svg class="i-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                <svg class="i-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
+            </button>
+        </div>
     </div>
 
     <!-- Structure toggles + legend -->
@@ -978,6 +988,7 @@
 
         })();
     </script>
+    <script src="js/site.js"></script>
 </body>
 
 </html>

--- a/cpt-search.html
+++ b/cpt-search.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CPT Code Search | skflx.MD</title>
     <meta name="description" content="Fast surgical CPT code lookup for otolaryngology residents.">
+    <script>(function(){try{var t=localStorage.getItem('sk_theme');if(!t)t='light';document.documentElement.setAttribute('data-theme',t);}catch(e){document.documentElement.setAttribute('data-theme','light');}})();</script>
+    <link rel="stylesheet" href="css/site.css">
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -238,33 +240,20 @@
 </head>
 <body>
     <!-- Header -->
-    <header class="header">
-        <div class="container">
-            <div class="header-inner">
-                <a href="index.html" class="logo">skflx.MD</a>
-                <nav class="nav">
-                    <ul class="nav-links">
-                        <li><a href="index.html">Home</a></li>
-                        <li><a href="index.html#work">Projects</a></li>
-                        <li><a href="index.html#connect">Contact</a></li>
-                    </ul>
-                    <button class="theme-toggle" aria-label="Toggle dark mode">
-                        <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
-                        </svg>
-                        <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>
-                        </svg>
-                    </button>
-                    <button class="mobile-menu-btn" aria-label="Toggle menu">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
-                        </svg>
-                    </button>
-                </nav>
-            </div>
+    <div class="site-topbar">
+        <a class="site-wordmark" href="index.html">skflx.MD</a>
+        <span class="site-topbar-title">CPT Code Search</span>
+        <span class="site-topbar-spacer"></span>
+        <div class="site-topbar-actions">
+            <a class="site-navlink" href="index.html">Home</a>
+            <a class="site-navlink" href="index.html#work">Projects</a>
+            <a class="site-navlink" href="index.html#connect">Contact</a>
+            <button class="site-theme-toggle" type="button" aria-label="Toggle day / night">
+                <svg class="i-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                <svg class="i-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
+            </button>
         </div>
-    </header>
+    </div>
 
     <!-- Page header -->
     <section class="section">
@@ -872,5 +861,6 @@
         input.focus();
     }());
     </script>
+    <script src="js/site.js"></script>
 </body>
 </html>

--- a/css/site.css
+++ b/css/site.css
@@ -1,0 +1,188 @@
+/* =============================================================
+   site.css — shared, site-wide design layer for skflx.MD
+   One palette across every tool. Mirrors the mature OKSAT
+   reference (css/oksat.css): the --ok-* tokens, warm cream light +
+   warm dark, light/dark via html[data-theme], token-only components.
+   Theme is read from localStorage 'sk_theme' (same key OKSAT uses)
+   by a pre-paint inline script on each page, with a
+   prefers-color-scheme fallback. Components are prefixed .site-*
+   and consume ONLY tokens, so a retheme is a one-block edit.
+   ============================================================= */
+
+/* ===== TOKENS ===== */
+:root {
+  --ok-radius: 12px;
+  --ok-radius-lg: 14px;
+  --ok-font-display: 'Fraunces', Georgia, serif;
+  --ok-font-body: 'Crimson Pro', Georgia, serif;
+  --ok-font-ui: system-ui, -apple-system, sans-serif;
+}
+
+html[data-theme="light"] {
+  --ok-bg: #FAF6EE;
+  --ok-surface: #FFFFFF;
+  --ok-border: #E8DFD0;
+  --ok-border-soft: #F0E8D7;
+  --ok-text: #2A241D;
+  --ok-text-muted: #6B5F4F;
+  --ok-text-faint: #8A7C66;
+  --ok-accent: #2C5454;
+  --ok-accent-soft: #3D6B6B;
+  --ok-ochre: #9C7A45;
+  --ok-correct: #4F7042;
+  --ok-correct-bg: #EAEFDA;
+  --ok-incorrect: #9A4537;
+  --ok-incorrect-bg: #F4DDD3;
+  --ok-glow: rgba(176, 141, 87, 0.06);
+  --ok-shadow: 0 1px 3px rgba(42, 36, 29, 0.04);
+  --ok-shadow-hover: 0 4px 12px rgba(42, 36, 29, 0.08);
+  color-scheme: light;
+}
+
+html[data-theme="dark"] {
+  --ok-bg: #1B1813;
+  --ok-surface: #242019;
+  --ok-border: #3A3226;
+  --ok-border-soft: #2F2920;
+  --ok-text: #F1E7D8;
+  --ok-text-muted: #B6A48D;
+  --ok-text-faint: #8A7C68;
+  --ok-accent: #5FA3A3;
+  --ok-accent-soft: #7FB8B8;
+  --ok-ochre: #D6AC63;
+  --ok-correct: #9FBF7E;
+  --ok-correct-bg: #2A3320;
+  --ok-incorrect: #DD9683;
+  --ok-incorrect-bg: #3A241E;
+  --ok-glow: rgba(214, 172, 99, 0.05);
+  --ok-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  --ok-shadow-hover: 0 6px 18px rgba(0, 0, 0, 0.45);
+  color-scheme: dark;
+}
+
+/* Fallback for pages that reach paint before data-theme is set. */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --ok-bg: #1B1813; --ok-surface: #242019; --ok-border: #3A3226; --ok-border-soft: #2F2920;
+    --ok-text: #F1E7D8; --ok-text-muted: #B6A48D; --ok-text-faint: #8A7C68;
+    --ok-accent: #5FA3A3; --ok-ochre: #D6AC63; --ok-correct: #9FBF7E; --ok-incorrect: #DD9683;
+    --ok-border-soft: #2F2920; --ok-shadow: 0 1px 3px rgba(0,0,0,0.3); --ok-shadow-hover: 0 6px 18px rgba(0,0,0,0.45);
+    color-scheme: dark;
+  }
+}
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) {
+    --ok-bg: #FAF6EE; --ok-surface: #FFFFFF; --ok-border: #E8DFD0; --ok-border-soft: #F0E8D7;
+    --ok-text: #2A241D; --ok-text-muted: #6B5F4F; --ok-text-faint: #8A7C66;
+    --ok-accent: #2C5454; --ok-ochre: #9C7A45; --ok-correct: #4F7042; --ok-incorrect: #9A4537;
+    --ok-shadow: 0 1px 3px rgba(42,36,29,0.04); --ok-shadow-hover: 0 4px 12px rgba(42,36,29,0.08);
+    color-scheme: light;
+  }
+}
+
+/* ===== BASE TYPOGRAPHY / LINKS / FOCUS ===== */
+.site-scope, body.site-body {
+  font-family: var(--ok-font-body);
+}
+a { color: var(--ok-accent); text-decoration: none; }
+a:hover { color: var(--ok-accent-soft); }
+
+:focus-visible {
+  outline: 2px solid var(--ok-accent);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+/* ===== SHARED TOP BAR ===== */
+.site-topbar {
+  position: sticky; top: 0; z-index: 50;
+  display: flex; align-items: center; gap: 0.75rem;
+  padding: 0.4rem 1.1rem; min-height: 48px;
+  background: color-mix(in srgb, var(--ok-bg) 90%, transparent);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--ok-border);
+  font-family: var(--ok-font-ui); font-size: 12px;
+  flex-shrink: 0;
+}
+.site-wordmark {
+  display: inline-flex; align-items: center; gap: 0.4rem;
+  font-family: var(--ok-font-ui); font-weight: 700; font-size: 0.95rem;
+  letter-spacing: -0.02em; color: var(--ok-text); text-decoration: none;
+  flex-shrink: 0; transition: color 0.15s;
+}
+.site-wordmark:hover { color: var(--ok-accent); }
+.site-topbar-title {
+  font-family: var(--ok-font-ui); font-size: 11px; font-weight: 500;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--ok-text-faint); white-space: nowrap;
+  padding-left: 0.75rem; margin-left: 0.15rem;
+  border-left: 1px solid var(--ok-border); flex-shrink: 0;
+}
+.site-topbar-actions {
+  display: flex; align-items: center; gap: 0.5rem; margin-left: auto; flex-shrink: 0;
+}
+.site-topbar-spacer { flex: 1; min-width: 0; }
+
+.site-theme-toggle {
+  width: 30px; height: 30px; flex: none; padding: 0;
+  border: 1px solid var(--ok-border); border-radius: 50%;
+  background: var(--ok-surface); color: var(--ok-text-muted);
+  display: inline-flex; align-items: center; justify-content: center;
+  cursor: pointer; transition: all 0.2s;
+}
+.site-theme-toggle:hover { color: var(--ok-accent); border-color: var(--ok-accent); }
+.site-theme-toggle svg { width: 15px; height: 15px; }
+.site-theme-toggle .i-sun { display: none; }
+.site-theme-toggle .i-moon { display: block; }
+html[data-theme="dark"] .site-theme-toggle .i-sun { display: block; }
+html[data-theme="dark"] .site-theme-toggle .i-moon { display: none; }
+
+.site-navlink {
+  color: var(--ok-text-muted); text-decoration: none;
+  font-family: var(--ok-font-ui); font-size: 12px;
+  padding: 4px 8px; border-radius: 8px; transition: all 0.15s; white-space: nowrap;
+}
+.site-navlink:hover { color: var(--ok-text); background: var(--ok-border-soft); }
+
+/* ===== BUTTONS ===== */
+.site-btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 0.4rem;
+  font-family: var(--ok-font-ui); font-size: 0.8rem; font-weight: 600;
+  padding: 0.5rem 1rem; border-radius: var(--ok-radius);
+  background: var(--ok-surface); border: 1px solid var(--ok-border); color: var(--ok-text);
+  cursor: pointer; transition: all 0.18s;
+}
+.site-btn:hover { border-color: var(--ok-accent); color: var(--ok-accent); }
+.site-btn:active { transform: scale(0.985); }
+.site-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.site-btn-primary {
+  background: var(--ok-accent); border-color: var(--ok-accent); color: var(--ok-surface);
+}
+.site-btn-primary:hover { background: var(--ok-accent-soft); border-color: var(--ok-accent-soft); color: var(--ok-surface); }
+.site-btn-sm { padding: 0.35rem 0.7rem; font-size: 0.72rem; border-radius: 8px; }
+
+/* ===== PILL ===== */
+.site-pill {
+  font-family: var(--ok-font-ui); font-size: 0.68rem; font-weight: 500;
+  padding: 4px 10px; border-radius: 999px;
+  border: 1px solid var(--ok-border); background: transparent; color: var(--ok-text-muted);
+  cursor: pointer; white-space: nowrap; transition: all 0.15s;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.site-pill:hover { border-color: var(--ok-text-faint); color: var(--ok-text); }
+.site-pill.active {
+  background: var(--ok-accent); border-color: var(--ok-accent); color: var(--ok-surface);
+}
+
+/* ===== CARD ===== */
+.site-card {
+  background: var(--ok-surface); border: 1px solid var(--ok-border);
+  border-radius: var(--ok-radius-lg); box-shadow: var(--ok-shadow);
+}
+
+/* ===== REDUCED MOTION ===== */
+@media (prefers-reduced-motion: reduce) {
+  .site-topbar, .site-btn, .site-pill, .site-theme-toggle, .site-navlink, .site-wordmark {
+    transition: none !important;
+  }
+}

--- a/data/kag-graph.json
+++ b/data/kag-graph.json
@@ -1,9 +1,10 @@
 {
   "version": 2,
-  "updated": "2026-07-02T19:40:51.998Z",
-  "status": "SEED — vetted temporal-bone otology core. Authored expansion nodes (later phases) carry review:false until owner review.",
+  "updated": "2026-07-02T20:01:14.367Z",
+  "status": "DRAFT expansion — 40-node temporal-bone seed is vetted (review:true); all other nodes are subagent-authored scaffolding (review:false) pending owner stress-test against curated source text.",
   "sources": [
-    "Cummings Otolaryngology 7e"
+    "Cummings Otolaryngology 7e",
+    "AAO-HNSF Core Curriculum"
   ],
   "nodes": [
     {
@@ -1224,6 +1225,13339 @@
         "topics": []
       },
       "review": true
+    },
+    {
+      "id": "thyroid-gland",
+      "label": "Thyroid Gland",
+      "type": "anatomy",
+      "subspecialty": "endocrine",
+      "detail": "Bilobed endocrine organ overlying tracheal rings 2-4, invested by pretracheal (visceral) fascia; follicular cells make T3/T4, parafollicular C cells (neural-crest derived) make calcitonin. Descends from the foramen cecum along the thyroglossal duct.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "thyroid-nodule-bethesda-molecular",
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "recurrent-laryngeal-nerve",
+      "label": "Recurrent Laryngeal Nerve",
+      "type": "nerve",
+      "subspecialty": "endocrine",
+      "detail": "Branch of vagus supplying all intrinsic laryngeal muscles except cricothyroid; runs in the tracheoesophageal groove, ascends deep to Berry's ligament and near the inferior thyroid artery. Right loops around the subclavian, left around the aortic arch; a non-recurrent right nerve accompanies an aberrant subclavian.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "RLN",
+        "inferior laryngeal nerve"
+      ],
+      "abbrev": "RLN",
+      "structure": null,
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [
+          "dtc-risk-stratification"
+        ],
+        "concepts": [
+          {
+            "module": "dtc-risk-stratification",
+            "concept": "rln"
+          }
+        ],
+        "topics": [
+          "hyperparathyroidism",
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "superior-laryngeal-nerve-external-branch",
+      "label": "External Branch of Superior Laryngeal Nerve",
+      "type": "nerve",
+      "subspecialty": "endocrine",
+      "detail": "Motor to the cricothyroid muscle (pitch/tension); runs with the superior thyroid vessels near the upper pole. Cernea classification grades its relationship to the superior pole; injury causes voice fatigue and loss of high-pitch phonation. Protected by ligating superior pole vessels low and on the capsule.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "EBSLN"
+      ],
+      "abbrev": "EBSLN",
+      "structure": null,
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "berry-ligament",
+      "label": "Ligament of Berry",
+      "type": "anatomy",
+      "subspecialty": "endocrine",
+      "detail": "Posterior suspensory ligament tethering the thyroid lobe to the cricoid and first tracheal rings; the RLN passes immediately deep/medial to it, making this the most common site of RLN injury during thyroidectomy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "posterior suspensory ligament"
+      ],
+      "abbrev": null,
+      "structure": "ligament",
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "tubercle-of-zuckerkandl",
+      "label": "Tubercle of Zuckerkandl",
+      "type": "anatomy",
+      "subspecialty": "endocrine",
+      "detail": "Posterolateral extension of the thyroid lobe; a reliable surgical landmark—the RLN typically runs medial (deep) to it, and the superior parathyroid lies just cranial. An enlarged tubercle can splay the nerve laterally.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Zuckerkandl tubercle"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "parathyroid-glands",
+      "label": "Parathyroid Glands",
+      "type": "anatomy",
+      "subspecialty": "endocrine",
+      "detail": "Usually four glands; superior pair derive from the 4th branchial pouch (more constant, posterior at the cricothyroid junction), inferior pair from the 3rd pouch (with the thymus, more variable position). Chief cells secrete PTH.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hyperparathyroidism"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "inferior-thyroid-artery",
+      "label": "Inferior Thyroid Artery",
+      "type": "vessel",
+      "subspecialty": "endocrine",
+      "detail": "Branch of the thyrocervical trunk; the dominant blood supply to BOTH the superior and inferior parathyroid glands. Its terminal branches should be ligated on the thyroid capsule to preserve parathyroid perfusion; it has an intimate, variable relationship with the RLN.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ITA"
+      ],
+      "abbrev": "ITA",
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hyperparathyroidism"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "superior-thyroid-artery",
+      "label": "Superior Thyroid Artery",
+      "type": "vessel",
+      "subspecialty": "endocrine",
+      "detail": "First anterior branch of the external carotid; supplies the superior pole and runs adjacent to the external branch of the superior laryngeal nerve, which must be spared during upper-pole ligation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hyperparathyroidism",
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "thyroid-nodule",
+      "label": "Thyroid Nodule",
+      "type": "pathology",
+      "subspecialty": "endocrine",
+      "detail": "Very common; ~5-15% harbor malignancy. Workup starts with TSH (suppressed → radionuclide scan for autonomous/hot nodule, which rarely needs FNA) and ultrasound to assign sonographic risk before deciding on fine-needle aspiration.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "thyroid-nodule-bethesda-molecular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "fna-thyroid",
+      "label": "Thyroid Fine-Needle Aspiration",
+      "type": "procedure",
+      "subspecialty": "endocrine",
+      "detail": "Ultrasound-guided cytologic sampling; the primary triage test for suspicious nodules. Results are reported by the Bethesda System, which drives the decision between surveillance, molecular testing, or surgery.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "FNAB",
+        "FNAC"
+      ],
+      "abbrev": "FNA",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "thyroid-nodule-bethesda-molecular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "bethesda-system",
+      "label": "Bethesda System for Reporting Thyroid Cytopathology",
+      "type": "concept",
+      "subspecialty": "endocrine",
+      "detail": "Six categories with implied risk of malignancy (2023 3rd ed., ROM approx.): I Nondiagnostic (~13%, repeat FNA); II Benign (~4%); III Atypia of Undetermined Significance/AUS (~22%); IV Follicular Neoplasm (~30%); V Suspicious for Malignancy (~74%); VI Malignant (~97%). 3rd edition uses single names per category, simplifies AUS into two subgroups, and adds pediatric ROM ranges.",
+      "sources": [
+        "https://journals.sagepub.com/doi/10.1089/thy.2023.0141"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "TBSRTC",
+        "Bethesda"
+      ],
+      "abbrev": "TBSRTC",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "thyroid-nodule-bethesda-molecular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "bethesda-iii-aus",
+      "label": "Bethesda III — Atypia of Undetermined Significance",
+      "type": "concept",
+      "subspecialty": "endocrine",
+      "detail": "Indeterminate cytology (ROM ~22%). Options are repeat FNA, molecular testing (Afirma/ThyroSeq), or diagnostic lobectomy. The 2023 edition collapses prior AUS subcategories into two groups (nuclear atypia vs other) to better align with molecular profiling.",
+      "sources": [
+        "https://journals.sagepub.com/doi/10.1089/thy.2023.0141"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "AUS",
+        "FLUS"
+      ],
+      "abbrev": "AUS",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "thyroid-nodule-bethesda-molecular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "bethesda-iv-follicular-neoplasm",
+      "label": "Bethesda IV — Follicular Neoplasm",
+      "type": "concept",
+      "subspecialty": "endocrine",
+      "detail": "Indeterminate (ROM ~30%). Cytology cannot distinguish follicular adenoma from carcinoma because the diagnosis of malignancy requires capsular/vascular invasion on histology. Managed by molecular testing or diagnostic lobectomy; the Hürthle-cell pattern is now folded into this category.",
+      "sources": [
+        "https://journals.sagepub.com/doi/10.1089/thy.2023.0141"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Follicular neoplasm / suspicious for follicular neoplasm"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "thyroid-nodule-bethesda-molecular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "ti-rads",
+      "label": "ACR TI-RADS",
+      "type": "concept",
+      "subspecialty": "endocrine",
+      "detail": "Point-based sonographic risk system across five features (composition, echogenicity, shape, margin, echogenic foci). Categories TR1 (0 pts) to TR5 (≥7 pts). FNA thresholds: TR5 if ≥1 cm, TR4 if ≥1.5 cm, TR3 if ≥2.5 cm; TR1/TR2 need neither FNA nor follow-up. High-risk (+3) features include taller-than-wide shape, extrathyroidal extension, and punctate echogenic foci (microcalcifications).",
+      "sources": [
+        "https://radssupport.acr.org/support/solutions/articles/11000071474-acr-ti-rads-faq"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Thyroid Imaging Reporting and Data System"
+      ],
+      "abbrev": "TI-RADS",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "thyroid-nodule-bethesda-molecular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "afirma-gsc",
+      "label": "Afirma Genomic Sequencing Classifier",
+      "type": "concept",
+      "subspecialty": "endocrine",
+      "detail": "RNA-based rule-OUT test for Bethesda III/IV nodules; a benign result (high negative predictive value) supports surveillance and avoids diagnostic surgery. Reported sensitivity >95% with specificity ~80%; a high benign-call rate is notable for Hürthle-cell nodules. Includes add-on classifiers (e.g., medullary, BRAF).",
+      "sources": [
+        "https://academic.oup.com/jcem/article/108/9/e698/7095610"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Afirma GSC"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "dtc-risk-stratification"
+        ],
+        "concepts": [
+          {
+            "module": "dtc-risk-stratification",
+            "concept": "molecular"
+          }
+        ],
+        "topics": [
+          "thyroid-nodule-bethesda-molecular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "thyroseq-v3",
+      "label": "ThyroSeq v3",
+      "type": "concept",
+      "subspecialty": "endocrine",
+      "detail": "Next-generation-sequencing DNA/RNA panel (>110 genes) for indeterminate nodules; both rules OUT (high NPV, negative result → surveillance) and rules IN (mutations such as BRAF, RAS, TERT, RET/PAX8 inform cancer risk and extent of surgery). Sensitivity >95%, specificity ~85%; best overall AUC in comparative meta-analyses.",
+      "sources": [
+        "https://academic.oup.com/jcem/article/108/9/e698/7095610"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ThyroSeq"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "dtc-risk-stratification"
+        ],
+        "concepts": [
+          {
+            "module": "dtc-risk-stratification",
+            "concept": "molecular"
+          }
+        ],
+        "topics": [
+          "thyroid-nodule-bethesda-molecular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "niftp",
+      "label": "NIFTP",
+      "type": "pathology",
+      "subspecialty": "endocrine",
+      "detail": "Noninvasive follicular thyroid neoplasm with papillary-like nuclear features—a 2016 reclassification of the encapsulated, noninvasive follicular-variant PTC as a low-risk lesion (not carcinoma). Requires an intact capsule with no invasion; treated with lobectomy alone, no RAI. Frequently RAS-mutated.",
+      "sources": [
+        "https://journals.sagepub.com/doi/10.1089/thy.2023.0141"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "noninvasive follicular thyroid neoplasm with papillary-like nuclear features"
+      ],
+      "abbrev": "NIFTP",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "dtc-risk-stratification"
+        ],
+        "concepts": [
+          {
+            "module": "dtc-risk-stratification",
+            "concept": "niftp"
+          }
+        ],
+        "topics": [
+          "thyroid-nodule-bethesda-molecular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pth-physiology",
+      "label": "PTH Physiology & Calcium Homeostasis",
+      "type": "concept",
+      "subspecialty": "endocrine",
+      "detail": "PTH raises serum calcium: mobilizes bone Ca, increases distal-tubule Ca reabsorption while promoting phosphate excretion, and stimulates renal 1-alpha-hydroxylase to make active 1,25-vitamin D (boosting gut Ca absorption). Chief cells sense Ca via the calcium-sensing receptor (CaSR); low Ca drives secretion.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "parathyroid hormone"
+      ],
+      "abbrev": "PTH",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hyperparathyroidism"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "primary-hyperparathyroidism",
+      "label": "Primary Hyperparathyroidism",
+      "type": "pathology",
+      "subspecialty": "endocrine",
+      "detail": "Autonomous PTH excess causing HIGH calcium with high/inappropriately-normal PTH and low phosphate. ~85% single adenoma, ~15% multigland hyperplasia, <1% carcinoma. 'Stones, bones, groans, psychiatric moans'; most cases now asymptomatic on screening. Confirm with 24-hr urinary calcium to exclude FHH.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "PHPT"
+      ],
+      "abbrev": "PHPT",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hyperparathyroidism"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "secondary-hyperparathyroidism",
+      "label": "Secondary Hyperparathyroidism",
+      "type": "pathology",
+      "subspecialty": "endocrine",
+      "detail": "Compensatory PTH elevation with LOW or normal calcium, most often from chronic kidney disease (phosphate retention, low active vitamin D) or vitamin D deficiency. Treated medically (phosphate binders, calcitriol/analogs, calcimimetics) rather than surgically.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hyperparathyroidism"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "tertiary-hyperparathyroidism",
+      "label": "Tertiary Hyperparathyroidism",
+      "type": "pathology",
+      "subspecialty": "endocrine",
+      "detail": "Long-standing secondary HPT (usually post-renal-transplant) in which the glands become autonomous, producing HIGH calcium and markedly elevated PTH. Managed with subtotal (3.5-gland) or total parathyroidectomy with autotransplantation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hyperparathyroidism"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "parathyroid-adenoma",
+      "label": "Parathyroid Adenoma",
+      "type": "pathology",
+      "subspecialty": "endocrine",
+      "detail": "Benign monoclonal chief-cell tumor; the single most common cause of primary hyperparathyroidism. Preoperative localization (sestamibi ± SPECT/CT, ultrasound, or 4D-CT) enables focused minimally-invasive parathyroidectomy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hyperparathyroidism"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "familial-hypocalciuric-hypercalcemia",
+      "label": "Familial Hypocalciuric Hypercalcemia",
+      "type": "pathology",
+      "subspecialty": "endocrine",
+      "detail": "Autosomal-dominant inactivating CaSR mutation causing mild hypercalcemia with high-normal PTH but LOW urinary calcium (calcium/creatinine clearance ratio <0.01). Critical to distinguish from primary HPT because parathyroidectomy does NOT help—it is a key pre-op exclusion.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "FHH"
+      ],
+      "abbrev": "FHH",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hyperparathyroidism"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sestamibi-scan",
+      "label": "Tc-99m Sestamibi Scan",
+      "type": "procedure",
+      "subspecialty": "endocrine",
+      "detail": "Nuclear localization exploiting delayed radiotracer washout from mitochondria-rich hyperfunctioning parathyroid tissue; SPECT/CT adds anatomic detail. Best for single adenomas; sensitivity drops with multigland disease and small/ectopic glands.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "MIBI",
+        "parathyroid scintigraphy"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hyperparathyroidism"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "4d-ct-parathyroid",
+      "label": "4D-CT Parathyroid Localization",
+      "type": "procedure",
+      "subspecialty": "endocrine",
+      "detail": "Multiphase contrast CT ('4th dimension' = perfusion over time); adenomas show early arterial enhancement and rapid washout. High sensitivity, especially for reoperative or non-localizing (negative sestamibi/US) cases and ectopic glands.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "4D-CT"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hyperparathyroidism"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "parathyroidectomy",
+      "label": "Parathyroidectomy",
+      "type": "procedure",
+      "subspecialty": "endocrine",
+      "detail": "Definitive treatment for primary HPT. With positive localization and intraop PTH monitoring, a focused (minimally invasive) single-gland excision is standard; non-localizing or multigland disease warrants bilateral neck exploration. Risks: RLN injury and hypocalcemia.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hyperparathyroidism"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "intraoperative-pth-monitoring",
+      "label": "Intraoperative PTH Monitoring",
+      "type": "concept",
+      "subspecialty": "endocrine",
+      "detail": "PTH's short (~3-5 min) half-life allows real-time confirmation of cure. Miami criterion: a >50% drop from the highest pre-excision baseline at 10 minutes post-excision (into the normal range) predicts a single adenoma has been removed; failure to drop suggests additional hyperfunctioning tissue.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ioPTH",
+        "Miami criterion"
+      ],
+      "abbrev": "ioPTH",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hyperparathyroidism"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "medullary-thyroid-carcinoma",
+      "label": "Medullary Thyroid Carcinoma",
+      "type": "pathology",
+      "subspecialty": "endocrine",
+      "detail": "Neuroendocrine tumor of parafollicular C cells (neural crest origin); ~75% sporadic, ~25% hereditary (MEN2). Secretes calcitonin and CEA (serial tumor markers) and does NOT take up RAI. Treatment is total thyroidectomy with central compartment neck dissection; check for pheochromocytoma before any operation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "MTC"
+      ],
+      "abbrev": "MTC",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "medullary-anaplastic-familial"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "calcitonin-cea-markers",
+      "label": "Calcitonin & CEA Tumor Markers",
+      "type": "concept",
+      "subspecialty": "endocrine",
+      "detail": "Calcitonin is the sensitive, specific serum marker for MTC (correlates with tumor burden; a very high level suggests distant disease). CEA is a complementary marker. Post-op marker doubling times predict recurrence and prognosis; a normal basal calcitonin excludes clinically significant MTC.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "calcitonin",
+        "CEA"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "medullary-anaplastic-familial"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "ret-protooncogene",
+      "label": "RET Proto-oncogene",
+      "type": "concept",
+      "subspecialty": "endocrine",
+      "detail": "Receptor tyrosine kinase on chromosome 10; germline activating mutations cause MEN2 (codon 634 → MEN2A; codon M918T → MEN2B, most aggressive). Codon-specific risk categories (ATA highest/high/moderate) dictate the timing of prophylactic thyroidectomy. Somatic RET and RET fusions are actionable drug targets.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "RET"
+      ],
+      "abbrev": "RET",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "medullary-anaplastic-familial"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "men2a",
+      "label": "MEN2A",
+      "type": "concept",
+      "subspecialty": "endocrine",
+      "detail": "Autosomal-dominant RET syndrome (Sipple): medullary thyroid carcinoma (~100%), pheochromocytoma (~50%), and primary hyperparathyroidism (~20-30%). MTC is the leading cause of death; always exclude/treat pheochromocytoma before thyroid or parathyroid surgery.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Sipple syndrome"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "medullary-anaplastic-familial"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "men2b",
+      "label": "MEN2B",
+      "type": "concept",
+      "subspecialty": "endocrine",
+      "detail": "RET M918T syndrome: the most aggressive, earliest-onset MTC plus pheochromocytoma, mucosal neuromas, marfanoid habitus, and intestinal ganglioneuromatosis—but NO hyperparathyroidism. Prophylactic thyroidectomy is recommended within the first year of life.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "medullary-anaplastic-familial"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "familial-mtc",
+      "label": "Familial Medullary Thyroid Carcinoma",
+      "type": "concept",
+      "subspecialty": "endocrine",
+      "detail": "Hereditary RET-driven MTC without pheochromocytoma or hyperparathyroidism; now regarded as a variant within the MEN2A spectrum. Generally more indolent, but still warrants germline RET testing and prophylactic thyroidectomy timed to codon risk.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "FMTC"
+      ],
+      "abbrev": "FMTC",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "dtc-risk-stratification"
+        ],
+        "concepts": [
+          {
+            "module": "dtc-risk-stratification",
+            "concept": "familial"
+          }
+        ],
+        "topics": [
+          "medullary-anaplastic-familial"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "prophylactic-thyroidectomy",
+      "label": "Prophylactic Thyroidectomy",
+      "type": "procedure",
+      "subspecialty": "endocrine",
+      "detail": "Risk-reducing total thyroidectomy in RET mutation carriers, timed by ATA codon risk: MEN2B (M918T, highest risk) within the first 6-12 months of life; high-risk (C634, A883F) by age 5; moderate-risk when calcitonin rises or by childhood. Aims to remove the gland before MTC develops or spreads.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "medullary-anaplastic-familial"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pheochromocytoma",
+      "label": "Pheochromocytoma",
+      "type": "pathology",
+      "subspecialty": "endocrine",
+      "detail": "Catecholamine-secreting adrenal medullary tumor seen in MEN2. Must be screened for (plasma/urine metanephrines) and, if present, resected FIRST after alpha- then beta-blockade—operating on an unrecognized pheo risks fatal hypertensive crisis.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "pheo"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "medullary-anaplastic-familial"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "anaplastic-thyroid-carcinoma",
+      "label": "Anaplastic Thyroid Carcinoma",
+      "type": "pathology",
+      "subspecialty": "endocrine",
+      "detail": "Rare, undifferentiated, one of the most lethal human cancers (median survival months); all cases are AJCC stage IV. Presents as a rapidly enlarging, invasive neck mass with airway compromise. Every case gets urgent BRAF V600E and molecular testing; management is multimodal (surgery if resectable, chemoRT, targeted therapy) with early airway planning.",
+      "sources": [
+        "https://jnccn.org/view/journals/jnccn/23/7/article-e250033.xml"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ATC",
+        "undifferentiated thyroid carcinoma"
+      ],
+      "abbrev": "ATC",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "medullary-anaplastic-familial"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "dabrafenib-trametinib",
+      "label": "Dabrafenib + Trametinib",
+      "type": "drug",
+      "subspecialty": "endocrine",
+      "detail": "BRAF inhibitor + MEK inhibitor combination; the preferred targeted therapy for BRAF V600E-mutant anaplastic thyroid carcinoma (ROAR trial). Used as neoadjuvant therapy to downstage unresectable disease toward surgery, or for stage IVC—underscoring why urgent BRAF testing is essential in ATC.",
+      "sources": [
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC9338780/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Tafinlar + Mekinist",
+        "dab/tram"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "medullary-anaplastic-familial"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "selpercatinib",
+      "label": "Selpercatinib",
+      "type": "drug",
+      "subspecialty": "endocrine",
+      "detail": "Selective RET kinase inhibitor; NCCN category-1 preferred systemic therapy for advanced RET-mutant medullary thyroid carcinoma and RET fusion-positive thyroid cancers (including ATC). Pralsetinib is an alternative RET inhibitor; these have largely supplanted the multikinase agents vandetanib/cabozantinib.",
+      "sources": [
+        "https://jnccn.org/view/journals/jnccn/23/7/article-e250033.xml"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Retevmo",
+        "LOXO-292"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "medullary-anaplastic-familial"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "total-thyroidectomy",
+      "label": "Total Thyroidectomy",
+      "type": "procedure",
+      "subspecialty": "endocrine",
+      "detail": "Complete removal of both thyroid lobes; indicated for larger or higher-risk differentiated cancers, MTC, and to permit RAI/thyroglobulin surveillance. Key risks are bilateral RLN injury and permanent hypoparathyroidism, so parathyroid preservation and nerve monitoring are central.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "dtc-risk-stratification"
+        ],
+        "concepts": [
+          {
+            "module": "dtc-risk-stratification",
+            "concept": "total-thyroidectomy"
+          }
+        ],
+        "topics": [
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "thyroid-lobectomy",
+      "label": "Thyroid Lobectomy",
+      "type": "procedure",
+      "subspecialty": "endocrine",
+      "detail": "Removal of one lobe (± isthmus); both a diagnostic step for indeterminate nodules and definitive treatment for low-risk (≤4 cm, intrathyroidal, node-negative) differentiated cancer per current ATA guidance. Preserves contralateral function and lowers hypoparathyroidism/RLN risk versus total thyroidectomy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "hemithyroidectomy"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "dtc-risk-stratification"
+        ],
+        "concepts": [
+          {
+            "module": "dtc-risk-stratification",
+            "concept": "lobectomy"
+          }
+        ],
+        "topics": [
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "central-neck-dissection",
+      "label": "Central Compartment Neck Dissection",
+      "type": "procedure",
+      "subspecialty": "endocrine",
+      "detail": "Removal of level VI (paratracheal/pretracheal, Delphian) nodes. Therapeutic for clinically involved nodes in DTC and routine in MTC; prophylactic central dissection is debated because it raises transient hypoparathyroidism and RLN-injury rates.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "level VI dissection"
+      ],
+      "abbrev": "CND",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "dtc-risk-stratification"
+        ],
+        "concepts": [
+          {
+            "module": "dtc-risk-stratification",
+            "concept": "nodal-completion"
+          }
+        ],
+        "topics": [
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "facial-nerve-segments",
+      "label": "Facial Nerve Segments",
+      "type": "nerve",
+      "subspecialty": "fprs",
+      "detail": "CN VII courses through six segments: intracranial, meatal, labyrinthine (narrowest, gives GSPN at geniculate ganglion), tympanic, mastoid (gives nerve to stapedius and chorda tympani), and extratemporal (branches within parotid into temporal, zygomatic, buccal, marginal mandibular, cervical). Pes anserinus at stylomastoid foramen.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CN VII anatomy",
+        "facial nerve course"
+      ],
+      "abbrev": "CN VII",
+      "structure": null,
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "nerve-segments"
+          },
+          {
+            "module": "facial-reanimation",
+            "concept": "geniculate-branches"
+          },
+          {
+            "module": "facial-reanimation",
+            "concept": "tympanic-segment"
+          },
+          {
+            "module": "facial-reanimation",
+            "concept": "mastoid-branches"
+          },
+          {
+            "module": "facial-reanimation",
+            "concept": "extratemporal"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "house-brackmann-scale",
+      "label": "House-Brackmann Grading Scale",
+      "type": "concept",
+      "subspecialty": "fprs",
+      "detail": "Six-grade clinician scale for facial nerve function: I normal, II mild dysfunction, III moderate (complete eye closure with effort, obvious asymmetry), IV moderate-severe (incomplete eye closure), V severe (barely perceptible motion), VI total paralysis. Grade III/IV is the common threshold for intervention decisions.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "HB scale"
+      ],
+      "abbrev": "HB",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "house-brackmann"
+          },
+          {
+            "module": "facial-reanimation",
+            "concept": "exam-findings"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sunnybrook-facial-grading",
+      "label": "Sunnybrook Facial Grading System",
+      "type": "concept",
+      "subspecialty": "fprs",
+      "detail": "Regional, weighted composite score (0-100) assessing resting symmetry, voluntary movement across five expressions, and synkinesis. More sensitive than House-Brackmann for tracking longitudinal change and detecting synkinesis after recovery.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Sunnybrook score"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "sunnybrook"
+          },
+          {
+            "module": "facial-reanimation",
+            "concept": "exam-findings"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "bells-palsy",
+      "label": "Bell's Palsy",
+      "type": "pathology",
+      "subspecialty": "fprs",
+      "detail": "Idiopathic (HSV-associated) acute peripheral facial paralysis and the most common cause of unilateral facial weakness. Treat with high-dose oral corticosteroids within 72 hours; antivirals add marginal benefit in severe/complete palsy. Eye protection is essential; most recover. Ramsay Hunt (VZV) has worse prognosis.",
+      "sources": [
+        "AAO-HNSF Clinical Practice Guideline: Bell's Palsy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "idiopathic facial paralysis"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "bells-palsy"
+          },
+          {
+            "module": "facial-reanimation",
+            "concept": "case-ramsay"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "facial-nerve-electrodiagnostics",
+      "label": "Facial Nerve Electrodiagnostics (ENoG/EMG)",
+      "type": "concept",
+      "subspecialty": "fprs",
+      "detail": "Electroneuronography (ENoG) compares evoked CMAP amplitude to the normal side; >90% degeneration within 14 days of complete palsy is a surgical decompression threshold. EMG detects voluntary motor units and reinnervation (polyphasic potentials), guiding prognosis and reanimation candidacy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ENoG",
+        "electromyography"
+      ],
+      "abbrev": "ENoG",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "electrodiagnostics"
+          },
+          {
+            "module": "facial-reanimation",
+            "concept": "imaging"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "synkinesis",
+      "label": "Facial Synkinesis",
+      "type": "pathology",
+      "subspecialty": "fprs",
+      "detail": "Involuntary co-contraction from aberrant reinnervation after facial nerve injury (e.g., oro-ocular synkinesis). Managed with neuromuscular retraining, botulinum toxin chemodenervation, and selective myectomy/neurectomy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "aberrant regeneration"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "synkinesis"
+          },
+          {
+            "module": "facial-reanimation",
+            "concept": "chemodenervation"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cross-facial-nerve-graft",
+      "label": "Cross-Facial Nerve Graft",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Stage 1 of two-stage smile reanimation: a sural nerve graft is coapted to redundant buccal branches of the healthy contralateral facial nerve and banked across the midline, allowing a Tinel sign to advance before stage 2 free muscle neurotization. Offers spontaneous, emotive smile but weaker excursion than masseteric input.",
+      "sources": [
+        "https://pubmed.ncbi.nlm.nih.gov/23416438/",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CFNG"
+      ],
+      "abbrev": "CFNG",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "CFNG"
+          },
+          {
+            "module": "facial-reanimation",
+            "concept": "nerve-transfer"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "masseteric-nerve-transfer",
+      "label": "Masseteric-to-Facial Nerve Transfer",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Transfer of the motor nerve to masseter (V3 branch) to a facial nerve branch or free muscle. Provides strong, reliable excursion and short reinnervation time but a bite-driven (non-spontaneous) smile; often combined with CFNG for dual innervation to add spontaneity.",
+      "sources": [
+        "https://pubmed.ncbi.nlm.nih.gov/30934175/",
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC10703116/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "V-VII transfer",
+        "nerve to masseter"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "nerve-transfer"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "gracilis-free-muscle-transfer",
+      "label": "Gracilis Free Muscle Transfer",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Workhorse free functional muscle for dynamic smile reanimation in long-standing paralysis (>2 years, absent native muscle). The gracilis (obturator nerve, medial circumflex femoral pedicle) is inset from oral commissure to zygoma and neurotized by CFNG, masseteric nerve, or both.",
+      "sources": [
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC10703116/",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "free gracilis",
+        "FFMT"
+      ],
+      "abbrev": "FFMT",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "muscle-transfer"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "eyelid-reanimation-gold-weight",
+      "label": "Upper Eyelid Weight (Gold/Platinum)",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Static upper-lid loading with a gold or platinum weight restores gravity-assisted eye closure in paralytic lagophthalmos, protecting the cornea. Combined with lower-lid tightening (lateral tarsal strip) and lubrication to prevent exposure keratopathy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "lid loading"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "eyelid"
+          },
+          {
+            "module": "facial-reanimation",
+            "concept": "corneal"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "facial-buttresses",
+      "label": "Facial Buttresses",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Thickened bony struts that transmit masticatory forces and dictate rigid fixation in midface trauma. Vertical: nasomaxillary (medial), zygomaticomaxillary (lateral), pterygomaxillary, and vertical mandible. Horizontal: frontal bar, infraorbital rim, maxillary alveolus/palate. Restoring buttresses restores facial height, width, and projection.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "midface buttresses"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "mandible",
+      "label": "Mandible",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "U-shaped lower facial bone; fracture subsites are condyle/subcondyle, ramus, angle, body, parasymphysis, and symphysis. Muscle vectors (masseter, pterygoids, mylohyoid, digastric) determine whether a fracture is favorable or unfavorable to displacement. Bears the lower dental arch.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "lower jaw"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "zygomaticomaxillary-complex",
+      "label": "Zygomaticomaxillary Complex (ZMC)",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "The malar 'tetrapod' articulating at zygomaticofrontal, zygomaticomaxillary (infraorbital rim), zygomaticotemporal (arch), and zygomaticosphenoid sutures. Determines malar projection and facial width; the zygomaticosphenoid suture at the lateral orbital wall is the key intraoperative gauge of reduction.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "malar complex",
+        "tripod"
+      ],
+      "abbrev": "ZMC",
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "orbital-floor",
+      "label": "Orbital Floor",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Thin maxillary/zygomatic plate over the maxillary sinus, weakest posteromedially. Herniation or entrapment here produces enophthalmos, hypoglobus, and restricted upgaze; the infraorbital nerve runs in its canal, causing cheek numbness when injured.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "orbital rim floor"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "le-fort-fractures",
+      "label": "Le Fort Fracture Classification",
+      "type": "concept",
+      "subspecialty": "fprs",
+      "detail": "Midface fracture patterns all crossing the pterygoid plates: Le Fort I (transverse, palate-separating 'floating palate'), Le Fort II (pyramidal, through infraorbital rims and nasofrontal region), Le Fort III (craniofacial disjunction through zygomaticofrontal sutures and orbits). Produce malocclusion and midface mobility.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Le Fort I II III"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "zmc-fracture",
+      "label": "ZMC Fracture",
+      "type": "pathology",
+      "subspecialty": "fprs",
+      "detail": "Malar fracture causing flattened cheek, infraorbital hypesthesia, trismus (arch impinging coronoid), and lateral subconjunctival hemorrhage. ORIF via up to three-point fixation (ZF suture, infraorbital rim, ZM buttress); reduction verified at the zygomaticosphenoid suture.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "tripod fracture",
+        "malar fracture"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "mandible-fracture",
+      "label": "Mandible Fracture",
+      "type": "pathology",
+      "subspecialty": "fprs",
+      "detail": "Common in the angle and parasymphysis (often bilateral 'guard's fracture'). Presents with malocclusion, step-off, and gingival tears (open fractures needing antibiotics). Treated by MMF and/or ORIF along Champy's ideal lines of osteosynthesis; condylar fractures often managed closed to avoid nerve injury.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "jaw fracture"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "orbital-blowout-fracture",
+      "label": "Orbital Blowout Fracture",
+      "type": "pathology",
+      "subspecialty": "fprs",
+      "detail": "Isolated floor/medial wall fracture from a sudden rise in intraorbital pressure. Watch for muscle entrapment (restricted upgaze, diplomatic diplopia, oculocardiac reflex—especially trapdoor fractures in children requiring urgent release), enophthalmos, and infraorbital numbness. Repair for large defects, enophthalmos, or persistent diplopia.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "blowout fracture",
+        "trapdoor fracture"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "naso-orbito-ethmoid-fracture",
+      "label": "Naso-Orbito-Ethmoid (NOE) Fracture",
+      "type": "pathology",
+      "subspecialty": "fprs",
+      "detail": "Central midface fracture disrupting the medial canthal tendon insertion, producing telecanthus, saddle-nose deformity, and possible CSF rhinorrhea. Markowitz classification (I-III) grades tendon involvement; transnasal canthopexy is required for comminuted (type III) patterns.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "NOE fracture"
+      ],
+      "abbrev": "NOE",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "open-reduction-internal-fixation",
+      "label": "Open Reduction & Internal Fixation (ORIF)",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Exposure and rigid miniplate/screw fixation restoring buttress continuity and pre-injury occlusion. Load-bearing plates for comminution, load-sharing for simple fractures; MMF re-establishes occlusion first. Goal is anatomic reduction of facial height, width, and projection.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ORIF"
+      ],
+      "abbrev": "ORIF",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "maxillomandibular-fixation",
+      "label": "Maxillomandibular Fixation (MMF)",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Temporary intermaxillary fixation via arch bars or MMF screws to re-establish premorbid occlusion before rigid fixation, or as definitive closed treatment for favorable/condylar fractures. Establishes the occlusal 'key' that guides reduction.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "MMF",
+        "IMF"
+      ],
+      "abbrev": "MMF",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "relaxed-skin-tension-lines",
+      "label": "Relaxed Skin Tension Lines (RSTL)",
+      "type": "concept",
+      "subspecialty": "fprs",
+      "detail": "Lines of minimal resting skin tension, generally perpendicular to underlying muscle vectors. Orienting incisions and scar revisions (Z-plasty, W-plasty) parallel to RSTL and along aesthetic subunit borders minimizes scar visibility and wound tension.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "RSTL",
+        "Langer's lines"
+      ],
+      "abbrev": "RSTL",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "local-flaps-mohs-reconstruction"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "mohs-micrographic-surgery",
+      "label": "Mohs Micrographic Surgery",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Staged excision with complete peripheral and deep margin assessment via horizontal frozen sections, giving the highest cure rate while sparing tissue—ideal for high-risk facial BCC/SCC in cosmetically sensitive areas. Reconstruction follows margin clearance.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Mohs"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "local-flaps-mohs-reconstruction"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "rotation-flap",
+      "label": "Rotation Flap",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Local random-pattern flap pivoting curvilinearly about a point to close a triangular defect, recruiting adjacent laxity (e.g., cervicofacial, dorsal nasal/Rieger flaps). Useful on cheek and scalp; standing cutaneous deformity (dog-ear) managed with a Burow's triangle.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "pivot flap"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "local-flaps-mohs-reconstruction"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "advancement-flap",
+      "label": "Advancement Flap",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Tissue advanced in a straight line along its linear axis (single, bilateral/H-plasty, or V-Y). Relies on adjacent skin elasticity; Burow's triangles offload standing cones. Common for forehead, lip, and helical rim defects.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "V-Y flap",
+        "H-plasty"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "local-flaps-mohs-reconstruction"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "transposition-flap",
+      "label": "Transposition Flap",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Flap lifted and rotated over intervening skin into an adjacent defect, redirecting tension vectors—rhombic (Limberg), bilobed (workhorse for lower-third nasal defects), and note flaps. Redistributes closure tension away from free margins like the eyelid or ala.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "rhombic flap",
+        "bilobed flap"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "local-flaps-mohs-reconstruction"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "paramedian-forehead-flap",
+      "label": "Paramedian Forehead Flap",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Interpolated axial flap based on the supratrochlear artery, the workhorse for large full-thickness nasal (tip/ala) reconstruction. Staged with pedicle division at ~3 weeks; robust, color-matched forehead skin ideal for the nasal external lining/cover.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "forehead flap"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "local-flaps-mohs-reconstruction"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "skin-graft-ftsg-stsg",
+      "label": "Skin Grafts (FTSG/STSG)",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Full-thickness grafts (retroauricular, preauricular, supraclavicular donors) contract less and match facial color/texture; split-thickness grafts cover larger beds but contract more. Both require a well-vascularized recipient bed (survive by imbibition, then inosculation and revascularization).",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "FTSG",
+        "STSG"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "local-flaps-mohs-reconstruction"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "nasal-aesthetic-subunits",
+      "label": "Nasal Aesthetic Subunits",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Nine topographic subunits (dorsum, paired sidewalls, tip, paired alae, columella, paired soft-triangles). Burget-Menick subunit principle: when a defect involves >50% of a convex subunit, resurface the entire subunit so scars fall in the shadowed borders.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "subunit principle"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "rhinoplasty-nasal-analysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "nasal-septum",
+      "label": "Nasal Septum",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Midline partition of quadrangular (septal) cartilage plus perpendicular plate of ethmoid and vomer. Caudal septum is a major tip-support structure and the source of septal cartilage grafts (spreader, columellar strut). L-strut of ≥10-15 mm dorsal and caudal must be preserved to avoid saddle deformity.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "septal cartilage"
+      ],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "nasal-sinus",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "rhinoplasty-nasal-analysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "lower-lateral-cartilage",
+      "label": "Lower Lateral (Alar) Cartilage",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Paired U-shaped tip cartilages with medial, middle (domal), and lateral crura defining tip shape, projection, and rotation. Their intrinsic strength and attachments are major tip-support mechanisms; cephalic trim and suture techniques refine the tip.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "alar cartilage",
+        "LLC"
+      ],
+      "abbrev": "LLC",
+      "structure": "cartilage",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "rhinoplasty-nasal-analysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "nasal-analysis",
+      "label": "Nasal Analysis & Aesthetics",
+      "type": "concept",
+      "subspecialty": "fprs",
+      "detail": "Systematic assessment of nasofrontal angle (115-130°), nasolabial angle (90-100° men, 95-115° women), tip projection (Goode ratio ~0.55-0.60), rotation, and dorsal aesthetic lines. Guides operative planning and preserves airway function.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "facial analysis nose"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "rhinoplasty-nasal-analysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "rhinoplasty",
+      "label": "Rhinoplasty",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Reshaping of the bony-cartilaginous nose via open (transcolumellar) or closed (endonasal) approach. Structural techniques—spreader grafts, columellar strut, tip sutures, osteotomies—balance aesthetics with airway (internal/external nasal valve) preservation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "nose job",
+        "septorhinoplasty"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "rhinoplasty-nasal-analysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "nasal-grafts",
+      "label": "Structural Nasal Grafts",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Cartilage grafts to support and shape the nose: spreader grafts (widen internal valve, restore dorsal aesthetic lines), columellar strut and septal extension grafts (tip support/projection), alar batten/rim grafts (external valve), and shield/onlay tip grafts. Septal cartilage is first choice; auricular or costal cartilage when depleted.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "spreader graft",
+        "columellar strut"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "rhinoplasty-nasal-analysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "costal-cartilage-graft",
+      "label": "Costal Cartilage Graft",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Autologous rib cartilage (typically 6th-9th ribs) providing abundant graft material for major dorsal augmentation, revision/saddle-nose rhinoplasty, and the microtia auricular framework. Concentric carving reduces warping; risks include warping, pneumothorax, and donor-site pain.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "https://www.ncbi.nlm.nih.gov/books/NBK563243/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "rib cartilage",
+        "costochondral graft"
+      ],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "rhinoplasty-nasal-analysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "radial-forearm-free-flap",
+      "label": "Radial Forearm Free Flap (RFFF)",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Thin, pliable fasciocutaneous flap on the radial artery and cephalic/venae comitantes—the workhorse for oral tongue, floor-of-mouth, and pharyngeal soft-tissue reconstruction. Long reliable pedicle; requires a preoperative Allen test to confirm ulnar collateral flow.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "RFFF",
+        "Chinese flap"
+      ],
+      "abbrev": "RFFF",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "free-tissue-transfer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "fibula-free-flap",
+      "label": "Fibula Free Flap",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Vascularized osteocutaneous flap (peroneal artery) providing up to ~25 cm of bicortical bone that tolerates multiple osteotomies—the standard for segmental mandibular reconstruction and osseointegrated dental implants. Preoperative CT angiography confirms three-vessel leg runoff.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "free fibula",
+        "fibula osteocutaneous flap"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "free-tissue-transfer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "anterolateral-thigh-flap",
+      "label": "Anterolateral Thigh Flap (ALT)",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Versatile perforator flap on the descending branch of the lateral circumflex femoral artery, providing large-volume, variable-thickness soft tissue with low donor morbidity. Used for bulky total glossectomy, scalp, and through-and-through cheek defects; can be chimeric.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ALT flap"
+      ],
+      "abbrev": "ALT",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "free-tissue-transfer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "microvascular-anastomosis",
+      "label": "Microvascular Anastomosis & Free Flap Monitoring",
+      "type": "concept",
+      "subspecialty": "fprs",
+      "detail": "Free tissue transfer requires microsurgical arterial and venous anastomosis to neck recipient vessels (commonly facial artery, external jugular/IJ branches). Postoperative monitoring (clinical color/turgor/capillary refill, implantable Doppler) detects venous congestion or arterial thrombosis early; salvage depends on prompt re-exploration.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "flap monitoring",
+        "microsurgery"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "free-tissue-transfer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "microtia",
+      "label": "Microtia",
+      "type": "pathology",
+      "subspecialty": "fprs",
+      "detail": "Congenital auricular hypoplasia (grades I-III, with anotia grade IV), commonly with aural atresia and conductive hearing loss; frequently syndromic (hemifacial microsomia, Treacher Collins). Facial nerve may be anomalous. Audiologic workup precedes reconstruction.",
+      "sources": [
+        "https://www.ncbi.nlm.nih.gov/books/NBK563243/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "microtia-anotia"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "external-ear",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "otoplasty-microtia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "auricular-reconstruction",
+      "label": "Autologous Auricular Reconstruction",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Staged reconstruction using a carved costal cartilage framework. Brent (3-4 stages, from age ~6, contralateral rib) vs Nagata (2 stages, from age ~10 with chest circumference >60 cm, ipsilateral rib, lobule transposition and tragus in stage 1). Alternatives: porous polyethylene (Medpor) implant or prosthesis.",
+      "sources": [
+        "https://www.plarecon.com/microtia-surgery-brent-nagata-firmin-ear-reconstruction/",
+        "https://www.ncbi.nlm.nih.gov/books/NBK563243/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ear reconstruction",
+        "Nagata",
+        "Brent"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "external-ear",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "otoplasty-microtia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "prominent-ear",
+      "label": "Prominent (Protruding) Ear",
+      "type": "pathology",
+      "subspecialty": "fprs",
+      "detail": "Protrusion from an underdeveloped antihelical fold, conchal bowl excess/hypertrophy, and/or increased auriculocephalic angle (>25° or >2 cm helix-to-mastoid). The anatomic basis for otoplasty planning.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "protruding ear"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "external-ear",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "otoplasty-microtia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "otoplasty",
+      "label": "Otoplasty",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Correction of prominent ear, typically after age 5-6. Mustardé conchoscaphal sutures recreate the antihelical fold; Furnas conchomastoid sutures set back the conchal bowl; cartilage scoring weakens spring. Over-resection risks a telephone-ear deformity.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ear pinning",
+        "Mustarde",
+        "Furnas"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "external-ear",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "otoplasty-microtia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "smas",
+      "label": "Superficial Musculoaponeurotic System (SMAS)",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Continuous fibromuscular fascial layer investing the mimetic muscles, continuous with the platysma inferiorly and the temporoparietal fascia superiorly. It is the key structural plane manipulated (plication, imbrication, deep-plane dissection) in rhytidectomy; the facial nerve branches run deep to it.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "SMAS"
+      ],
+      "abbrev": "SMAS",
+      "structure": "fascia",
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "aging-face-blepharoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "facial-danger-zones",
+      "label": "Facial Danger Zones",
+      "type": "concept",
+      "subspecialty": "fprs",
+      "detail": "Regions of superficial nerve vulnerability: temporal (frontal) branch of CN VII along Pitanguy's line, marginal mandibular branch near the mandibular border, the great auricular nerve over the sternocleidomastoid (most commonly injured in facelift), and the spinal accessory nerve in the posterior triangle. Knowledge prevents iatrogenic palsy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "danger zones of the face"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "aging-face-blepharoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "rhytidectomy",
+      "label": "Rhytidectomy (Facelift)",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Repositioning of ptotic facial soft tissue by redraping skin and resuspending the SMAS (plication, SMASectomy, or deep-plane). Addresses jowls and the nasolabial/melolabial fold. The great auricular nerve is the most commonly injured structure; hematoma is the most common early complication.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "facelift"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "aging-face-blepharoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "blepharoplasty",
+      "label": "Blepharoplasty",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Removal/repositioning of redundant eyelid skin and herniated orbital fat (upper lid: skin excision; lower lid: transconjunctival or transcutaneous fat management). Preoperative assessment of dermatochalasis, brow ptosis, lid laxity (snap-back test), and dry eye. Retrobulbar hematoma is a vision-threatening emergency.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "eyelid lift"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "aging-face-blepharoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "brow-lift",
+      "label": "Brow Lift",
+      "type": "procedure",
+      "subspecialty": "fprs",
+      "detail": "Elevation of the ptotic brow (endoscopic, pretrichial/trichophytic, direct, or coronal) by releasing and weakening the depressors (corrugator, procerus) and resuspending the forehead. Often precedes or accompanies upper blepharoplasty to avoid worsening lid crowding.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "forehead lift",
+        "browplasty"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "aging-face-blepharoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "superficial-cervical-fascia",
+      "label": "Superficial Cervical Fascia",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Subcutaneous layer of the neck enveloping the platysma and superficial vessels/nerves; analogous to the body's subcutaneous fascia and distinct from the deep cervical fascia. Not a barrier to infection spread.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "superficial fascia of neck"
+      ],
+      "abbrev": null,
+      "structure": "fascia",
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "platysma-muscle",
+      "label": "Platysma Muscle",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Thin sheet of muscle within the superficial cervical fascia, innervated by the cervical branch of the facial nerve; a key surgical landmark whose subplatysmal plane is developed during neck dissection.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "platysma"
+      ],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "deep-cervical-fascia",
+      "label": "Deep Cervical Fascia",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Fibrous framework of the neck comprising the superficial (investing) layer, the middle (pretracheal/visceral) layer, and the deep (prevertebral) layer, with the carotid sheath formed from all three. Its layers define the deep neck spaces and route of infection spread.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "deep fascia of the neck"
+      ],
+      "abbrev": "DCF",
+      "structure": "fascia",
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "investing-layer-deep-cervical-fascia",
+      "label": "Investing (Superficial) Layer of Deep Cervical Fascia",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Superficial layer of the deep cervical fascia that completely encircles the neck, splitting to enclose the sternocleidomastoid, trapezius, submandibular and parotid glands. Attaches to mandible, hyoid, sternum, clavicle and scapular spine.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "superficial layer of deep cervical fascia",
+        "anterior layer"
+      ],
+      "abbrev": null,
+      "structure": "fascia",
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pretracheal-visceral-fascia",
+      "label": "Pretracheal (Visceral) Fascia",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Middle layer of the deep cervical fascia enveloping the pharynx, larynx, trachea, esophagus and thyroid. Its posterior pharyngeal component (buccopharyngeal fascia) forms the anterior wall of the retropharyngeal space; extends into the superior mediastinum.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "middle layer",
+        "visceral fascia",
+        "buccopharyngeal fascia"
+      ],
+      "abbrev": null,
+      "structure": "fascia",
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "prevertebral-fascia",
+      "label": "Prevertebral Fascia",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Deep layer of the deep cervical fascia covering the vertebral bodies and paraspinous/prevertebral muscles, extending from the skull base to the coccyx. Its anteriorly split alar division helps bound the danger space.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "deep layer of deep cervical fascia"
+      ],
+      "abbrev": null,
+      "structure": "fascia",
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "alar-fascia",
+      "label": "Alar Fascia",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "A coronal partition between the visceral and prevertebral fasciae, dividing the retropharyngeal space (anterior) from the danger space (posterior). Extends from skull base to ~T2 where it fuses with the visceral fascia.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "alar layer"
+      ],
+      "abbrev": null,
+      "structure": "fascia",
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "carotid-sheath",
+      "label": "Carotid Sheath",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Tubular fascial condensation formed by contributions of all three deep cervical fascia layers ('Lincoln's highway'), extending skull base to mediastinum. Contains the carotid artery, internal jugular vein and vagus nerve; a conduit for infection to the chest.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Lincoln's highway"
+      ],
+      "abbrev": null,
+      "structure": "fascia",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "parapharyngeal-space",
+      "label": "Parapharyngeal Space",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Inverted-pyramid space (skull base to hyoid) divided by the styloid process into a prestyloid compartment (fat, deep parotid) and a poststyloid compartment (carotid sheath, CN IX–XII, sympathetic chain). Central to deep neck infection spread and parapharyngeal tumors.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "lateral pharyngeal space",
+        "pharyngomaxillary space"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "retropharyngeal-space",
+      "label": "Retropharyngeal Space",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Midline space between the buccopharyngeal (visceral) fascia anteriorly and the alar fascia posteriorly, extending skull base to ~T1–T2. Contains retropharyngeal nodes (of Rouvière) that regress after childhood; a key site of pediatric deep neck abscess.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "retropharyngeal",
+        "space of Gillette"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "danger-space",
+      "label": "Danger Space",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Space 4 lying between the alar fascia (anterior) and prevertebral fascia (posterior), running from the skull base to the posterior mediastinum/diaphragm with loose areolar tissue. Its uninterrupted extent allows rapid caudal spread of infection to the mediastinum.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "space 4",
+        "Grodinsky and Holyoke space 4"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "prevertebral-space",
+      "label": "Prevertebral Space",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Space between the prevertebral fascia and the vertebral bodies, extending from the skull base to the coccyx. Involved in Pott disease and vertebral osteomyelitis; infection is confined here by the prevertebral fascia.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "perivertebral space"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "submandibular-space",
+      "label": "Submandibular Space",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Space between the mucosa of the floor of mouth and the investing fascia/hyoid, divided by the mylohyoid muscle into sublingual (superior) and submaxillary/submylohyoid (inferior) compartments that communicate around the posterior mylohyoid. Origin of Ludwig's angina.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "submaxillary space"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "masticator-space",
+      "label": "Masticator Space",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Space enclosed by the split investing layer of deep cervical fascia around the muscles of mastication and the ramus/body of the mandible. Contains masseter, pterygoids, temporalis insertion and CN V3; odontogenic infection here causes trismus.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "masticatory space"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "parotid-space",
+      "label": "Parotid Space",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Space enclosed by the investing layer of deep cervical fascia around the parotid gland; its medial capsule is incomplete, communicating with the parapharyngeal space and allowing deep-lobe tumors to present as dumbbell parapharyngeal masses.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "ludwigs-angina",
+      "label": "Ludwig's Angina",
+      "type": "pathology",
+      "subspecialty": "fundamentals",
+      "detail": "Rapidly spreading bilateral cellulitis of the submandibular (sublingual and submaxillary) spaces, usually of odontogenic origin (2nd/3rd molars). Causes a brawny, non-fluctuant floor-of-mouth induration with tongue elevation and airway compromise; a surgical/airway emergency.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Ludwig angina"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "deep-neck-space-abscess",
+      "label": "Deep Neck Space Abscess",
+      "type": "pathology",
+      "subspecialty": "fundamentals",
+      "detail": "Suppurative collection within a deep neck space, typically polymicrobial (Streptococcus, anaerobes, Staphylococcus). Diagnosed by contrast CT (ring-enhancing, hypodense center); managed with airway control, IV antibiotics and incision and drainage. Complications include descending mediastinitis, carotid blowout and Lemierre's.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "deep neck infection",
+        "retropharyngeal abscess",
+        "parapharyngeal abscess"
+      ],
+      "abbrev": "DNI",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "descending-mediastinitis",
+      "label": "Descending Necrotizing Mediastinitis",
+      "type": "pathology",
+      "subspecialty": "fundamentals",
+      "detail": "Life-threatening spread of a deep neck infection into the mediastinum, most often via the retropharyngeal/danger space. High mortality; requires early CT chest, broad-spectrum antibiotics and aggressive surgical drainage (often thoracic).",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "mediastinitis"
+      ],
+      "abbrev": "DNM",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "neck-abscess-incision-drainage",
+      "label": "Incision and Drainage of Neck Abscess",
+      "type": "procedure",
+      "subspecialty": "fundamentals",
+      "detail": "Surgical drainage of a deep neck abscess through a transcervical or transoral approach after securing the airway. Cultures guide antibiotic de-escalation; small (<2–2.5 cm) collections may resolve with IV antibiotics alone.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "I&D",
+        "neck drainage"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "computed-tomography",
+      "label": "Computed Tomography (CT)",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "X-ray cross-sectional imaging that is the workhorse for bony detail, sinonasal/temporal bone anatomy and deep neck infection. Contrast enhancement (iodinated) highlights vessels and ring-enhancing abscesses; Hounsfield units quantify tissue density.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CT scan",
+        "CAT scan"
+      ],
+      "abbrev": "CT",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "imaging-radiology-principles"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "magnetic-resonance-imaging",
+      "label": "Magnetic Resonance Imaging (MRI)",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "Superior soft-tissue and neural imaging using T1/T2 sequences; preferred for skull base, perineural spread, parotid/parapharyngeal tumors and vestibular schwannoma. Gadolinium enhances vascular/inflammatory tissue; DWI aids cholesteatoma and abscess detection.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "MR imaging"
+      ],
+      "abbrev": "MRI",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "imaging-radiology-principles"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pet-ct",
+      "label": "PET/CT (FDG)",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "Fluorodeoxyglucose PET fused with CT quantifies metabolic activity (SUV) for cancer staging, unknown primary workup and post-treatment surveillance. Best performed ≥12 weeks after chemoradiation to reduce false positives from inflammation.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "FDG-PET",
+        "PET scan"
+      ],
+      "abbrev": "PET",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "imaging-radiology-principles"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "iodinated-contrast",
+      "label": "Iodinated Contrast",
+      "type": "drug",
+      "subspecialty": "fundamentals",
+      "detail": "Intravenous CT contrast that enhances vessels and inflammatory rims. Cautions include contrast-induced nephropathy in renal impairment, allergic-type reactions, and interaction with metformin; thyroid iodine load can affect subsequent RAI therapy.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CT contrast"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "imaging-radiology-principles"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "gadolinium-contrast",
+      "label": "Gadolinium Contrast",
+      "type": "drug",
+      "subspecialty": "fundamentals",
+      "detail": "Paramagnetic MRI contrast agent that shortens T1, enhancing vascular and inflammatory tissue. Risk of nephrogenic systemic fibrosis in severe renal failure limits use; newer macrocyclic agents are more stable.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "gadolinium",
+        "MRI contrast"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "imaging-radiology-principles"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "difficult-airway-algorithm",
+      "label": "Difficult Airway Algorithm",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "ASA framework for anticipated/unanticipated difficult airways emphasizing awake intubation when difficulty is predicted, maintaining oxygenation, limiting attempts, calling for help, and progressing to supraglottic rescue then surgical (front-of-neck) access. 'Cannot intubate, cannot oxygenate' triggers cricothyrotomy.",
+      "sources": [
+        "ASA Difficult Airway Guidelines",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ASA difficult airway",
+        "CICO"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "airway-management-anesthesia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "endotracheal-intubation",
+      "label": "Endotracheal Intubation",
+      "type": "procedure",
+      "subspecialty": "fundamentals",
+      "detail": "Placement of a cuffed tube into the trachea for airway protection and ventilation, via direct or video laryngoscopy, or awake fiberoptic when difficulty is anticipated. Mallampati, thyromental distance and mouth opening predict difficulty.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "intubation",
+        "ETT placement"
+      ],
+      "abbrev": "ETT",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "airway-management-anesthesia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "tracheostomy",
+      "label": "Tracheostomy",
+      "type": "procedure",
+      "subspecialty": "fundamentals",
+      "detail": "Surgical airway created typically between the 2nd and 3rd tracheal rings for prolonged ventilation, upper airway obstruction, or pulmonary toilet. Avoid the thyroid isthmus and high innominate artery; early complications include bleeding and tube dislodgement, late include tracheoinnominate fistula and stenosis.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "tracheotomy"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "airway-management-anesthesia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cricothyrotomy",
+      "label": "Cricothyrotomy",
+      "type": "procedure",
+      "subspecialty": "fundamentals",
+      "detail": "Emergency front-of-neck airway through the cricothyroid membrane for 'cannot intubate, cannot oxygenate' situations. Faster and safer than emergency tracheostomy; converted to a formal tracheostomy within 24–72 hours to avoid subglottic stenosis. Avoid in children under ~12.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "ASA Difficult Airway Guidelines"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "cricothyroidotomy",
+        "surgical airway"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "airway-management-anesthesia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cricothyroid-membrane",
+      "label": "Cricothyroid Membrane",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Membrane between the thyroid and cricoid cartilages; the target for emergency cricothyrotomy. Palpable landmark just inferior to the laryngeal prominence, relatively avascular in the midline.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "cricothyroid ligament"
+      ],
+      "abbrev": null,
+      "structure": "membrane",
+      "region": "larynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "airway-management-anesthesia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "rapid-sequence-induction",
+      "label": "Rapid Sequence Induction",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "Induction technique for aspiration-risk patients using preoxygenation, a rapid-onset induction agent and a fast-acting paralytic (succinylcholine or rocuronium) with minimal bag-mask ventilation to secure the airway quickly.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "RSI"
+      ],
+      "abbrev": "RSI",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "airway-management-anesthesia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "local-anesthetics",
+      "label": "Local Anesthetics",
+      "type": "drug",
+      "subspecialty": "fundamentals",
+      "detail": "Amides (lidocaine, bupivacaine) and esters that block voltage-gated sodium channels. Know maximum safe doses (lidocaine ~4.5 mg/kg, or ~7 mg/kg with epinephrine) and signs of systemic toxicity (perioral numbness, seizures, cardiac arrest) treated with lipid emulsion.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "lidocaine",
+        "bupivacaine"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "airway-management-anesthesia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "coagulation-cascade",
+      "label": "Coagulation Cascade",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "Intrinsic (PTT-monitored), extrinsic (PT/INR-monitored) and common pathways converging on thrombin and fibrin. Platelet plug formation (primary hemostasis) precedes the fibrin clot (secondary hemostasis); vitamin K-dependent factors are II, VII, IX, X.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "clotting cascade",
+        "hemostasis pathway"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hemostasis-transfusion-periop"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "perioperative-anticoagulation",
+      "label": "Perioperative Anticoagulation Management",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "Balancing thromboembolic vs bleeding risk when holding/bridging warfarin, DOACs and antiplatelets around surgery. Warfarin held ~5 days (INR normalization), DOACs 1–3 days by renal function; bridging with heparin reserved for high-risk indications.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "anticoagulation bridging",
+        "warfarin",
+        "DOAC"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hemostasis-transfusion-periop"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "blood-transfusion",
+      "label": "Blood Transfusion",
+      "type": "procedure",
+      "subspecialty": "fundamentals",
+      "detail": "Replacement of blood products; a restrictive threshold (~Hb 7 g/dL, higher in cardiac disease) is generally favored. Complications include acute/delayed hemolytic reactions, febrile non-hemolytic reactions, TRALI, TACO and infection.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "transfusion",
+        "pRBC transfusion"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hemostasis-transfusion-periop"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "tranexamic-acid",
+      "label": "Tranexamic Acid",
+      "type": "drug",
+      "subspecialty": "fundamentals",
+      "detail": "Antifibrinolytic lysine analogue that inhibits plasminogen activation, reducing perioperative and mucosal (e.g., epistaxis, post-tonsillectomy) bleeding. Caution in thromboembolic risk and seizure history.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "TXA"
+      ],
+      "abbrev": "TXA",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hemostasis-transfusion-periop"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "von-willebrand-disease",
+      "label": "Von Willebrand Disease",
+      "type": "pathology",
+      "subspecialty": "fundamentals",
+      "detail": "Most common inherited bleeding disorder; deficient/defective vWF impairs platelet adhesion and stabilization of factor VIII. Presents with mucocutaneous bleeding and prolonged bleeding after tonsillectomy/adenoidectomy; treated with desmopressin (DDAVP) or vWF concentrate.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "vWD"
+      ],
+      "abbrev": "vWD",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hemostasis-transfusion-periop"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "amoxicillin-clavulanate",
+      "label": "Amoxicillin-Clavulanate",
+      "type": "drug",
+      "subspecialty": "fundamentals",
+      "detail": "Aminopenicillin plus beta-lactamase inhibitor; first-line for acute bacterial rhinosinusitis, acute otitis media (high-dose) and odontogenic infections, covering S. pneumoniae, H. influenzae, M. catarrhalis and oral anaerobes.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Augmentin",
+        "co-amoxiclav"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "antimicrobials-pharmacology"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "clindamycin",
+      "label": "Clindamycin",
+      "type": "drug",
+      "subspecialty": "fundamentals",
+      "detail": "Lincosamide with strong anaerobic and gram-positive coverage; used for penicillin-allergic patients with odontogenic/deep neck infections and as MRSA option. Risk of Clostridioides difficile colitis; rising anaerobic resistance noted.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "antimicrobials-pharmacology"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "ampicillin-sulbactam",
+      "label": "Ampicillin-Sulbactam",
+      "type": "drug",
+      "subspecialty": "fundamentals",
+      "detail": "IV beta-lactam/beta-lactamase inhibitor combination that is a mainstay empiric therapy for deep neck space infections, covering streptococci, oral anaerobes and many gram-negatives.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Unasyn"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "antimicrobials-pharmacology"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "surgical-antibiotic-prophylaxis",
+      "label": "Surgical Antibiotic Prophylaxis",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "Timing (within 60 min of incision), agent (cefazolin ± metronidazole; add anaerobic/gram-negative coverage for clean-contaminated mucosal head and neck cases) and redosing based on surgical wound classification. Prophylaxis not routinely indicated for clean cases like thyroidectomy.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "perioperative antibiotics",
+        "SCIP prophylaxis"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "antimicrobials-pharmacology"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "vancomycin",
+      "label": "Vancomycin",
+      "type": "drug",
+      "subspecialty": "fundamentals",
+      "detail": "Glycopeptide covering MRSA and resistant gram-positives via cell-wall synthesis inhibition. Requires trough/AUC monitoring; nephrotoxicity and red-man (infusion) reaction are key adverse effects. Added when MRSA is suspected in severe head and neck infection.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "antimicrobials-pharmacology"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sensitivity-specificity",
+      "label": "Sensitivity & Specificity",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "Sensitivity = true positives / all diseased (SnNout: a sensitive test that is negative rules out disease). Specificity = true negatives / all non-diseased (SpPin: a specific test that is positive rules in). Both are intrinsic to the test and independent of prevalence.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Sn",
+        "Sp",
+        "SnNout",
+        "SpPin"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "biostatistics-evidence"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "predictive-values",
+      "label": "Positive & Negative Predictive Value",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "PPV = true positives / all test-positives; NPV = true negatives / all test-negatives. Unlike sensitivity/specificity, predictive values depend on disease prevalence: PPV rises and NPV falls as prevalence increases.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "PPV",
+        "NPV"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "biostatistics-evidence"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "likelihood-ratios",
+      "label": "Likelihood Ratios",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "LR+ = sensitivity/(1−specificity); LR− = (1−sensitivity)/specificity. Prevalence-independent; combined with pretest odds they yield post-test probability. LR+ >10 or LR− <0.1 substantially change management.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "LR+",
+        "LR-"
+      ],
+      "abbrev": "LR",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "biostatistics-evidence"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "study-designs",
+      "label": "Study Designs & Levels of Evidence",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "Hierarchy from case reports/series up through case-control (odds ratio), cohort (relative risk), randomized controlled trials, and systematic reviews/meta-analyses at the apex. RCTs minimize bias via randomization and blinding; observational designs suit rare/prognostic questions.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "levels of evidence",
+        "RCT",
+        "cohort",
+        "case-control"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "biostatistics-evidence"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "p-value-confidence-interval",
+      "label": "P-Value & Confidence Interval",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "The p-value is the probability of observing data as/more extreme under the null hypothesis (conventionally significant at <0.05); a 95% confidence interval conveys precision and, if it excludes the null (1 for ratios, 0 for differences), indicates significance. Type I error = false positive, Type II = false negative (1−power).",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "p value",
+        "confidence interval",
+        "CI",
+        "type I error",
+        "type II error"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "biostatistics-evidence"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "oral-cavity-scc",
+      "label": "Oral Cavity Squamous Cell Carcinoma",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "Most common oral cavity malignancy; risk factors tobacco/alcohol/betel nut. Oral tongue is the most common subsite. Elective neck dissection is favored when depth of invasion exceeds ~4 mm given occult nodal risk.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Oral SCC",
+        "OSCC"
+      ],
+      "abbrev": "OSCC",
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "oral-cavity-cancer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "oral-tongue",
+      "label": "Oral Tongue (Anterior Two-Thirds)",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Anterior two-thirds of the tongue, an oral cavity subsite; the lateral border is the most common site of oral SCC. Lymphatic drainage is primarily to levels I–III.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Anterior tongue"
+      ],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "oral-pharynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "oral-cavity-cancer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "floor-of-mouth",
+      "label": "Floor of Mouth",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Oral cavity subsite bounded by the mandible and tongue; houses the submandibular ducts. FOM tumors can approach the mandible and periosteum, influencing marginal versus segmental mandibulectomy decisions.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "FOM"
+      ],
+      "abbrev": "FOM",
+      "structure": "space",
+      "region": "oral-pharynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "oral-cavity-cancer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "depth-of-invasion",
+      "label": "Depth of Invasion (DOI)",
+      "type": "concept",
+      "subspecialty": "hn_onc",
+      "detail": "AJCC 8th edition added DOI to oral cavity T-staging: DOI ≤5 mm, >5–10 mm, and >10 mm upstage T1→T2→T3 respectively. DOI (measured from the basement membrane) is distinct from surface tumor thickness.",
+      "sources": [
+        "AJCC Cancer Staging Manual 8th ed",
+        "https://acsjournals.onlinelibrary.wiley.com/doi/full/10.3322/caac.21389"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "DOI"
+      ],
+      "abbrev": "DOI",
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "oral-cavity-cancer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "ajcc8-oral-cavity-staging",
+      "label": "AJCC 8th Ed. Oral Cavity Staging",
+      "type": "concept",
+      "subspecialty": "hn_onc",
+      "detail": "Incorporates depth of invasion into T and extranodal extension into N. Clinical/pathologic ENE upstages nodal disease (pN3b), reflecting its adverse prognostic weight in non-HPV mucosal SCC.",
+      "sources": [
+        "AJCC Cancer Staging Manual 8th ed",
+        "https://acsjournals.onlinelibrary.wiley.com/doi/full/10.3322/caac.21389"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "oral-cavity-cancer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "glossectomy",
+      "label": "Glossectomy",
+      "type": "procedure",
+      "subspecialty": "hn_onc",
+      "detail": "Partial to total resection of the tongue for oral tongue SCC. Reconstruction ranges from primary closure to radial forearm or ALT free flaps depending on defect size; speech/swallow outcomes drive reconstructive choice.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Partial glossectomy"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "oral-cavity-cancer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "oropharyngeal-scc",
+      "label": "Oropharyngeal Squamous Cell Carcinoma",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "Arises in tonsil, base of tongue, soft palate, posterior wall. HPV-positive disease now predominates and carries a markedly better prognosis than HPV-negative/tobacco-related tumors.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "https://acsjournals.onlinelibrary.wiley.com/doi/full/10.3322/caac.21389"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "OPSCC"
+      ],
+      "abbrev": "OPSCC",
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "oropharynx-hpv"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "hpv-p16-scc",
+      "label": "HPV / p16-Positive SCC",
+      "type": "concept",
+      "subspecialty": "hn_onc",
+      "detail": "p16 immunohistochemistry is the surrogate marker for transcriptionally active HPV (usually type 16) in oropharyngeal SCC. p16-positive tumors have distinct biology, better radiosensitivity, and separate AJCC 8th staging.",
+      "sources": [
+        "https://acsjournals.onlinelibrary.wiley.com/doi/full/10.3322/caac.21389",
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC7410862/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "p16-positive SCC",
+        "HPV-mediated SCC"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "oropharynx-hpv"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "palatine-tonsil",
+      "label": "Palatine Tonsil",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Lymphoid tissue in the tonsillar fossa between the palatoglossal and palatopharyngeal arches; the most common oropharyngeal subsite for HPV-associated SCC. Drains to levels II–III.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Tonsil"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "oropharynx-hpv"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "base-of-tongue",
+      "label": "Base of Tongue",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Posterior third of the tongue (lingual tonsil), an oropharyngeal subsite. A frequent site of HPV-associated SCC and of occult primaries presenting as cystic level II nodes.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "BOT",
+        "Tongue base"
+      ],
+      "abbrev": "BOT",
+      "structure": "muscle",
+      "region": "oral-pharynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "oropharynx-hpv"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "transoral-robotic-surgery",
+      "label": "Transoral Robotic Surgery (TORS)",
+      "type": "procedure",
+      "subspecialty": "hn_onc",
+      "detail": "Robotic-assisted transoral resection of oropharyngeal tumors, allowing de-escalation of adjuvant therapy in select HPV+ cases. ORATOR/ORATOR2 compared primary TORS with primary radiotherapy; the surgical arm had more swallowing morbidity and, in ORATOR2, excess grade-5 toxicity, tempering enthusiasm.",
+      "sources": [
+        "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC11121063/",
+        "https://www.ejcancer.com/article/S0959-8049(25)00124-8/abstract"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "TORS"
+      ],
+      "abbrev": "TORS",
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "oropharynx-hpv"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "ajcc8-hpv-oropharynx-staging",
+      "label": "AJCC 8th Ed. HPV+ Oropharynx Staging",
+      "type": "concept",
+      "subspecialty": "hn_onc",
+      "detail": "p16-positive OPSCC has its own staging: no Tis or T4b; clinical N by laterality/size (≤6 cm); pathologic N by node count (pN1 ≤4 nodes, pN2 >4). ENE is NOT part of HPV+ staging. Stage groupings shift so many node-positive patients are stage I–II, reflecting favorable survival.",
+      "sources": [
+        "https://acsjournals.onlinelibrary.wiley.com/doi/full/10.3322/caac.21389",
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC7410862/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "oropharynx-hpv"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "laryngeal-scc",
+      "label": "Laryngeal Squamous Cell Carcinoma",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "Strongly tobacco/alcohol related. Divided into glottic, supraglottic, and subglottic subsites with differing lymphatic drainage and prognosis. Organ-preservation chemoradiation competes with total laryngectomy for advanced disease.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Larynx cancer"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "larynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "laryngeal-cancer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "glottic-cancer",
+      "label": "Glottic Cancer",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "SCC of the true vocal folds; presents early with hoarseness and has sparse lymphatics, so early tumors (T1–T2) have excellent cure with single-modality radiation or transoral laser microsurgery.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "larynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "laryngeal-cancer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "supraglottic-cancer",
+      "label": "Supraglottic Cancer",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "SCC of epiglottis/false cords/aryepiglottic folds; rich bilateral lymphatics cause early, often bilateral, nodal metastasis, so elective treatment of both necks is standard.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "larynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "laryngeal-cancer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "true-vocal-fold",
+      "label": "True Vocal Fold",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Free edge of the glottis composed of the vocalis muscle, vocal ligament, and layered lamina propria. The paucity of lymphatics here underlies the favorable prognosis of early glottic cancer.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Vocal cord"
+      ],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "laryngeal-cancer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "total-laryngectomy",
+      "label": "Total Laryngectomy",
+      "type": "procedure",
+      "subspecialty": "hn_onc",
+      "detail": "En bloc removal of the larynx with permanent tracheostoma, for advanced or radiation-failed disease. Voice rehabilitation via tracheoesophageal puncture and prosthesis is standard.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Laryngectomy"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "larynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "laryngeal-cancer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "organ-preservation-larynx",
+      "label": "Laryngeal Organ Preservation",
+      "type": "concept",
+      "subspecialty": "hn_onc",
+      "detail": "Concurrent cisplatin-based chemoradiation preserves the larynx in many advanced cases (RTOG 91-11), reserving total laryngectomy for salvage. Not appropriate for a nonfunctional larynx or extensive cartilage invasion (T4a), where upfront surgery gives better survival.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "larynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "laryngeal-cancer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "transoral-laser-microsurgery",
+      "label": "Transoral Laser Microsurgery (TLM)",
+      "type": "procedure",
+      "subspecialty": "hn_onc",
+      "detail": "CO2-laser endoscopic resection of early glottic/supraglottic tumors, offering an organ-preserving alternative to radiation with the ability to re-treat and preserve future options.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "TLM"
+      ],
+      "abbrev": "TLM",
+      "structure": null,
+      "region": "larynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "laryngeal-cancer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "parotid-gland",
+      "label": "Parotid Gland",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Largest salivary gland, divided into superficial and deep lobes by the facial nerve. About 80% of salivary tumors arise here and most are benign; the facial nerve dictates surgical approach.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "salivary-gland-neoplasms"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pleomorphic-adenoma",
+      "label": "Pleomorphic Adenoma",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "Most common salivary neoplasm (benign mixed tumor) with epithelial and myxochondroid stroma. Requires complete excision with a cuff of normal tissue; enucleation risks recurrence, and long-standing lesions can undergo carcinoma ex pleomorphic adenoma transformation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Benign mixed tumor"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "salivary-gland-neoplasms"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "warthin-tumor",
+      "label": "Warthin Tumor",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "Papillary cystadenoma lymphomatosum: benign, associated with smoking, can be bilateral/multifocal, and is essentially confined to the parotid. Shows avidity on technetium pertechnetate scans.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Papillary cystadenoma lymphomatosum"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "salivary-gland-neoplasms"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "mucoepidermoid-carcinoma",
+      "label": "Mucoepidermoid Carcinoma",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "Most common salivary malignancy (and most common pediatric salivary malignancy). Graded low to high; harbors MAML2 fusions. Low-grade tumors behave indolently while high-grade tumors metastasize.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "MEC"
+      ],
+      "abbrev": "MEC",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "salivary-gland-neoplasms"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "adenoid-cystic-carcinoma",
+      "label": "Adenoid Cystic Carcinoma",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "Malignancy notorious for perineural invasion and late distant (lung) metastasis; cribriform, tubular, and solid patterns with the solid pattern most aggressive. Prone to skip lesions along nerves, complicating margin clearance.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ACC"
+      ],
+      "abbrev": "ACC",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "salivary-gland-neoplasms"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "parotidectomy",
+      "label": "Parotidectomy",
+      "type": "procedure",
+      "subspecialty": "hn_onc",
+      "detail": "Superficial or total parotidectomy with facial nerve identification (via the tragal pointer, tympanomastoid suture, posterior belly of digastric). Frey syndrome and facial nerve weakness are key complications.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "salivary-gland-neoplasms"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "fna-salivary",
+      "label": "Salivary FNA / Milan System",
+      "type": "concept",
+      "subspecialty": "hn_onc",
+      "detail": "Fine-needle aspiration is first-line for a salivary mass; the Milan System for Reporting Salivary Gland Cytopathology stratifies malignancy risk across six categories to guide surgery.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Milan System",
+        "FNA"
+      ],
+      "abbrev": "FNA",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "salivary-gland-neoplasms"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "level-i-neck",
+      "label": "Neck Level I (Submental/Submandibular)",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Level Ia (submental) and Ib (submandibular); first-echelon drainage for the oral cavity, lip, and anterior tongue. Bounded by the mandible, digastric, and hyoid.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Level 1"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "level-ii-neck",
+      "label": "Neck Level II (Upper Jugular)",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Upper jugular nodes from skull base to hyoid, split into IIa/IIb by the spinal accessory nerve. First-echelon drainage for oropharynx, larynx, and the most common site of cystic nodal metastasis in HPV+ disease.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Level 2"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "level-iii-neck",
+      "label": "Neck Level III (Middle Jugular)",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Middle jugular nodes from hyoid to cricoid. Drains the oral cavity, oropharynx, hypopharynx, and larynx.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Level 3"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "level-iv-neck",
+      "label": "Neck Level IV (Lower Jugular)",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Lower jugular nodes from cricoid to clavicle. Drains the hypopharynx, larynx, thyroid, and cervical esophagus; includes the Virchow node region.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Level 4"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "level-v-neck",
+      "label": "Neck Level V (Posterior Triangle)",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Posterior triangle nodes behind the sternocleidomastoid, split by the omohyoid. Drains the nasopharynx, posterior scalp, and neck skin; involved in nasopharyngeal and cutaneous malignancies.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Level 5"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "level-vi-neck",
+      "label": "Neck Level VI (Central Compartment)",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Central compartment (pretracheal, paratracheal, prelaryngeal/Delphian) nodes between the carotid sheaths. Primary drainage for the thyroid, subglottis, and cervical esophagus.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Level 6",
+        "Central compartment"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "level-vii-neck",
+      "label": "Neck Level VII (Superior Mediastinal)",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Superior mediastinal nodes below the suprasternal notch. Involved by subglottic, thyroid, cervical esophageal, and advanced hypopharyngeal cancers.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Level 7"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "neck-dissection",
+      "label": "Neck Dissection",
+      "type": "procedure",
+      "subspecialty": "hn_onc",
+      "detail": "Systematic removal of cervical lymph node levels for staging and treatment. Classified as radical, modified radical, selective, and extended based on which levels and non-lymphatic structures (SCM, IJV, CN XI) are addressed.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "radical-neck-dissection",
+      "label": "Radical Neck Dissection",
+      "type": "procedure",
+      "subspecialty": "hn_onc",
+      "detail": "Removal of levels I–V with sacrifice of the spinal accessory nerve, internal jugular vein, and sternocleidomastoid. Modified radical variants preserve one or more of these three structures to reduce shoulder morbidity.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "RND"
+      ],
+      "abbrev": "RND",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "selective-neck-dissection",
+      "label": "Selective Neck Dissection",
+      "type": "procedure",
+      "subspecialty": "hn_onc",
+      "detail": "Preserves node levels not at risk while removing first-echelon basins (e.g., I–III for oral cavity, II–IV for larynx/pharynx). Standard for the N0 or low-burden neck; spares CN XI, IJV, and SCM.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "SND"
+      ],
+      "abbrev": "SND",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "unknown-primary-scc",
+      "label": "Carcinoma of Unknown Primary (Head & Neck)",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "Metastatic cervical SCC with no identified mucosal source. Workup includes p16/EBV testing, PET-CT, exam under anesthesia, and TORS lingual/palatine tonsillectomy; p16+ level II nodes point to an occult oropharyngeal primary.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CUP",
+        "Unknown primary"
+      ],
+      "abbrev": "CUP",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sentinel-lymph-node-biopsy",
+      "label": "Sentinel Lymph Node Biopsy",
+      "type": "procedure",
+      "subspecialty": "hn_onc",
+      "detail": "Lymphatic mapping to identify the first-draining node, established for cutaneous melanoma and increasingly used in early oral cavity SCC to stage the clinically N0 neck while avoiding elective dissection.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "SLNB"
+      ],
+      "abbrev": "SLNB",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "extranodal-extension",
+      "label": "Extranodal Extension (ENE)",
+      "type": "concept",
+      "subspecialty": "hn_onc",
+      "detail": "Tumor breach of the nodal capsule into perinodal tissue; a strong adverse prognosticator that upstages non-HPV nodal disease (pN3b) in AJCC 8th ed and, with positive margins, indicates adjuvant concurrent chemoradiation. Not incorporated into HPV+ oropharyngeal staging.",
+      "sources": [
+        "https://acsjournals.onlinelibrary.wiley.com/doi/full/10.3322/caac.21389",
+        "https://pubmed.ncbi.nlm.nih.gov/36655591/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ENE",
+        "Extracapsular spread",
+        "ECS"
+      ],
+      "abbrev": "ENE",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cutaneous-scc",
+      "label": "Cutaneous Squamous Cell Carcinoma",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "Common sun-exposed head/neck skin cancer. High-risk features include >2 mm thickness, perineural invasion, poor differentiation, ear/lip primary, and immunosuppression; these drive nodal metastasis to parotid and neck nodes.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC11352224/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "cSCC"
+      ],
+      "abbrev": "cSCC",
+      "structure": null,
+      "region": "external-ear",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "cutaneous-scc-melanoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cutaneous-melanoma",
+      "label": "Cutaneous Melanoma (Head & Neck)",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "Head/neck (especially scalp) melanomas are thicker and more lethal than other sites. Wide local excision margins scale with Breslow thickness; sentinel node biopsy is considered for lesions ≥0.8 mm or with adverse features.",
+      "sources": [
+        "https://www.ncbi.nlm.nih.gov/books/NBK572149/",
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC10743441/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Melanoma"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "external-ear",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "cutaneous-scc-melanoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "breslow-thickness",
+      "label": "Breslow Thickness",
+      "type": "concept",
+      "subspecialty": "hn_onc",
+      "detail": "Vertical tumor thickness in mm from the granular layer, the dominant T-category determinant for melanoma in AJCC 8th ed alongside ulceration. Guides excision margins and sentinel node decisions.",
+      "sources": [
+        "AJCC Cancer Staging Manual 8th ed",
+        "https://iowaprotocols.medicine.uiowa.edu/protocols/melanoma-evaluation-and-management-8th-edition-ajcc"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Breslow depth"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "external-ear",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "cutaneous-scc-melanoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "parotid-lymph-nodes",
+      "label": "Parotid (Periparotid) Lymph Nodes",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Intra- and periparotid nodes that are the first-echelon basin for the anterior scalp, temple, and auricle. Frequently involved by cutaneous SCC and melanoma, often mandating parotidectomy plus neck dissection.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "cutaneous-scc-melanoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "mohs-surgery",
+      "label": "Mohs Micrographic Surgery",
+      "type": "procedure",
+      "subspecialty": "hn_onc",
+      "detail": "Staged excision with complete circumferential peripheral and deep margin assessment, maximizing cure and tissue conservation for high-risk facial cutaneous SCC and basal cell carcinoma.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Mohs"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "cutaneous-scc-melanoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "nasopharyngeal-carcinoma",
+      "label": "Nasopharyngeal Carcinoma",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "EBV-associated (WHO type III nonkeratinizing) carcinoma endemic in Southern China. Presents with a neck mass, epistaxis, and serous otitis; radiosensitive, treated primarily with (chemo)radiation rather than surgery.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "NPC"
+      ],
+      "abbrev": "NPC",
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "nasopharyngeal-carcinoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "nasopharynx",
+      "label": "Nasopharynx",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Space behind the nasal cavity above the soft palate; the fossa of Rosenmüller is the most common origin of NPC. Eustachian tube obstruction here causes unilateral serous otitis media in adults, a red flag.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "space",
+      "region": "nasal-sinus",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "nasopharyngeal-carcinoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "ebv-nasopharyngeal",
+      "label": "Epstein-Barr Virus (NPC)",
+      "type": "concept",
+      "subspecialty": "hn_onc",
+      "detail": "EBV drives nonkeratinizing NPC; plasma EBV DNA serves as a biomarker for diagnosis, monitoring treatment response, and detecting recurrence in endemic populations.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "EBV"
+      ],
+      "abbrev": "EBV",
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "nasopharyngeal-carcinoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "hypopharyngeal-scc",
+      "label": "Hypopharyngeal Squamous Cell Carcinoma",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "Aggressive SCC (pyriform sinus most common) with early submucosal spread and nodal metastasis, hence poor prognosis. Advanced disease often needs total laryngopharyngectomy with free-flap reconstruction.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "larynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hypopharynx-cervical-esophagus"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pyriform-sinus",
+      "label": "Pyriform Sinus",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Most common hypopharyngeal subsite, a recess lateral to the larynx. Rich lymphatics lead to early level II–IV nodal spread; medial-wall tumors can invade the larynx.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Piriform sinus",
+        "Pyriform fossa"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hypopharynx-cervical-esophagus"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cervical-esophagus",
+      "label": "Cervical Esophagus / Postcricoid Region",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Hypopharyngeal-esophageal junction; postcricoid carcinoma is associated with Plummer-Vinson syndrome. Circumferential defects here typically need jejunal or tubed free-flap reconstruction.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Postcricoid region"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "larynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hypopharynx-cervical-esophagus"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "free-flap-reconstruction",
+      "label": "Free Flap Reconstruction (Pharyngoesophageal)",
+      "type": "procedure",
+      "subspecialty": "hn_onc",
+      "detail": "Microvascular reconstruction of pharyngoesophageal defects using radial forearm, anterolateral thigh (tubed), or jejunal free flaps to restore swallowing continuity after laryngopharyngectomy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Free tissue transfer"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hypopharynx-cervical-esophagus"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "paraganglioma",
+      "label": "Paraganglioma (Head & Neck)",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "Neuroendocrine tumor of paraganglia (glomus tumors), usually benign but hypervascular. Classic salt-and-pepper appearance on MRI; a minority are catecholamine-secreting and require preoperative screening.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Glomus tumor"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "paraganglioma-vascular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "carotid-body-tumor",
+      "label": "Carotid Body Tumor",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "Paraganglioma at the carotid bifurcation, splaying the internal and external carotid arteries (lyre sign). Shamblin classification grades encasement of the carotid and predicts surgical risk.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Chemodectoma"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "paraganglioma-vascular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "glomus-jugulare",
+      "label": "Glomus Jugulare / Tympanicum",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "Temporal bone paraganglioma of the jugular bulb (jugulare) or Jacobson nerve on the promontory (tympanicum). Presents with pulsatile tinnitus and a red retrotympanic mass; Fisch classification guides management.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Glomus tympanicum",
+        "Jugulotympanic paraganglioma"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "temporal-bone",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "paraganglioma-vascular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sdhx-mutation",
+      "label": "SDHx Mutations",
+      "type": "concept",
+      "subspecialty": "hn_onc",
+      "detail": "Germline succinate dehydrogenase subunit (SDHB/C/D) mutations underlie hereditary paraganglioma-pheochromocytoma syndromes; SDHB carries higher malignancy risk. Genetic testing is recommended for head/neck paraganglioma, especially multifocal or young patients.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "SDHB",
+        "SDHD"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "paraganglioma-vascular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "preoperative-embolization",
+      "label": "Preoperative Embolization",
+      "type": "procedure",
+      "subspecialty": "hn_onc",
+      "detail": "Angiographic embolization of feeding vessels 24–48 h before resection of hypervascular tumors (paragangliomas, JNA) to reduce intraoperative blood loss.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Embolization"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "paraganglioma-vascular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "imrt",
+      "label": "Intensity-Modulated Radiation Therapy",
+      "type": "procedure",
+      "subspecialty": "hn_onc",
+      "detail": "Conformal RT that shapes dose to the target while sparing parotids and other organs at risk, reducing xerostomia. Standard technique for definitive and adjuvant head/neck radiation, typically ~70 Gy definitive.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "IMRT"
+      ],
+      "abbrev": "IMRT",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "radiation-systemic-principles"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cisplatin",
+      "label": "Cisplatin",
+      "type": "drug",
+      "subspecialty": "hn_onc",
+      "detail": "Platinum radiosensitizer given concurrently with definitive/adjuvant RT (high-dose 100 mg/m² q3 weeks). Key toxicities are nephrotoxicity, ototoxicity, and neuropathy; indicated as adjuvant chemoradiation for ENE or positive margins.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "radiation-systemic-principles"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cetuximab",
+      "label": "Cetuximab",
+      "type": "drug",
+      "subspecialty": "hn_onc",
+      "detail": "Anti-EGFR monoclonal antibody used as a radiosensitizer (Bonner trial) for patients unable to tolerate cisplatin. De-escalation trials (RTOG 1016/De-ESCALaTE) showed it is inferior to cisplatin in HPV+ oropharyngeal cancer, so it is not preferred there.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "radiation-systemic-principles"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pembrolizumab",
+      "label": "Pembrolizumab",
+      "type": "drug",
+      "subspecialty": "hn_onc",
+      "detail": "Anti-PD-1 checkpoint inhibitor. KEYNOTE-048 established first-line pembrolizumab (monotherapy if CPS ≥1, or with platinum/5-FU) for recurrent/metastatic HNSCC, improving overall survival versus the EXTREME regimen.",
+      "sources": [
+        "https://ascopost.com/issues/june-25-2019/fda-approves-pembrolizumab-for-the-first-line-treatment-of-hnscc/",
+        "https://www.merck.com/news/keytruda-pembrolizumab-monotherapy-met-a-primary-endpoint-in-the-phase-3-keynote-048-trial-significantly-improving-os-as-first-line-therapy-in-head-and-neck-squamous-cell-carcinoma-patients-w/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Keytruda"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "radiation-systemic-principles"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "concurrent-chemoradiation",
+      "label": "Concurrent Chemoradiation",
+      "type": "concept",
+      "subspecialty": "hn_onc",
+      "detail": "Definitive or adjuvant platinum-based chemotherapy delivered concurrently with radiation to radiosensitize and treat micrometastases. Standard for advanced laryngeal (organ preservation), nasopharyngeal, and high-risk postoperative disease.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CRT",
+        "Chemoradiotherapy"
+      ],
+      "abbrev": "CRT",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "radiation-systemic-principles"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "radiation-toxicity-head-neck",
+      "label": "Head & Neck Radiation Toxicity",
+      "type": "concept",
+      "subspecialty": "hn_onc",
+      "detail": "Acute mucositis and dermatitis and late xerostomia, dysphagia, trismus, hypothyroidism, and osteoradionecrosis of the mandible. IMRT and dental clearance before RT mitigate these; osteoradionecrosis risk drives pre-RT extraction planning.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Osteoradionecrosis",
+        "Xerostomia"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "radiation-systemic-principles"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "thyroid-cartilage",
+      "label": "Thyroid Cartilage",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Largest laryngeal cartilage; two laminae meet anteriorly at the laryngeal prominence. Its inner surface at the anterior commissure is the attachment (Broyles ligament) for the vocal ligaments and a route of tumor spread.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Adam's apple"
+      ],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cricoid-cartilage",
+      "label": "Cricoid Cartilage",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Only complete cartilaginous ring of the airway (signet-ring shape, tall posterior lamina). Forms the subglottis; narrowest point of the pediatric airway and the level implicated in subglottic stenosis.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "arytenoid-cartilage",
+      "label": "Arytenoid Cartilage",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Paired pyramidal cartilages atop the cricoid; the vocal process anchors the vocal ligament and the muscular process receives the posterior and lateral cricoarytenoid muscles. Rotation/gliding at the cricoarytenoid joint abducts and adducts the vocal folds.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "epiglottis",
+      "label": "Epiglottis",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Leaf-shaped elastic cartilage that deflects the bolus during swallowing. Its petiole attaches to the thyroid cartilage; the pre-epiglottic space is a route of supraglottic cancer spread.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cricoarytenoid-joint",
+      "label": "Cricoarytenoid Joint",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Synovial joint between the arytenoid base and the cricoid lamina permitting the rocking/gliding that opens and closes the glottis. Fixation (e.g., rheumatoid arthritis, intubation trauma) mimics vocal fold paralysis and is distinguished by palpation under anesthesia and by EMG.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cricothyroid-joint",
+      "label": "Cricothyroid Joint",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Synovial articulation between the inferior thyroid cornu and the cricoid; visor-like rotation by the cricothyroid muscle lengthens and tenses the vocal folds to raise pitch.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "vocal-ligament",
+      "label": "Vocal Ligament",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "The intermediate and deep layers of the lamina propria; the free upper edge of the conus elasticus running from the vocal process of the arytenoid to the anterior commissure. Forms the medial edge of the vocal fold.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "ligament",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "benign-vocal-fold-lesions"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "vocal-fold-lamina-propria",
+      "label": "Vocal Fold Lamina Propria (Layered)",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Trilaminar cover of the vocal fold: superficial (Reinke space, gelatinous), intermediate (elastic), and deep (collagenous) layers; the intermediate + deep layers form the vocal ligament. The pliable superficial layer generates the mucosal wave; scar or lesions that stiffen it cause dysphonia (Hirano body-cover model).",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "body-cover model"
+      ],
+      "abbrev": null,
+      "structure": "membrane",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "benign-vocal-fold-lesions"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "reinke-space",
+      "label": "Reinke's Space",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "The superficial layer of the lamina propria, a loose gelatinous potential space essential to the mucosal wave. Fluid accumulation here (polypoid corditis/Reinke edema) is classically caused by smoking.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "superficial lamina propria"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "benign-vocal-fold-lesions"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "conus-elasticus",
+      "label": "Conus Elasticus (Cricothyroid Membrane)",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Elastic membrane rising from the cricoid arch to end superiorly as the free vocal ligaments; its anterior thickening is the cricothyroid membrane traversed in cricothyrotomy. Bounds the subglottis medially.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "cricovocal membrane"
+      ],
+      "abbrev": null,
+      "structure": "membrane",
+      "region": "larynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "laryngotracheal-stenosis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "thyroarytenoid-muscle",
+      "label": "Thyroarytenoid Muscle",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Intrinsic adductor forming the body of the vocal fold; its medial vocalis fibers fine-tune tension. Primary target for botulinum toxin in adductor spasmodic dysphonia.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "vocalis"
+      ],
+      "abbrev": "TA",
+      "structure": "muscle",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "posterior-cricoarytenoid-muscle",
+      "label": "Posterior Cricoarytenoid Muscle",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "The ONLY abductor of the vocal folds, opening the glottis for respiration. Bilateral loss produces adducted folds and airway compromise.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "PCA"
+      ],
+      "abbrev": "PCA",
+      "structure": "muscle",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "lateral-cricoarytenoid-muscle",
+      "label": "Lateral Cricoarytenoid Muscle",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Intrinsic adductor that rotates the arytenoid to close the membranous glottis for phonation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "LCA"
+      ],
+      "abbrev": "LCA",
+      "structure": "muscle",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "interarytenoid-muscle",
+      "label": "Interarytenoid Muscle",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Transverse and oblique fibers bridging the arytenoids to close the posterior (cartilaginous) glottis. The only intrinsic laryngeal muscle with bilateral RLN innervation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "arytenoid muscle"
+      ],
+      "abbrev": "IA",
+      "structure": "muscle",
+      "region": "larynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cricothyroid-muscle",
+      "label": "Cricothyroid Muscle",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Tensor of the vocal folds (raises pitch); the only intrinsic laryngeal muscle NOT innervated by the recurrent laryngeal nerve—it is supplied by the external branch of the superior laryngeal nerve.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CT muscle"
+      ],
+      "abbrev": "CT",
+      "structure": "muscle",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cricopharyngeus-muscle",
+      "label": "Cricopharyngeus Muscle",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Horizontal fibers of the inferior pharyngeal constrictor forming the upper esophageal sphincter. Failure to relax (cricopharyngeal dysfunction) raises hypopharyngeal pressure and predisposes to Zenker diverticulum through Killian's dehiscence.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "upper esophageal sphincter"
+      ],
+      "abbrev": "UES",
+      "structure": "muscle",
+      "region": "larynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "zenker-cricopharyngeal-dysphagia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "superior-laryngeal-nerve",
+      "label": "Superior Laryngeal Nerve",
+      "type": "nerve",
+      "subspecialty": "laryngology",
+      "detail": "Vagal branch dividing into an internal branch (supraglottic sensation, pierces the thyrohyoid membrane) and an external branch (motor to cricothyroid). External branch injury during thyroidectomy causes loss of high-pitch/vocal fatigue (the 'Amelita Galli-Curci' lesion).",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "SLN"
+      ],
+      "abbrev": "SLN",
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "vocal-fold-nodules",
+      "label": "Vocal Fold Nodules",
+      "type": "pathology",
+      "subspecialty": "laryngology",
+      "detail": "Bilateral, symmetric fibrous thickenings at the midpoint of the membranous fold (junction of anterior and middle thirds) from phonotrauma. First-line treatment is voice therapy, not surgery.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "singer's nodules",
+        "screamer's nodules"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "benign-vocal-fold-lesions"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "vocal-fold-polyp",
+      "label": "Vocal Fold Polyp",
+      "type": "pathology",
+      "subspecialty": "laryngology",
+      "detail": "Usually unilateral exophytic lesion of the superficial lamina propria, often hemorrhagic from a single phonotraumatic event. Frequently requires phonomicrosurgery when it fails to resolve with voice rest and therapy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "benign-vocal-fold-lesions"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "vocal-fold-cyst",
+      "label": "Vocal Fold Cyst",
+      "type": "pathology",
+      "subspecialty": "laryngology",
+      "detail": "Subepithelial mucus-retention or epidermoid cyst within the lamina propria that dampens the mucosal wave. Tends to resist voice therapy and needs microsurgical excision preserving the ligament.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "benign-vocal-fold-lesions"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "reinke-edema",
+      "label": "Reinke's Edema (Polypoid Corditis)",
+      "type": "pathology",
+      "subspecialty": "laryngology",
+      "detail": "Diffuse gelatinous fluid accumulation in Reinke's space, typically bilateral and strongly associated with smoking; produces a low, gravelly voice. Management centers on smoking cessation with staged microflap reduction.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "polypoid corditis",
+        "smoker's polyps"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "benign-vocal-fold-lesions"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "vocal-fold-microflap",
+      "label": "Phonomicrosurgery / Microflap Excision",
+      "type": "procedure",
+      "subspecialty": "laryngology",
+      "detail": "Microlaryngoscopic elevation of a mucosal microflap to remove a benign lesion while preserving the vocal ligament and superficial lamina propria, protecting the mucosal wave. Cornerstone of surgical management for cysts and recalcitrant polyps.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "microflap",
+        "phonosurgery"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "benign-vocal-fold-lesions"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "vocal-fold-paralysis",
+      "label": "Vocal Fold Paralysis",
+      "type": "pathology",
+      "subspecialty": "laryngology",
+      "detail": "Immobility from RLN/vagal injury; unilateral (breathy voice, aspiration) most often from thyroid/thoracic surgery or malignancy, bilateral (airway obstruction) after thyroidectomy. Must be distinguished from cricoarytenoid joint fixation by laryngeal EMG and palpation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "vocal cord paralysis",
+        "vocal fold immobility"
+      ],
+      "abbrev": "VFP",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "medialization-thyroplasty",
+      "label": "Medialization Laryngoplasty (Type I Thyroplasty)",
+      "type": "procedure",
+      "subspecialty": "laryngology",
+      "detail": "Isshiki type I thyroplasty places an implant (Silastic, Gore-Tex, or titanium) through a thyroid cartilage window to push a paralyzed fold medially. Permanent option for unilateral paralysis, often combined with arytenoid adduction for a large posterior glottic gap.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "type I thyroplasty",
+        "laryngeal framework surgery"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "injection-laryngoplasty",
+      "label": "Injection Laryngoplasty",
+      "type": "procedure",
+      "subspecialty": "laryngology",
+      "detail": "Injection of a bulking agent (carboxymethylcellulose or hyaluronic acid temporarily, calcium hydroxylapatite longer-term) lateral to the vocalis to medialize the fold. Ideal early/temporary treatment when spontaneous recovery of the RLN is still possible.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "vocal fold injection",
+        "injection augmentation"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "laryngeal-reinnervation",
+      "label": "Laryngeal Reinnervation",
+      "type": "procedure",
+      "subspecialty": "laryngology",
+      "detail": "Ansa cervicalis-to-RLN anastomosis restores muscle tone and bulk to a paralyzed fold without restoring purposeful movement; favored in younger patients with permanent unilateral paralysis.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ansa-to-RLN reinnervation"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "subglottic-stenosis",
+      "label": "Laryngotracheal / Subglottic Stenosis",
+      "type": "pathology",
+      "subspecialty": "laryngology",
+      "detail": "Narrowing at the cricoid/subglottis, most often acquired from prolonged intubation; other causes include GPA (granulomatosis with polyangiitis) and idiopathic subglottic stenosis in women. Graded by the Cotton-Myer system.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "subglottic stenosis",
+        "laryngotracheal stenosis",
+        "SGS"
+      ],
+      "abbrev": "SGS",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "laryngotracheal-stenosis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cotton-myer-classification",
+      "label": "Cotton-Myer Classification",
+      "type": "concept",
+      "subspecialty": "laryngology",
+      "detail": "Grades subglottic stenosis by luminal obstruction: Grade I 0-50%, II 51-70%, III 71-99%, IV no detectable lumen. Assessed under anesthesia by comparing the largest endotracheal tube passed (with an air leak) against age-expected size.",
+      "sources": [
+        "https://journals.sagepub.com/doi/10.1177/000348949410300410",
+        "https://www.ncbi.nlm.nih.gov/books/NBK563265/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Myer-Cotton grading"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "laryngotracheal-stenosis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "endoscopic-airway-dilation",
+      "label": "Endoscopic Airway Dilation",
+      "type": "procedure",
+      "subspecialty": "laryngology",
+      "detail": "Balloon or rigid dilation of a stenotic segment, often with radial CO2 laser incisions and adjunct topical/intralesional steroid or mitomycin-C. Best for thin, short (Cotton-Myer I-II) web-like stenoses; mature circumferential scar tends to recur and may need open repair.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "balloon dilation",
+        "endoscopic dilation"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "laryngotracheal-stenosis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cricotracheal-resection",
+      "label": "Cricotracheal Resection",
+      "type": "procedure",
+      "subspecialty": "laryngology",
+      "detail": "Open resection of the stenotic subglottic/cricoid segment with thyrotracheal anastomosis; definitive treatment for severe (Cotton-Myer III-IV) or refractory stenosis. Suprahyoid release and chin-to-chest positioning reduce anastomotic tension.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CTR",
+        "tracheal resection"
+      ],
+      "abbrev": "CTR",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "laryngotracheal-stenosis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "laryngotracheal-reconstruction",
+      "label": "Laryngotracheal Reconstruction",
+      "type": "procedure",
+      "subspecialty": "laryngology",
+      "detail": "Expansion of the airway with autologous (costal) cartilage grafts placed via anterior and/or posterior cricoid split, done as single- or double-stage repair. Mainstay open technique for pediatric subglottic stenosis.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "LTR",
+        "laryngotracheoplasty"
+      ],
+      "abbrev": "LTR",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "laryngotracheal-stenosis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "killian-dehiscence",
+      "label": "Killian's Dehiscence",
+      "type": "concept",
+      "subspecialty": "laryngology",
+      "detail": "Triangular area of weakness in the posterior hypopharyngeal wall between the oblique thyropharyngeus and horizontal cricopharyngeus fibers. This is the site through which a Zenker (pulsion) diverticulum herniates.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Killian triangle"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "zenker-cricopharyngeal-dysphagia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "zenker-diverticulum",
+      "label": "Zenker's Diverticulum",
+      "type": "pathology",
+      "subspecialty": "laryngology",
+      "detail": "False (mucosal) pulsion diverticulum through Killian's dehiscence driven by cricopharyngeal dysfunction; presents with dysphagia, regurgitation of undigested food, halitosis, and aspiration in older adults. Diagnosed by barium esophagram.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "pharyngoesophageal diverticulum",
+        "Zenker"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "zenker-cricopharyngeal-dysphagia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cricopharyngeal-dysfunction",
+      "label": "Cricopharyngeal Dysfunction",
+      "type": "pathology",
+      "subspecialty": "laryngology",
+      "detail": "Impaired relaxation/opening of the upper esophageal sphincter producing a cricopharyngeal bar on esophagram and transfer dysphagia. Underlies Zenker formation and can be idiopathic, neurogenic, or reflux-related.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "cricopharyngeal achalasia",
+        "cricopharyngeal bar"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "zenker-cricopharyngeal-dysphagia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cricopharyngeal-myotomy",
+      "label": "Cricopharyngeal Myotomy",
+      "type": "procedure",
+      "subspecialty": "laryngology",
+      "detail": "Division of the cricopharyngeus (open or endoscopic) to relieve UES outflow obstruction; the key step in both open and endoscopic treatment of Zenker diverticulum and isolated cricopharyngeal dysfunction. Botulinum toxin injection is a less durable alternative/diagnostic test.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CP myotomy"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "zenker-cricopharyngeal-dysphagia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "endoscopic-diverticulotomy",
+      "label": "Endoscopic Diverticulotomy (Stapler/Laser)",
+      "type": "procedure",
+      "subspecialty": "laryngology",
+      "detail": "Transoral division of the common wall between the diverticulum and esophagus (stapler or CO2 laser), simultaneously performing the cricopharyngeal myotomy. Faster recovery than open repair but requires adequate neck extension and a pouch large enough to expose.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Dohlman procedure",
+        "endoscopic stapling"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "zenker-cricopharyngeal-dysphagia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "laryngopharyngeal-reflux",
+      "label": "Laryngopharyngeal Reflux",
+      "type": "pathology",
+      "subspecialty": "laryngology",
+      "detail": "Retrograde flow of gastric contents reaching the larynx/pharynx causing hoarseness, globus, throat clearing, and cough; posterior laryngeal edema/erythema on exam. Unlike GERD, heartburn is often absent (upright/atypical reflux).",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "LPR",
+        "reflux laryngitis"
+      ],
+      "abbrev": "LPR",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "lpr-chronic-cough"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "chronic-cough",
+      "label": "Chronic (Neurogenic) Cough",
+      "type": "pathology",
+      "subspecialty": "laryngology",
+      "detail": "Cough >8 weeks; after excluding asthma, upper airway cough syndrome, and reflux, a refractory/neurogenic cough from laryngeal sensory neuropathy is treated with neuromodulators (gabapentin, amitriptyline) and behavioral cough-suppression therapy. Superior laryngeal nerve block is an emerging option.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "neurogenic cough",
+        "laryngeal sensory neuropathy"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "lpr-chronic-cough"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "reflux-symptom-index",
+      "label": "Reflux Symptom Index (RSI)",
+      "type": "concept",
+      "subspecialty": "laryngology",
+      "detail": "Nine-item patient questionnaire (each 0-5, max 45) scoring LPR symptoms; a score >13 is considered abnormal and suggestive of laryngopharyngeal reflux.",
+      "sources": [
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC9702003/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "RSI"
+      ],
+      "abbrev": "RSI",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "lpr-chronic-cough"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "reflux-finding-score",
+      "label": "Reflux Finding Score (RFS)",
+      "type": "concept",
+      "subspecialty": "laryngology",
+      "detail": "Eight-item laryngoscopic grading of reflux signs (subglottic edema, ventricular obliteration, erythema, vocal fold/diffuse edema, posterior commissure hypertrophy, granuloma, thick mucus), 0-26; a score >7 suggests LPR.",
+      "sources": [
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC9194976/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "RFS"
+      ],
+      "abbrev": "RFS",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "lpr-chronic-cough"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "proton-pump-inhibitor",
+      "label": "Proton Pump Inhibitor",
+      "type": "drug",
+      "subspecialty": "laryngology",
+      "detail": "Irreversibly inhibits gastric H+/K+ ATPase; empiric once- to twice-daily PPI therapy for 2-3 months is first-line for LPR alongside behavioral/dietary reflux precautions. Benefit in isolated laryngeal symptoms is debated given a strong placebo effect.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "PPI",
+        "omeprazole"
+      ],
+      "abbrev": "PPI",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "lpr-chronic-cough"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "spasmodic-dysphonia",
+      "label": "Spasmodic Dysphonia",
+      "type": "pathology",
+      "subspecialty": "laryngology",
+      "detail": "Task-specific focal laryngeal dystonia. Adductor type (most common) gives a strained-strangled voice with glottal stops; abductor type gives breathy breaks. Symptoms lessen with singing/laughing, distinguishing it from muscle tension dysphonia.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "laryngeal dystonia",
+        "SD"
+      ],
+      "abbrev": "SD",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "spasmodic-dysphonia-neurolaryngology"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "muscle-tension-dysphonia",
+      "label": "Muscle Tension Dysphonia",
+      "type": "pathology",
+      "subspecialty": "laryngology",
+      "detail": "Functional hyperfunctional voice disorder with excessive laryngeal/supraglottic muscle recruitment and no primary neurologic lesion; unlike spasmodic dysphonia it is not task-specific and responds to voice therapy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "MTD"
+      ],
+      "abbrev": "MTD",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "spasmodic-dysphonia-neurolaryngology"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "essential-vocal-tremor",
+      "label": "Essential Vocal Tremor",
+      "type": "pathology",
+      "subspecialty": "laryngology",
+      "detail": "Rhythmic 4-8 Hz oscillation of the voice present across tasks (including sustained vowels and at rest), often part of essential tremor. Distinguished from spasmodic dysphonia by its regular rhythm and lack of voice breaks.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "vocal tremor"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "spasmodic-dysphonia-neurolaryngology"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "botulinum-toxin",
+      "label": "Botulinum Toxin (OnabotulinumtoxinA)",
+      "type": "drug",
+      "subspecialty": "laryngology",
+      "detail": "Cleaves SNAP-25 to block acetylcholine release at the neuromuscular junction. First-line for adductor spasmodic dysphonia via EMG-guided injection into the thyroarytenoid muscles (commonly ~1.25-2.5 units per side), with effects lasting ~3-4 months; also used for cricopharyngeal dysfunction and sialorrhea.",
+      "sources": [
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC5712671/",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Botox",
+        "BoNT-A"
+      ],
+      "abbrev": "BoNT",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "spasmodic-dysphonia-neurolaryngology"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "laryngeal-emg",
+      "label": "Laryngeal Electromyography",
+      "type": "procedure",
+      "subspecialty": "laryngology",
+      "detail": "Records intrinsic laryngeal muscle activity to distinguish neurogenic paralysis from cricoarytenoid joint fixation, prognosticate recovery of vocal fold paralysis, and guide targeted botulinum toxin injection in spasmodic dysphonia.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "LEMG"
+      ],
+      "abbrev": "LEMG",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "spasmodic-dysphonia-neurolaryngology"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "caustic-ingestion",
+      "label": "Caustic Ingestion",
+      "type": "pathology",
+      "subspecialty": "laryngology",
+      "detail": "Alkali causes liquefactive necrosis with deep penetration (worse esophageal injury/stricture), whereas acid causes coagulative necrosis. Do NOT induce emesis, give charcoal, or blindly pass a nasogastric tube; early flexible endoscopy grades injury. Airway assessment is paramount.",
+      "sources": [
+        "https://www.ncbi.nlm.nih.gov/books/NBK557442/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "caustic injury",
+        "corrosive ingestion"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "esophagology-caustic-ingestion"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "zargar-classification",
+      "label": "Zargar Endoscopic Classification",
+      "type": "concept",
+      "subspecialty": "laryngology",
+      "detail": "Grades caustic mucosal injury: 0 normal; I edema/hyperemia; IIa superficial ulceration/exudate; IIb deep or circumferential ulcers; IIIa focal necrosis; IIIb extensive necrosis; IV perforation. Grade IIb and III predict stricture formation and higher morbidity/mortality.",
+      "sources": [
+        "https://www.otoscape.com/eponyms/zargar-classification-of-caustic-esophageal-injury.html",
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC5421115/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Zargar grading"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "esophagology-caustic-ingestion"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "esophageal-stricture",
+      "label": "Esophageal Stricture",
+      "type": "pathology",
+      "subspecialty": "laryngology",
+      "detail": "Fibrotic luminal narrowing, classically a delayed sequela of caustic injury (weeks to months) or chronic reflux, presenting with progressive dysphagia to solids. Long-standing caustic strictures carry an increased lifetime risk of esophageal squamous cell carcinoma.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "esophagology-caustic-ingestion"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "esophagoscopy",
+      "label": "Esophagoscopy",
+      "type": "procedure",
+      "subspecialty": "laryngology",
+      "detail": "Flexible or rigid endoscopic evaluation of the esophagus to diagnose and grade injury, evaluate dysphagia/odynophagia, and remove foreign bodies. In caustic ingestion, early (within 12-24 h) endoscopy stages injury and guides management.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "esophagogastroduodenoscopy",
+        "EGD"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "esophagology-caustic-ingestion"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "esophageal-dilation",
+      "label": "Esophageal Dilation",
+      "type": "procedure",
+      "subspecialty": "laryngology",
+      "detail": "Serial bougie or balloon dilation of a benign stricture, often after the caustic injury has matured (delayed several weeks to reduce perforation risk); refractory strictures may need steroid injection, stenting, or esophageal reconstruction.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "bougie dilation",
+        "stricture dilation"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "esophagology-caustic-ingestion"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "koos-classification",
+      "label": "Koos Grading of Vestibular Schwannoma",
+      "type": "concept",
+      "subspecialty": "otology",
+      "detail": "Grades vestibular schwannoma I-IV by extension: I intracanalicular, II small CPA, III CPA reaching brainstem, IV brainstem compression/displacement. Guides observation vs treatment.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Koos grade"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "vestibular-schwannoma"
+        ],
+        "concepts": [
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "Koos"
+          },
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "tumor-size"
+          }
+        ],
+        "topics": [
+          "vestibular-schwannoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "neurofibromatosis-type-2",
+      "label": "Neurofibromatosis Type 2",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Autosomal dominant tumor syndrome from biallelic loss of NF2 (merlin/schwannomin, chromosome 22q12). Hallmark is bilateral vestibular schwannomas; also meningiomas, ependymomas. Diagnosed by Manchester criteria.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "NF2"
+      ],
+      "abbrev": "NF2",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "vestibular-schwannoma"
+        ],
+        "concepts": [
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "NF2"
+          },
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "bilateral-VS"
+          },
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "molecular-genetics"
+          },
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "manchester-criteria"
+          }
+        ],
+        "topics": [
+          "vestibular-schwannoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cerebellopontine-angle",
+      "label": "Cerebellopontine Angle",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "CSF-filled space between pons, cerebellum and petrous temporal bone. Contains CN VII/VIII, AICA and the flocculus; most common site of extra-axial posterior fossa tumors (vestibular schwannoma, meningioma, epidermoid).",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CPA"
+      ],
+      "abbrev": "CPA",
+      "structure": "space",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [
+          "vestibular-schwannoma"
+        ],
+        "concepts": [
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "CPA"
+          },
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "surrounding-anatomy"
+          }
+        ],
+        "topics": [
+          "vestibular-schwannoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "translabyrinthine-approach",
+      "label": "Translabyrinthine Approach",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Sacrifices hearing to remove vestibular schwannoma via the labyrinth; offers early identification of the facial nerve at the fundus and wide access regardless of tumor size. Used when hearing is non-serviceable.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "translab"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "vestibular-schwannoma"
+        ],
+        "concepts": [
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "translabyrinthine"
+          },
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "surgery"
+          },
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "facial-nerve"
+          }
+        ],
+        "topics": [
+          "vestibular-schwannoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "retrosigmoid-approach",
+      "label": "Retrosigmoid (Suboccipital) Approach",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Posterior fossa approach for vestibular schwannoma allowing hearing preservation for tumors with limited lateral IAC extension. Risks include cerebellar retraction and headache.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "suboccipital"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "vestibular-schwannoma"
+        ],
+        "concepts": [
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "retrosigmoid"
+          },
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "surgery"
+          }
+        ],
+        "topics": [
+          "vestibular-schwannoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "middle-cranial-fossa-approach",
+      "label": "Middle Cranial Fossa Approach",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Extradural approach over the tegmen for hearing preservation in small, predominantly intracanalicular vestibular schwannomas. The facial nerve lies superiorly, increasing exposure-related risk.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "middle fossa"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "vestibular-schwannoma"
+        ],
+        "concepts": [
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "middle-fossa"
+          },
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "surgery"
+          }
+        ],
+        "topics": [
+          "vestibular-schwannoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "stereotactic-radiosurgery",
+      "label": "Stereotactic Radiosurgery",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Single-session focused radiation (e.g., Gamma Knife) for vestibular schwannomas generally <2.5-3 cm, giving ~90-95% tumor control. Preferred for poor surgical candidates; small risk of malignant transformation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "SRS",
+        "Gamma Knife"
+      ],
+      "abbrev": "SRS",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "vestibular-schwannoma"
+        ],
+        "concepts": [
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "radiosurgery"
+          }
+        ],
+        "topics": [
+          "vestibular-schwannoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "retraction-pocket",
+      "label": "Tympanic Membrane Retraction Pocket",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Invagination of the pars flaccida or tensa driven by eustachian tube dysfunction/negative middle ear pressure. When keratin fails to clear, it evolves into acquired cholesteatoma.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "chronic-otitis-media-cholesteatoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "congenital-cholesteatoma",
+      "label": "Congenital Cholesteatoma",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "White keratin mass behind an intact tympanic membrane, classically anterosuperior quadrant, without prior perforation/otorrhea history. Arises from epithelial rests (Levenson criteria).",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "chronic-otitis-media-cholesteatoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "tympanic-membrane-perforation",
+      "label": "Tympanic Membrane Perforation",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Defect in the eardrum from trauma or chronic OM. Central perforations are 'safe'; marginal/attic perforations are 'unsafe' owing to cholesteatoma risk. Causes conductive hearing loss proportional to size.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "TM perforation"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "chronic-otitis-media-cholesteatoma",
+          "tympanoplasty-ossiculoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "canal-wall-management",
+      "label": "Canal-Wall-Up vs Canal-Wall-Down Mastoidectomy",
+      "type": "concept",
+      "subspecialty": "otology",
+      "detail": "Cholesteatoma surgery decision: canal-wall-up preserves ear canal anatomy but has higher residual/recurrent disease and needs second-look; canal-wall-down exteriorizes disease into a mastoid bowl with lower recurrence but bowl maintenance.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CWU vs CWD"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "chronic-otitis-media-cholesteatoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "eustachian-tube-dysfunction",
+      "label": "Eustachian Tube Dysfunction",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Failure of eustachian tube pressure equalization producing negative middle ear pressure, effusion, retraction and predisposition to chronic OM/cholesteatoma. Dilatory dysfunction may be treated with balloon dilation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ETD"
+      ],
+      "abbrev": "ETD",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "chronic-otitis-media-cholesteatoma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "acute-mastoiditis",
+      "label": "Acute Mastoiditis",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Suppurative infection of mastoid air cells complicating acute OM, with postauricular erythema/swelling, protrusion of the pinna, and loss of the postauricular crease. Coalescent mastoiditis requires IV antibiotics +/- mastoidectomy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "complications-of-otitis-media"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "otogenic-facial-nerve-palsy",
+      "label": "Otogenic Facial Nerve Palsy",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Facial paresis complicating acute or chronic OM/cholesteatoma via a dehiscent tympanic segment of the fallopian canal. Acute OM cause is treated medically with myringotomy; cholesteatoma requires surgical decompression.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "complications-of-otitis-media"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sigmoid-sinus-thrombosis",
+      "label": "Sigmoid (Lateral) Sinus Thrombosis",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Otogenic thrombophlebitis of the sigmoid/lateral sinus with spiking 'picket-fence' fevers and Griesinger sign (postauricular edema over the mastoid emissary vein). Managed with antibiotics, surgery, and often anticoagulation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "lateral sinus thrombosis"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "complications-of-otitis-media"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "otogenic-intracranial-abscess",
+      "label": "Otogenic Intracranial Abscess / Meningitis",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Intracranial spread of otitis media producing meningitis (most common), or temporal lobe/cerebellar abscess and epidural/subdural empyema. Requires urgent imaging, neurosurgery, and mastoid source control.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "complications-of-otitis-media"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "petrous-apicitis",
+      "label": "Petrous Apicitis",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Infection of pneumatized petrous apex air cells. Gradenigo triad: deep retro-orbital pain (CN V), abducens palsy/diplopia (CN VI in Dorello canal), and persistent otorrhea.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "apical petrositis"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "complications-of-otitis-media"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "subperiosteal-abscess",
+      "label": "Subperiosteal / Bezold Abscess",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Pus escaping coalescent mastoiditis: postauricular subperiosteal abscess, or a Bezold abscess tracking through the mastoid tip into the sternocleidomastoid/neck.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Bezold abscess"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "complications-of-otitis-media"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sudden-sensorineural-hearing-loss",
+      "label": "Sudden Sensorineural Hearing Loss",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "≥30 dB SNHL over ≥3 contiguous frequencies within 72 hours; most idiopathic (ISSNHL). AAO-HNSF 2019 CPG: obtain audiogram, do NOT routinely order CT/labs, exclude retrocochlear disease with MRI, and counsel that early treatment improves odds.",
+      "sources": [
+        "https://www.entnet.org/quality-practice/quality-products/clinical-practice-guidelines/sudden-hearing-loss-update/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "SSNHL",
+        "ISSNHL"
+      ],
+      "abbrev": "SSNHL",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sudden-snhl"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "weber-rinne-tuning-fork",
+      "label": "Weber & Rinne Tuning Fork Tests",
+      "type": "concept",
+      "subspecialty": "otology",
+      "detail": "512 Hz bedside tests: Weber lateralizes to the poorer ear in SNHL and to the affected ear in conductive loss; a negative Rinne (BC>AC) indicates a conductive loss of roughly ≥25 dB.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "tuning fork tests"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sudden-snhl"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "oral-corticosteroids-snhl",
+      "label": "Systemic Corticosteroids (SSNHL)",
+      "type": "drug",
+      "subspecialty": "otology",
+      "detail": "High-dose oral prednisone (or equivalent) is the initial option for idiopathic SSNHL, ideally started within 2 weeks of onset. AAO-HNSF 2019 lists it as an option (not mandate) given weak evidence.",
+      "sources": [
+        "https://www.entnet.org/quality-practice/quality-products/clinical-practice-guidelines/sudden-hearing-loss-update/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "prednisone"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sudden-snhl"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "intratympanic-steroid-injection",
+      "label": "Intratympanic Steroid Injection",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Transtympanic dexamethasone/methylprednisolone diffusing across the round window. AAO-HNSF 2019 recommends offering it as SALVAGE therapy for incomplete recovery 2-6 weeks after onset; also used as initial therapy when systemic steroids are contraindicated.",
+      "sources": [
+        "https://www.entnet.org/quality-practice/quality-products/clinical-practice-guidelines/sudden-hearing-loss-update/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "IT steroids"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sudden-snhl"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "menieres-disease",
+      "label": "Ménière's Disease",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Idiopathic endolymphatic hydrops. Bárány/AAO-HNS 2015 definite criteria: ≥2 spontaneous vertigo episodes 20 min–12 h, audiometrically documented low-to-mid frequency SNHL in the affected ear, and fluctuating aural symptoms (hearing, tinnitus, fullness).",
+      "sources": [
+        "https://journals.sagepub.com/doi/10.3233/VES-150549"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Meniere disease",
+        "idiopathic endolymphatic hydrops"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "menieres-episodic-vertigo"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "endolymphatic-hydrops",
+      "label": "Endolymphatic Hydrops",
+      "type": "concept",
+      "subspecialty": "otology",
+      "detail": "Distension of the endolymphatic (scala media) compartment underlying Ménière's disease, attributed to impaired endolymph resorption. Can be visualized on delayed intravenous/intratympanic gadolinium MRI.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "hydrops"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "menieres-episodic-vertigo"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "electrocochleography",
+      "label": "Electrocochleography",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Records cochlear summating (SP) and action (AP) potentials; an elevated SP/AP ratio (>0.4-0.5) supports endolymphatic hydrops in Ménière's disease, though sensitivity is limited.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ECochG"
+      ],
+      "abbrev": "ECochG",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "menieres-episodic-vertigo"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "intratympanic-gentamicin",
+      "label": "Intratympanic Gentamicin",
+      "type": "drug",
+      "subspecialty": "otology",
+      "detail": "Vestibulotoxic aminoglycoside instilled transtympanically as a 'chemical labyrinthectomy' for intractable Ménière's vertigo, ablating vestibular hair cells while attempting to spare hearing.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "IT gentamicin"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "menieres-episodic-vertigo"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "endolymphatic-sac-decompression",
+      "label": "Endolymphatic Sac Decompression/Shunt",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Non-ablative, hearing-preserving surgery for medically refractory Ménière's disease; the mastoid bone over the endolymphatic sac is decompressed +/- shunted. Efficacy beyond placebo remains debated.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ELS decompression"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "menieres-episodic-vertigo"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "betahistine-diuretic-therapy",
+      "label": "Medical Therapy for Ménière's (Diuretic/Betahistine)",
+      "type": "drug",
+      "subspecialty": "otology",
+      "detail": "First-line conservative management: low-salt diet, thiazide/triamterene diuretic, and betahistine (widely used outside the US), with vestibular suppressants for acute attacks.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "betahistine"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "menieres-episodic-vertigo"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "benign-paroxysmal-positional-vertigo",
+      "label": "Benign Paroxysmal Positional Vertigo",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Brief positional vertigo from displaced otoconia, most often canalithiasis of the posterior semicircular canal. Diagnosed by provocative positional testing; highly responsive to canalith repositioning.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "BPPV"
+      ],
+      "abbrev": "BPPV",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "bppv-vestibular-testing"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "dix-hallpike-maneuver",
+      "label": "Dix-Hallpike Maneuver",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Gold-standard provocative test for posterior canal BPPV; a positive test shows latency-limited, fatigable upbeating-torsional nystagmus toward the dependent (affected) ear.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Dix-Hallpike"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "bppv-vestibular-testing"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "epley-maneuver",
+      "label": "Epley Canalith Repositioning",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Sequential head positioning that moves otoconia out of the posterior semicircular canal back into the utricle; first-line, highly effective treatment for posterior canal BPPV.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "canalith repositioning procedure",
+        "CRP"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "bppv-vestibular-testing"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "videonystagmography",
+      "label": "Videonystagmography & Caloric Testing",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Records eye movements to quantify spontaneous/positional nystagmus and, via bithermal caloric irrigation, unilateral vestibular (horizontal canal) weakness. Calorics probe low-frequency VOR function.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "VNG",
+        "ENG"
+      ],
+      "abbrev": "VNG",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "bppv-vestibular-testing"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "video-head-impulse-test",
+      "label": "Video Head Impulse Test",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Bedside/video quantification of high-frequency VOR gain for each semicircular canal; a corrective catch-up saccade with reduced gain indicates canal hypofunction.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "vHIT"
+      ],
+      "abbrev": "vHIT",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "bppv-vestibular-testing"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "carhart-notch",
+      "label": "Carhart Notch",
+      "type": "concept",
+      "subspecialty": "otology",
+      "detail": "Artifactual depression of bone-conduction thresholds maximal at 2 kHz seen in otosclerosis due to loss of the ossicular resonance contribution; it typically resolves after successful stapes surgery.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "otosclerosis-stapes"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "conductive-hearing-loss",
+      "label": "Conductive Hearing Loss",
+      "type": "concept",
+      "subspecialty": "otology",
+      "detail": "Hearing loss from impaired sound transmission through the external/middle ear, producing an air-bone gap and a negative Rinne. Causes include cerumen, effusion, TM perforation, ossicular fixation/discontinuity and otosclerosis.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CHL",
+        "air-bone gap"
+      ],
+      "abbrev": "CHL",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "otosclerosis-stapes",
+          "tympanoplasty-ossiculoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "stapedotomy",
+      "label": "Stapedotomy",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Preferred stapes surgery for otosclerosis: a small fenestra is made in the fixed footplate and a piston prosthesis is crimped from the incus, restoring ossicular mobility. Lower risk of SNHL than total stapedectomy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "small fenestra stapedotomy"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "otosclerosis-stapes"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "fissula-ante-fenestram",
+      "label": "Fissula Ante Fenestram",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Cleft of embryonic connective tissue just anterior to the oval window; the most common site of the initial otosclerotic focus.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "space",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "otosclerosis-stapes"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cochlear-implant-candidacy",
+      "label": "Cochlear Implant Candidacy",
+      "type": "concept",
+      "subspecialty": "otology",
+      "detail": "Bilateral moderate-to-profound SNHL with limited benefit from hearing aids (aided sentence scores below criterion, e.g., AzBio). FDA indications expanded to single-sided deafness (4PTA >80 dB impaired ear, ≤30 dB contralateral) after a CROS trial.",
+      "sources": [
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC9592177/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CI candidacy"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "cochlear-implants"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cochlear-implant-electrode-array",
+      "label": "Cochlear Implant Electrode Array",
+      "type": "concept",
+      "subspecialty": "otology",
+      "detail": "Intracochlear electrode inserted through the round window/cochleostomy into scala tympani. Lateral-wall (straight) arrays favor atraumatic hearing preservation; perimodiolar (modiolus-hugging) arrays place contacts closer to the spiral ganglion.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "electrode array"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "cochlear-implants"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cochlear-implant-mapping",
+      "label": "Cochlear Implant Mapping (Programming)",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Post-activation audiologic programming that sets threshold (T) and comfort (C/M) levels per electrode, selects the processing strategy, and drives auditory rehabilitation for optimal speech perception.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "mapping"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "cochlear-implants"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sensorineural-hearing-loss",
+      "label": "Sensorineural Hearing Loss",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Hearing loss from cochlear hair-cell or cochlear-nerve (retrocochlear) dysfunction, with no air-bone gap. Etiologies include presbycusis, noise, ototoxicity and genetic loss; severe-to-profound cases are candidates for cochlear implantation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "SNHL"
+      ],
+      "abbrev": "SNHL",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "cochlear-implants",
+          "sudden-snhl"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "temporal-bone-fracture",
+      "label": "Temporal Bone Fracture",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Classified as otic-capsule-sparing vs otic-capsule-violating (better predictor of facial palsy, SNHL and CSF leak than the older longitudinal/transverse scheme). Longitudinal fractures more often cause conductive loss; transverse cause SNHL/facial palsy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "temporal bone trauma"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "temporal-bone-trauma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "traumatic-facial-nerve-paralysis",
+      "label": "Traumatic Facial Nerve Paralysis",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Injury most often at the perigeniculate region. Immediate-onset complete paralysis with >90-95% degeneration on ENoG (and absent voluntary EMG) favors surgical decompression; delayed or incomplete paralysis is observed with steroids and usually recovers.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "temporal-bone-trauma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "csf-otorrhea",
+      "label": "CSF Otorrhea",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "CSF leak through a tegmen or otic-capsule breach, presenting as clear otorrhea (or rhinorrhea via the eustachian tube). Confirmed with beta-2 transferrin; most post-traumatic leaks resolve conservatively, with surgery for persistence.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CSF leak"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "temporal-bone-trauma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "hemotympanum",
+      "label": "Hemotympanum",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Blood in the middle ear space behind an intact tympanic membrane, giving a bluish drum and a common early sign of temporal bone fracture. Usually resolves spontaneously.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "temporal-bone-trauma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "tympanic-membrane-graft",
+      "label": "Tympanic Membrane Graft",
+      "type": "concept",
+      "subspecialty": "otology",
+      "detail": "Grafting material for eardrum repair: temporalis fascia, tragal/conchal cartilage-perichondrium (preferred for high-risk/revision ears). Placed by underlay (medial) or overlay (lateral) technique.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "fascia graft"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "tympanoplasty-ossiculoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "ossicular-prosthesis",
+      "label": "Ossicular Prosthesis (PORP/TORP)",
+      "type": "concept",
+      "subspecialty": "otology",
+      "detail": "Reconstructs the ossicular chain: a partial prosthesis (PORP) bridges the TM/malleus to the stapes head when the superstructure is intact; a total prosthesis (TORP) reaches the footplate when the stapes superstructure is absent.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "PORP",
+        "TORP"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "tympanoplasty-ossiculoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "wullstein-classification",
+      "label": "Wullstein Tympanoplasty Classification",
+      "type": "concept",
+      "subspecialty": "otology",
+      "detail": "Types I-V describe the reconstructed sound-conducting mechanism: Type I (myringoplasty, intact ossicles) through Types II-IV (graft onto remaining ossicles/footplate) and Type V (fenestration).",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "tympanoplasty-ossiculoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "myringoplasty",
+      "label": "Myringoplasty",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Repair of a tympanic membrane perforation without addressing the middle ear or ossicular chain (Wullstein Type I). Suitable for a dry central perforation with a healthy ossicular chain.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "tympanoplasty-ossiculoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "superior-canal-dehiscence",
+      "label": "Superior Semicircular Canal Dehiscence",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Absence of bone over the superior semicircular canal in the middle cranial fossa floor creating a mobile third window. Presents with sound-/pressure-induced vertigo (Tullio, Hennebert), autophony, pulsatile oscillopsia and a low-frequency conductive loss with intact acoustic reflexes.",
+      "sources": [
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC5408023/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "SSCD",
+        "SCDS"
+      ],
+      "abbrev": "SSCD",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sscd-third-window"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "third-window-physiology",
+      "label": "Third Window Physiology",
+      "type": "concept",
+      "subspecialty": "otology",
+      "detail": "A pathologic third mobile window (e.g., SSCD, large vestibular aqueduct) shunts acoustic energy away from the cochlea, lowering air-conduction (apparent air-bone gap) while paradoxically improving bone conduction to negative thresholds.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "third mobile window"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sscd-third-window"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "vestibular-evoked-myogenic-potential",
+      "label": "Vestibular Evoked Myogenic Potential",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Sound-evoked reflex recordings: cervical VEMP (saccule/inferior vestibular nerve, SCM) and ocular VEMP (utricle/superior vestibular nerve). In SSCD, cVEMP thresholds are abnormally low and oVEMP amplitudes abnormally high.",
+      "sources": [
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC5408023/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "VEMP",
+        "cVEMP",
+        "oVEMP"
+      ],
+      "abbrev": "VEMP",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sscd-third-window"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "superior-canal-plugging",
+      "label": "Superior Canal Resurfacing/Plugging",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Surgical repair of symptomatic SSCD via a middle cranial fossa (or transmastoid) approach, plugging and/or resurfacing the dehiscent canal to eliminate the third-window effect.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "canal plugging"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sscd-third-window"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "congenital-cmv",
+      "label": "Congenital Cytomegalovirus (cCMV)",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Most common non-genetic cause of congenital SNHL; hearing loss may be progressive/late-onset and unilateral or bilateral. Diagnose by PCR (urine/saliva) within first 3 weeks of life. Valganciclovir (6 months) can stabilize or improve hearing in symptomatic infants.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "cCMV"
+      ],
+      "abbrev": "cCMV",
+      "structure": null,
+      "region": "temporal-bone",
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "pediatrics"
+        ],
+        "concepts": [
+          {
+            "module": "pediatrics",
+            "concept": "cCMV"
+          },
+          {
+            "module": "pediatrics",
+            "concept": "acquired-SNHL"
+          }
+        ],
+        "topics": [
+          "pediatric-hearing-loss"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "auditory-neuropathy-spectrum-disorder",
+      "label": "Auditory Neuropathy Spectrum Disorder (ANSD)",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Present OAEs / cochlear microphonic with absent or abnormal ABR — dyssynchronous neural transmission. Risk factors include prematurity, hyperbilirubinemia, and OTOF mutations. Amplification often disappointing; many benefit from cochlear implantation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ANSD",
+        "auditory neuropathy"
+      ],
+      "abbrev": "ANSD",
+      "structure": null,
+      "region": "temporal-bone",
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "pediatrics"
+        ],
+        "concepts": [
+          {
+            "module": "pediatrics",
+            "concept": "ANSD"
+          },
+          {
+            "module": "pediatrics",
+            "concept": "audiology"
+          }
+        ],
+        "topics": [
+          "pediatric-hearing-loss"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "enlarged-vestibular-aqueduct",
+      "label": "Enlarged Vestibular Aqueduct (EVA)",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Most common radiologic inner-ear anomaly in pediatric SNHL; vestibular aqueduct >1.5 mm (midpoint). Associated with SLC26A4/Pendred and stepwise/fluctuating SNHL after minor head trauma. Counsel head-injury and contact-sport avoidance.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "EVA",
+        "large vestibular aqueduct"
+      ],
+      "abbrev": "EVA",
+      "structure": null,
+      "region": "temporal-bone",
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "pediatrics"
+        ],
+        "concepts": [
+          {
+            "module": "pediatrics",
+            "concept": "EVA"
+          },
+          {
+            "module": "pediatrics",
+            "concept": "pendred"
+          },
+          {
+            "module": "pediatrics",
+            "concept": "imaging"
+          }
+        ],
+        "topics": [
+          "pediatric-hearing-loss"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "otitis-media-with-effusion",
+      "label": "Otitis Media with Effusion (OME)",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Middle-ear fluid without acute infection; flat (type B) tympanogram. Watchful waiting 3 months; tubes indicated for persistent bilateral OME >3 months with hearing loss or at-risk children. Avoid antihistamines/decongestants (ineffective).",
+      "sources": [
+        "AAO-HNSF Clinical Practice Guideline: OME",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "OME",
+        "serous otitis media",
+        "glue ear"
+      ],
+      "abbrev": "OME",
+      "structure": null,
+      "region": "temporal-bone",
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "ta-tubes"
+        ],
+        "concepts": [
+          {
+            "module": "ta-tubes",
+            "concept": "OME"
+          },
+          {
+            "module": "ta-tubes",
+            "concept": "tympanometry"
+          }
+        ],
+        "topics": [
+          "tubes-tonsils-neck"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "tympanostomy-tubes",
+      "label": "Tympanostomy Tubes",
+      "type": "procedure",
+      "subspecialty": "pediatrics",
+      "detail": "Myringotomy with tube placement for recurrent AOM (≥3 in 6 mo / ≥4 in 12 mo with effusion) or chronic OME with hearing loss. Placed in anteroinferior quadrant. Water precautions not routinely required; otorrhea is the most common complication.",
+      "sources": [
+        "AAO-HNSF Clinical Practice Guideline: Tympanostomy Tubes",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ear tubes",
+        "PE tubes",
+        "grommets"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "temporal-bone",
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "ta-tubes"
+        ],
+        "concepts": [
+          {
+            "module": "ta-tubes",
+            "concept": "tubes"
+          },
+          {
+            "module": "ta-tubes",
+            "concept": "myringotomy"
+          }
+        ],
+        "topics": [
+          "tubes-tonsils-neck"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "post-tonsillectomy-hemorrhage",
+      "label": "Post-Tonsillectomy Hemorrhage",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Primary hemorrhage (<24 h) reflects hemostasis; secondary hemorrhage peaks postoperative days 5–10 with eschar separation. Any bleeding warrants evaluation; brisk/recurrent bleeding needs OR control. Overall ~2–4% incidence, higher in older patients.",
+      "sources": [
+        "AAO-HNSF Clinical Practice Guideline: Tonsillectomy",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "post-tonsillectomy bleed"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "ta-tubes"
+        ],
+        "concepts": [
+          {
+            "module": "ta-tubes",
+            "concept": "hemorrhage"
+          },
+          {
+            "module": "ta-tubes",
+            "concept": "hemostasis"
+          }
+        ],
+        "topics": [
+          "tubes-tonsils-neck"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pediatric-stridor",
+      "label": "Pediatric Stridor",
+      "type": "concept",
+      "subspecialty": "pediatrics",
+      "detail": "Localizing sign: inspiratory stridor suggests supraglottic obstruction, biphasic suggests glottic/subglottic, and expiratory suggests intrathoracic tracheobronchial disease. Character, feeding, and positional change guide workup and flexible laryngoscopy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "stridor"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "larynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-airway"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "laryngomalacia",
+      "label": "Laryngomalacia",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Most common cause of stridor in infants; inspiratory stridor worse with feeding/supine/agitation. Endoscopy shows omega-shaped epiglottis, short aryepiglottic folds, and prolapsing arytenoid mucosa. Usually self-limited by 12–18 months; treat reflux and observe.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "larynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-airway"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "supraglottoplasty",
+      "label": "Supraglottoplasty",
+      "type": "procedure",
+      "subspecialty": "pediatrics",
+      "detail": "Endoscopic division of shortened aryepiglottic folds ± trimming of redundant arytenoid mucosa for severe laryngomalacia (failure to thrive, cyanosis, apnea, cor pulmonale). Overcorrection risks supraglottic stenosis; aspiration is a key postoperative concern.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "aryepiglottoplasty"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "larynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-airway"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pediatric-subglottic-stenosis",
+      "label": "Pediatric Subglottic Stenosis",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Narrowing at the cricoid (only complete cartilaginous ring). Congenital subglottic diameter <4 mm in term neonate; acquired usually from prolonged intubation. Biphasic stridor; graded by Cotton-Myer. Management ranges from observation to endoscopic dilation or open reconstruction.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "subglottic stenosis"
+      ],
+      "abbrev": "SGS",
+      "structure": null,
+      "region": "larynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-airway"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cotton-myer-grading",
+      "label": "Cotton-Myer Grading",
+      "type": "concept",
+      "subspecialty": "pediatrics",
+      "detail": "Classifies subglottic stenosis by percent luminal obstruction: Grade I <50%, II 51–70%, III 71–99%, IV no detectable lumen. Guides candidacy for endoscopic versus open airway reconstruction.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Myer-Cotton",
+        "Cotton-Myer classification"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "larynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-airway"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "tracheomalacia",
+      "label": "Tracheomalacia",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Dynamic collapse of the trachea from weak cartilage or excessive posterior membrane; expiratory stridor and 'barky' cough. Associated with tracheoesophageal fistula/esophageal atresia and vascular compression. Most improve with growth; severe cases may need aortopexy or CPAP.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "larynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-airway"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "vascular-ring",
+      "label": "Vascular Ring",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Aortic-arch anomaly encircling the trachea/esophagus (e.g., double aortic arch, right arch with aberrant left subclavian/ligamentum). Presents with biphasic stridor, dysphagia, reflex apnea. Barium esophagram shows posterior indentation; CTA/MRA confirms; surgical division is curative.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "double aortic arch",
+        "vascular sling"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "larynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-airway"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "rigid-bronchoscopy",
+      "label": "Rigid Bronchoscopy",
+      "type": "procedure",
+      "subspecialty": "pediatrics",
+      "detail": "Gold standard for evaluating and treating pediatric airway lesions and removing airway foreign bodies; provides a secure ventilating airway with optical forceps. Performed under general anesthesia with the anesthesiologist maintaining spontaneous ventilation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "bronchoscopy"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "larynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-airway",
+          "airway-foreign-bodies-caustics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "subglottic-hemangioma",
+      "label": "Subglottic Hemangioma",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Infantile hemangioma of the subglottis; biphasic stridor worsening at 1–3 months during proliferation, often with a 'beard-distribution' cutaneous hemangioma. Classically asymmetric on endoscopy. Propranolol has largely replaced open resection and tracheostomy as first-line therapy.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC8423716/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "larynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-airway",
+          "congenital-neck-masses-vascular-anomalies"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "thyroglossal-duct-cyst",
+      "label": "Thyroglossal Duct Cyst",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Most common congenital midline neck mass; embryologic remnant of thyroid descent from foramen cecum. Classically moves with tongue protrusion/swallowing. Confirm normal orthotopic thyroid on ultrasound before excision to avoid removing ectopic (lingual) thyroid.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "TGDC"
+      ],
+      "abbrev": "TGDC",
+      "structure": null,
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "congenital-neck-masses-vascular-anomalies"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sistrunk-procedure",
+      "label": "Sistrunk Procedure",
+      "type": "procedure",
+      "subspecialty": "pediatrics",
+      "detail": "Excision of thyroglossal duct cyst with the central hyoid body and a core of tongue-base tissue to the foramen cecum. Removing the mid-hyoid segment markedly lowers recurrence compared with simple cystectomy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Sistrunk"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "congenital-neck-masses-vascular-anomalies"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "branchial-cleft-anomaly",
+      "label": "Branchial Cleft Anomaly",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Lateral neck cyst/sinus/fistula from incomplete obliteration of branchial apparatus. Second-cleft (most common) tracks along anterior SCM, between internal/external carotids to the tonsillar fossa. First-cleft relates to the parotid/facial nerve; treat with complete excision.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "branchial cleft cyst",
+        "branchial anomaly"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "congenital-neck-masses-vascular-anomalies"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "issva-classification",
+      "label": "ISSVA Classification of Vascular Anomalies",
+      "type": "concept",
+      "subspecialty": "pediatrics",
+      "detail": "Divides vascular anomalies into tumors (e.g., infantile hemangioma) and malformations (capillary, venous, lymphatic, arteriovenous — further split into low- vs high-flow). Distinction drives imaging and therapy and replaces imprecise terms like 'cystic hygroma.'",
+      "sources": [
+        "ISSVA Classification 2018",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ISSVA"
+      ],
+      "abbrev": "ISSVA",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "congenital-neck-masses-vascular-anomalies"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "infantile-hemangioma",
+      "label": "Infantile Hemangioma",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Most common tumor of infancy; GLUT-1 positive. Absent/small at birth, then rapid proliferation over the first months followed by slow involution. Segmental facial 'beard' lesions raise concern for airway involvement and PHACE syndrome (warrants MRA head/neck and cardiac imaging).",
+      "sources": [
+        "Cummings Otolaryngology",
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC8423716/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "hemangioma of infancy",
+        "IH"
+      ],
+      "abbrev": "IH",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "congenital-neck-masses-vascular-anomalies"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "propranolol-hemangioma",
+      "label": "Propranolol (Infantile Hemangioma)",
+      "type": "drug",
+      "subspecialty": "pediatrics",
+      "detail": "First-line therapy for problematic infantile hemangiomas at ~1–3 mg/kg/day divided doses. Non-selective beta-blocker acting via vasoconstriction, downregulation of VEGF, and endothelial apoptosis. Watch for hypoglycemia, bradycardia, hypotension; PHACE patients need low, thrice-daily dosing after vascular workup.",
+      "sources": [
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC3529954/",
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC8423716/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "propranolol"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "congenital-neck-masses-vascular-anomalies"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "lymphatic-malformation",
+      "label": "Lymphatic Malformation",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Low-flow malformation (formerly 'cystic hygroma'), often posterior triangle; macrocystic vs microcystic. May abruptly enlarge with infection or intralesional bleeding. Sclerotherapy (OK-432, doxycycline, bleomycin) for macrocystic; oral sirolimus increasingly used for complicated/microcystic disease.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "https://link.springer.com/article/10.1007/s00405-023-07991-1"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "cystic hygroma",
+        "lymphangioma",
+        "LM"
+      ],
+      "abbrev": "LM",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "congenital-neck-masses-vascular-anomalies"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "venous-malformation",
+      "label": "Venous Malformation",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Low-flow malformation that is compressible and enlarges with dependency/Valsalva; phleboliths are pathognomonic on imaging. MRI shows T2-hyperintense lesion. Treated with sclerotherapy and/or resection; grows proportionally with the child (does not spontaneously involute).",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "VM"
+      ],
+      "abbrev": "VM",
+      "structure": null,
+      "region": "neck",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "congenital-neck-masses-vascular-anomalies"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sirolimus",
+      "label": "Sirolimus (mTOR inhibitor)",
+      "type": "drug",
+      "subspecialty": "pediatrics",
+      "detail": "Oral mTOR inhibitor used for complicated or microcystic lymphatic malformations and other complex vascular anomalies, producing volume reduction and reduced bleeding/leakage. Requires monitoring of trough levels; a topical formulation is under trial for microcystic disease.",
+      "sources": [
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC10902623/",
+        "https://clinicaltrials.gov/study/NCT05050149"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "rapamycin"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "congenital-neck-masses-vascular-anomalies"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "airway-foreign-body",
+      "label": "Airway Foreign Body Aspiration",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Peak in toddlers; organic objects (peanuts) most common and lodge in the right mainstem bronchus. Classic triad of cough, wheeze, decreased breath sounds. Radiolucent objects cause air-trapping/hyperinflation on expiratory films; rigid bronchoscopy is diagnostic and therapeutic.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "foreign body aspiration",
+        "FB aspiration"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "larynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "airway-foreign-bodies-caustics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "esophageal-foreign-body",
+      "label": "Esophageal Foreign Body",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Most commonly lodges at the cricopharyngeus (upper esophageal sphincter). Coins lie in the coronal plane on AP chest film. Sharp objects, and any object retained >24 h, warrant prompt removal by rigid esophagoscopy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "airway-foreign-bodies-caustics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "button-battery-ingestion",
+      "label": "Button Battery Ingestion",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "True emergency: an esophageal button battery causes liquefactive necrosis within hours, risking TE fistula, aortoenteric fistula, and death. 'Double-ring/halo' sign on X-ray. Honey en route and immediate endoscopic removal; watch for delayed vascular erosion after retrieval.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "NEISS/NCPC button battery guidelines"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "disc battery"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "airway-foreign-bodies-caustics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pediatric-caustic-ingestion",
+      "label": "Pediatric Caustic Ingestion",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Alkali (e.g., lye) causes deep liquefactive necrosis; acid causes coagulative injury. Absence of oral burns does not exclude esophageal injury. Avoid emetics, neutralizers, and blind NG placement; early esophagoscopy grades injury and stricture is a late risk.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "caustic injury"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "airway-foreign-bodies-caustics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "choanal-atresia",
+      "label": "Choanal Atresia",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Failure of posterior nasal aperture to canalize (bony/mixed most common). Bilateral atresia is a neonatal emergency (obligate nasal breathers) with cyclical cyanosis relieved by crying; inability to pass a catheter and CT confirm. Repair transnasally; associated with CHARGE.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "choanal-atresia-craniofacial-syndromes"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "charge-syndrome",
+      "label": "CHARGE Syndrome",
+      "type": "concept",
+      "subspecialty": "pediatrics",
+      "detail": "CHD7 mutation: Coloboma, Heart defects, Atresia choanae, Retardation of growth/development, Genital hypoplasia, Ear anomalies/deafness. Otologic findings include Mondini/absent semicircular canals and cranial neuropathies; screen every choanal atresia infant for CHARGE.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CHARGE"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "pediatrics"
+        ],
+        "concepts": [
+          {
+            "module": "pediatrics",
+            "concept": "CHARGE"
+          }
+        ],
+        "topics": [
+          "choanal-atresia-craniofacial-syndromes"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pierre-robin-sequence",
+      "label": "Pierre Robin Sequence",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Triad of micrognathia, glossoptosis, and airway obstruction, often with a U-shaped cleft palate. Prone positioning is first-line; refractory obstruction may need nasopharyngeal airway, tongue-lip adhesion, or mandibular distraction osteogenesis. Associated with Stickler syndrome.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Robin sequence",
+        "PRS"
+      ],
+      "abbrev": "PRS",
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "choanal-atresia-craniofacial-syndromes"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "treacher-collins-syndrome",
+      "label": "Treacher Collins Syndrome",
+      "type": "concept",
+      "subspecialty": "pediatrics",
+      "detail": "Autosomal-dominant mandibulofacial dysostosis (TCOF1) from first/second arch maldevelopment: malar/mandibular hypoplasia, downslanting palpebral fissures, colobomas, microtia, and conductive hearing loss. Airway compromise from micrognathia is common; hearing is typically conductive.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Treacher Collins",
+        "mandibulofacial dysostosis"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "pediatrics"
+        ],
+        "concepts": [
+          {
+            "module": "pediatrics",
+            "concept": "treacher-collins"
+          },
+          {
+            "module": "pediatrics",
+            "concept": "first-arch"
+          }
+        ],
+        "topics": [
+          "choanal-atresia-craniofacial-syndromes"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "craniosynostosis",
+      "label": "Craniosynostosis (Apert/Crouzon)",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Premature cranial suture fusion; syndromic forms (Apert, Crouzon) arise from FGFR mutations with midface hypoplasia causing nasal airway obstruction and OSA. Relevant to the otolaryngologist for airway, hearing, and chronic ear disease management.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Apert syndrome",
+        "Crouzon syndrome"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "choanal-atresia-craniofacial-syndromes"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "mandibular-distraction-osteogenesis",
+      "label": "Mandibular Distraction Osteogenesis",
+      "type": "procedure",
+      "subspecialty": "pediatrics",
+      "detail": "Gradual lengthening of the mandible via an osteotomy and distractor to relieve tongue-base airway obstruction in severe micrognathia (e.g., Pierre Robin). Can avert tracheostomy; risks include inferior alveolar nerve injury and tooth-bud damage.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "MDO"
+      ],
+      "abbrev": "MDO",
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "choanal-atresia-craniofacial-syndromes"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pediatric-acute-sinusitis",
+      "label": "Pediatric Acute Bacterial Sinusitis",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Diagnosed clinically by persistent (>10 days), worsening, or severe symptoms; ethmoid/maxillary sinuses develop first. Common pathogens: S. pneumoniae, H. influenzae, M. catarrhalis. Amoxicillin-clavulanate is first-line; imaging reserved for suspected orbital/intracranial complications.",
+      "sources": [
+        "AAP Clinical Practice Guideline: Sinusitis",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "pediatric rhinosinusitis"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-sinusitis-periorbital"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "periorbital-cellulitis",
+      "label": "Periorbital (Preseptal) Cellulitis",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Infection anterior to the orbital septum with lid edema/erythema but normal vision, motility, and no proptosis. Usually managed with oral/IV antibiotics. Loss of these normal orbital signs signals progression to postseptal (orbital) disease.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "preseptal cellulitis"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-sinusitis-periorbital"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "orbital-cellulitis",
+      "label": "Orbital (Postseptal) Cellulitis",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Postseptal infection, usually from ethmoid sinusitis crossing the thin lamina papyracea. Proptosis, chemosis, ophthalmoplegia, and pain with eye movement. Obtain contrast CT; IV antibiotics and ophthalmology involvement, with surgery for abscess or vision threat.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "postseptal cellulitis"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-sinusitis-periorbital"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "chandler-classification",
+      "label": "Chandler Classification",
+      "type": "concept",
+      "subspecialty": "pediatrics",
+      "detail": "Stages orbital complications of sinusitis: I preseptal cellulitis, II orbital cellulitis, III subperiosteal abscess, IV orbital abscess, V cavernous sinus thrombosis. Higher stages and vision change drive imaging and surgical drainage.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Chandler 1970"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Chandler stages"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-sinusitis-periorbital"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "velopharyngeal-insufficiency",
+      "label": "Velopharyngeal Insufficiency (VPI)",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Incomplete velopharyngeal closure causing hypernasal speech and nasal air escape; seen after cleft palate repair, with submucous cleft, or post-adenoidectomy. Evaluate with perceptual speech assessment, nasometry, and nasopharyngoscopy/videofluoroscopy to map the closure gap.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "VPI",
+        "velopharyngeal dysfunction"
+      ],
+      "abbrev": "VPI",
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "ta-tubes"
+        ],
+        "concepts": [
+          {
+            "module": "ta-tubes",
+            "concept": "VPI"
+          }
+        ],
+        "topics": [
+          "velopharyngeal-insufficiency-drooling"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cleft-palate",
+      "label": "Cleft Palate",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Failure of palatal shelf fusion; strongly associated with Eustachian tube dysfunction and chronic otitis media with effusion (from abnormal tensor veli palatini). Repair typically ~9–12 months to optimize speech; submucous cleft shows bifid uvula, zona pellucida, and notched hard palate.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "palatal cleft"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "velopharyngeal-insufficiency-drooling"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pharyngeal-flap",
+      "label": "Pharyngeal Flap / Sphincter Pharyngoplasty",
+      "type": "procedure",
+      "subspecialty": "pediatrics",
+      "detail": "Surgical options for VPI. A superiorly based posterior pharyngeal flap obstructs the midline with lateral ports; sphincter pharyngoplasty narrows the port with lateral myomucosal flaps. Overcorrection risks hyponasality and obstructive sleep apnea.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "sphincter pharyngoplasty"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "velopharyngeal-insufficiency-drooling"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pediatric-sialorrhea",
+      "label": "Pediatric Sialorrhea (Drooling)",
+      "type": "pathology",
+      "subspecialty": "pediatrics",
+      "detail": "Anterior/posterior drooling, most often from oromotor dysfunction in cerebral palsy rather than oversecretion. Stepwise management: oral-motor/behavioral therapy, anticholinergics (glycopyrrolate, scopolamine), salivary-gland botulinum toxin, then surgery (duct rerouting/ligation, gland excision).",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "drooling",
+        "sialorrhea"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "velopharyngeal-insufficiency-drooling"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "salivary-botulinum-toxin",
+      "label": "Salivary Gland Botulinum Toxin",
+      "type": "procedure",
+      "subspecialty": "pediatrics",
+      "detail": "Ultrasound-guided intraglandular botulinum toxin injection (submandibular ± parotid) temporarily reduces sialorrhea for several months. Reversible and repeatable; risks include dysphagia and thickened secretions. Glycopyrrolate is a common systemic pharmacologic alternative.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "botox for drooling"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "velopharyngeal-insufficiency-drooling"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pediatric-dise",
+      "label": "Drug-Induced Sleep Endoscopy (Pediatric)",
+      "type": "procedure",
+      "subspecialty": "pediatrics",
+      "detail": "Endoscopic evaluation of the airway under sedation to localize obstruction in persistent OSA after adenotonsillectomy, or before surgery in high-risk children (Down syndrome, obesity, craniofacial anomaly, hypotonia). Can reveal sleep-state-dependent laryngomalacia and tongue-base/velum collapse to target surgery.",
+      "sources": [
+        "https://aao-hnsfjournals.onlinelibrary.wiley.com/doi/10.1177/0194599820985000",
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC8356111/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "DISE",
+        "sleep endoscopy"
+      ],
+      "abbrev": "DISE",
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [
+          "ta-tubes"
+        ],
+        "concepts": [
+          {
+            "module": "ta-tubes",
+            "concept": "OSA"
+          }
+        ],
+        "topics": [
+          "tubes-tonsils-neck"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "middle-turbinate",
+      "label": "Middle Turbinate",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Attaches to skull base at the vertical basal lamella; a key surgical landmark whose axilla marks the frontal recess. Concha bullosa is pneumatization of the middle turbinate.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "MT"
+      ],
+      "abbrev": "MT",
+      "structure": "bone",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "crs-polyps-afrs-biologics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "inferior-turbinate",
+      "label": "Inferior Turbinate",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Largest turbinate; the nasolacrimal duct drains beneath it at the inferior meatus. Hypertrophy is a common cause of nasal obstruction treated with turbinate reduction.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "IT"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "allergic-rhinitis-immunotherapy"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "uncinate-process",
+      "label": "Uncinate Process",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Sickle-shaped bone whose removal (uncinectomy) is the first step of FESS, opening the ethmoid infundibulum and maxillary sinus. Superior attachment determines frontal recess drainage.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "crs-polyps-afrs-biologics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "ostiomeatal-complex",
+      "label": "Ostiomeatal Complex",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Common final drainage pathway of the maxillary, anterior ethmoid, and frontal sinuses into the middle meatus. Obstruction here is the central mechanism of chronic rhinosinusitis.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "OMC",
+        "osteomeatal complex"
+      ],
+      "abbrev": "OMC",
+      "structure": "space",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "acute-bacterial-rhinosinusitis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "maxillary-sinus",
+      "label": "Maxillary Sinus",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Largest paranasal sinus; its natural ostium lies high on the medial wall, draining superiorly into the middle meatus, which predisposes to poor gravity-dependent drainage.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "antrum of Highmore"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "acute-bacterial-rhinosinusitis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "ethmoid-sinus",
+      "label": "Ethmoid Sinus",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Labyrinth of anterior and posterior air cells; the anterior wall of the sphenoid and lamina papyracea border it. Most common origin of orbital complications in children.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ethmoid air cells"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "orbital-intracranial-sinus-complications"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "frontal-sinus",
+      "label": "Frontal Sinus",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Drains via the frontal recess (an inverted funnel), not a true duct. Posterior table erosion allows intracranial spread; obstruction can cause Pott puffy tumor.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "space",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "orbital-intracranial-sinus-complications"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sphenoid-sinus",
+      "label": "Sphenoid Sinus",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Deepest sinus; its roof forms the sellar floor and its lateral walls relate to the optic nerve and internal carotid artery. Gateway for endoscopic transsphenoidal pituitary surgery.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "space",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cribriform-plate",
+      "label": "Cribriform Plate",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Perforated horizontal ethmoid plate transmitting olfactory fibers; the thin lateral lamella is the most common site of iatrogenic CSF leak. Keros classification grades its depth (I–III).",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "csf-rhinorrhea-encephalocele"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "fovea-ethmoidalis",
+      "label": "Fovea Ethmoidalis",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Ethmoid roof formed by the frontal bone, lying lateral and superior to the cribriform plate. The anterior ethmoidal artery crosses it and is a key surgical danger zone.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ethmoid roof"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "csf-rhinorrhea-encephalocele"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "lamina-papyracea",
+      "label": "Lamina Papyracea",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Paper-thin medial orbital wall separating the ethmoid sinus from the orbit; its dehiscence or breach is the route of ethmoid orbital complications and inadvertent orbital entry in FESS.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "os planum"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "orbital-intracranial-sinus-complications"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sphenopalatine-artery",
+      "label": "Sphenopalatine Artery",
+      "type": "vessel",
+      "subspecialty": "rhinology",
+      "detail": "Terminal branch of the maxillary artery entering the nose through the sphenopalatine foramen behind the middle turbinate tail; principal source of severe posterior epistaxis and target of endoscopic ligation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "SPA"
+      ],
+      "abbrev": "SPA",
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "epistaxis-hht"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sphenopalatine-foramen",
+      "label": "Sphenopalatine Foramen",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Opening at the posterior end of the superior meatus transmitting the sphenopalatine artery and nasopalatine nerve; crista ethmoidalis is its anterior bony landmark for SPA ligation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "epistaxis-hht"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "anterior-ethmoidal-artery",
+      "label": "Anterior Ethmoidal Artery",
+      "type": "vessel",
+      "subspecialty": "rhinology",
+      "detail": "Branch of the ophthalmic (internal carotid) artery crossing the ethmoid roof; retraction into the orbit after transection can cause a sight-threatening orbital hematoma.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "AEA"
+      ],
+      "abbrev": "AEA",
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "epistaxis-hht"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "kiesselbach-plexus",
+      "label": "Kiesselbach Plexus",
+      "type": "vessel",
+      "subspecialty": "rhinology",
+      "detail": "Anterior septal anastomosis (Little's area) of the sphenopalatine, anterior ethmoidal, greater palatine, and superior labial arteries; site of the majority of anterior epistaxis.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Little's area",
+        "Kiesselbach's plexus"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "epistaxis-hht"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "woodruff-plexus",
+      "label": "Woodruff Plexus",
+      "type": "vessel",
+      "subspecialty": "rhinology",
+      "detail": "Venous plexus of the posterior inferior meatus/nasopharynx; classic source of posterior epistaxis in older hypertensive patients that is difficult to control with anterior packing.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Woodruff's plexus"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "epistaxis-hht"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sella-turcica",
+      "label": "Sella Turcica",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Saddle-shaped sphenoid depression housing the pituitary gland; its floor is the roof of the sphenoid sinus and the endoscopic corridor to the gland.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "sella"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "nasolacrimal-duct",
+      "label": "Nasolacrimal Duct",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Drains tears from the lacrimal sac into the inferior meatus via the valve of Hasner; obstruction causes epiphora and dacryocystitis, treated by dacryocystorhinostomy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "NLD"
+      ],
+      "abbrev": "NLD",
+      "structure": "space",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "allergic-rhinitis-immunotherapy"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "acute-bacterial-rhinosinusitis",
+      "label": "Acute Bacterial Rhinosinusitis",
+      "type": "pathology",
+      "subspecialty": "rhinology",
+      "detail": "Suspected when viral URI symptoms persist >10 days, worsen after initial improvement (double-worsening), or are severe (fever, purulence, facial pain). Top pathogens: S. pneumoniae, H. influenzae, M. catarrhalis.",
+      "sources": [
+        "AAO-HNSF Adult Sinusitis Clinical Practice Guideline"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ABRS",
+        "acute bacterial sinusitis"
+      ],
+      "abbrev": "ABRS",
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "acute-bacterial-rhinosinusitis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "chronic-rhinosinusitis",
+      "label": "Chronic Rhinosinusitis",
+      "type": "pathology",
+      "subspecialty": "rhinology",
+      "detail": "≥12 weeks of sinonasal inflammation with objective evidence (endoscopy or CT) plus ≥2 cardinal symptoms. Endotyped as type 2 (eosinophilic) vs non-type 2; phenotyped with (CRSwNP) or without (CRSsNP) polyps.",
+      "sources": [
+        "AAO-HNSF Core Curriculum",
+        "EPOS 2020"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CRS"
+      ],
+      "abbrev": "CRS",
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "crs-polyps-afrs-biologics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "nasal-polyposis",
+      "label": "Nasal Polyposis (CRSwNP)",
+      "type": "pathology",
+      "subspecialty": "rhinology",
+      "detail": "Bilateral edematous polyps arising from the ethmoids/middle meatus, typically eosinophilic type 2 inflammation. Associated with asthma and aspirin sensitivity (Samter's triad / AERD). Unilateral polyp warrants tumor workup.",
+      "sources": [
+        "AAO-HNSF Core Curriculum",
+        "EPOS 2020"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CRSwNP",
+        "nasal polyps"
+      ],
+      "abbrev": "CRSwNP",
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "crs-polyps-afrs-biologics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "allergic-fungal-rhinosinusitis",
+      "label": "Allergic Fungal Rhinosinusitis",
+      "type": "pathology",
+      "subspecialty": "rhinology",
+      "detail": "Type I hypersensitivity to fungi producing eosinophilic 'allergic mucin' without tissue invasion, often unilateral with bony expansion in atopic young patients. Treated with surgical debridement plus topical/oral steroids; dupilumab is under study.",
+      "sources": [
+        "https://www.annallergy.org/article/S1081-1206(23)00126-6/fulltext",
+        "https://clinicaltrials.gov/study/NCT04684524"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "AFRS",
+        "AFS"
+      ],
+      "abbrev": "AFRS",
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "crs-polyps-afrs-biologics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "bent-kuhn-criteria",
+      "label": "Bent-Kuhn Criteria",
+      "type": "concept",
+      "subspecialty": "rhinology",
+      "detail": "Five major diagnostic criteria for AFRS: nasal polyposis, fungi on staining, eosinophilic mucin without invasion, type I hypersensitivity to fungi, and characteristic CT findings (heterogeneous hyperattenuation).",
+      "sources": [
+        "https://www.otoscape.com/eponyms/bent-kuhn-criteria-for-afrs.html",
+        "https://www.backtable.com/shows/ent/articles/allergic-fungal-rhinosinusitis-symptoms-diagnostic-criteria"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Bent and Kuhn criteria"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "crs-polyps-afrs-biologics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "lund-mackay-score",
+      "label": "Lund-Mackay Score",
+      "type": "concept",
+      "subspecialty": "rhinology",
+      "detail": "CT staging of rhinosinusitis scoring each sinus group 0–2 and the OMC 0 or 2, per side, for a maximum of 24; standard radiologic severity measure used before FESS.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Lund-Mackay",
+        "LM score"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "crs-polyps-afrs-biologics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "functional-endoscopic-sinus-surgery",
+      "label": "Functional Endoscopic Sinus Surgery",
+      "type": "procedure",
+      "subspecialty": "rhinology",
+      "detail": "Endoscopic mucosa-sparing surgery restoring sinus ventilation and drainage (uncinectomy, maxillary antrostomy, ethmoidectomy, sphenoidotomy, frontal recess dissection) for CRS refractory to medical therapy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "FESS",
+        "ESS",
+        "endoscopic sinus surgery"
+      ],
+      "abbrev": "FESS",
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "crs-polyps-afrs-biologics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "intranasal-corticosteroids",
+      "label": "Intranasal Corticosteroids",
+      "type": "drug",
+      "subspecialty": "rhinology",
+      "detail": "First-line anti-inflammatory therapy for CRS, nasal polyps, and allergic rhinitis; reduce polyp size and congestion with minimal systemic absorption. Epistaxis is the most common local side effect.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "INCS",
+        "nasal steroid spray"
+      ],
+      "abbrev": "INCS",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "allergic-rhinitis-immunotherapy"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "dupilumab",
+      "label": "Dupilumab",
+      "type": "drug",
+      "subspecialty": "rhinology",
+      "detail": "Anti-IL-4Rα monoclonal antibody blocking IL-4 and IL-13 signaling; first biologic FDA-approved (2019) for CRSwNP. Reduces polyp size, congestion, and improves smell in type 2 disease.",
+      "sources": [
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC12535206/",
+        "https://bulletin.entnet.org/clinical-patient-care/article/22881642/biologics-for-chronic-rhinosinusitis-with-nasal-polyps"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Dupixent"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "crs-polyps-afrs-biologics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "omalizumab",
+      "label": "Omalizumab",
+      "type": "drug",
+      "subspecialty": "rhinology",
+      "detail": "Anti-IgE monoclonal antibody FDA-approved (2020) for CRSwNP; binds free IgE to reduce type 2 inflammation and polyp burden, particularly in allergic/asthmatic patients.",
+      "sources": [
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC12535206/",
+        "https://bulletin.entnet.org/clinical-patient-care/article/22881642/biologics-for-chronic-rhinosinusitis-with-nasal-polyps"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Xolair"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "crs-polyps-afrs-biologics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "mepolizumab",
+      "label": "Mepolizumab",
+      "type": "drug",
+      "subspecialty": "rhinology",
+      "detail": "Anti-IL-5 monoclonal antibody FDA-approved (2021) for CRSwNP; depletes eosinophils to shrink polyps. Tezepelumab (anti-TSLP) is a newer fourth biologic approved for CRSwNP.",
+      "sources": [
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC12535206/",
+        "https://pubmed.ncbi.nlm.nih.gov/35510314/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Nucala"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "crs-polyps-afrs-biologics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pott-puffy-tumor",
+      "label": "Pott Puffy Tumor",
+      "type": "pathology",
+      "subspecialty": "rhinology",
+      "detail": "Frontal osteomyelitis with a subperiosteal forehead abscess complicating frontal sinusitis; associated with epidural/intracranial abscess and requires imaging, drainage, and prolonged IV antibiotics.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Pott's puffy tumor"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "orbital-intracranial-sinus-complications"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cavernous-sinus-thrombosis",
+      "label": "Cavernous Sinus Thrombosis",
+      "type": "pathology",
+      "subspecialty": "rhinology",
+      "detail": "Septic thrombosis (Chandler V) spreading from sphenoid/ethmoid sinuses; bilateral eye findings, cranial neuropathies (III, IV, V1-2, VI), and sepsis. Requires antibiotics and often anticoagulation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CST"
+      ],
+      "abbrev": "CST",
+      "structure": null,
+      "region": "skull-base",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "orbital-intracranial-sinus-complications"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "epistaxis",
+      "label": "Epistaxis",
+      "type": "pathology",
+      "subspecialty": "rhinology",
+      "detail": "Anterior bleeds (90%) arise from Kiesselbach plexus and respond to cautery/packing; posterior bleeds from the sphenopalatine/Woodruff region may need posterior packing, SPA ligation, or embolization.",
+      "sources": [
+        "AAO-HNSF Clinical Practice Guideline: Nosebleed (Epistaxis)"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "nosebleed"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "epistaxis-hht"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "hereditary-hemorrhagic-telangiectasia",
+      "label": "Hereditary Hemorrhagic Telangiectasia",
+      "type": "pathology",
+      "subspecialty": "rhinology",
+      "detail": "Autosomal dominant (ENG, ACVRL1) vascular dysplasia; Curaçao criteria (epistaxis, telangiectasias, visceral AVMs, family history). Recurrent epistaxis is the commonest feature; bevacizumab and laser/KTP help.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "HHT",
+        "Osler-Weber-Rendu"
+      ],
+      "abbrev": "HHT",
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "epistaxis-hht"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sphenopalatine-artery-ligation",
+      "label": "Endoscopic Sphenopalatine Artery Ligation",
+      "type": "procedure",
+      "subspecialty": "rhinology",
+      "detail": "Endoscopic clipping/cautery of the SPA at the sphenopalatine foramen behind the middle turbinate tail; definitive treatment for refractory posterior epistaxis with high success and low morbidity.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "SPA ligation",
+        "ESPAL"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "epistaxis-hht"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "nasal-packing",
+      "label": "Nasal Packing",
+      "type": "procedure",
+      "subspecialty": "rhinology",
+      "detail": "Anterior (absorbable or expandable) and posterior (balloon/gauze) packing tamponades epistaxis; posterior packing risks hypoxia and requires monitoring for the nasopulmonary reflex.",
+      "sources": [
+        "AAO-HNSF Clinical Practice Guideline: Nosebleed (Epistaxis)"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "epistaxis-hht"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "allergic-rhinitis",
+      "label": "Allergic Rhinitis",
+      "type": "pathology",
+      "subspecialty": "rhinology",
+      "detail": "IgE-mediated type I hypersensitivity of the nasal mucosa causing sneezing, rhinorrhea, congestion, and itch. Diagnosed by history plus skin-prick or serum specific-IgE testing; classified seasonal vs perennial.",
+      "sources": [
+        "AAO-HNSF Clinical Practice Guideline: Allergic Rhinitis"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "AR",
+        "hay fever"
+      ],
+      "abbrev": "AR",
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "allergic-rhinitis-immunotherapy"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "allergen-immunotherapy",
+      "label": "Allergen Immunotherapy",
+      "type": "procedure",
+      "subspecialty": "rhinology",
+      "detail": "Subcutaneous (SCIT) or sublingual (SLIT) desensitization inducing regulatory T cells and blocking IgG4; the only disease-modifying therapy for allergic rhinitis, offered when pharmacotherapy fails.",
+      "sources": [
+        "AAO-HNSF Clinical Practice Guideline: Allergic Rhinitis"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "SCIT",
+        "SLIT",
+        "immunotherapy"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "allergic-rhinitis-immunotherapy"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "dacryocystorhinostomy",
+      "label": "Dacryocystorhinostomy",
+      "type": "procedure",
+      "subspecialty": "rhinology",
+      "detail": "Endoscopic or external creation of a fistula between the lacrimal sac and nasal cavity anterior to the middle turbinate for nasolacrimal duct obstruction causing epiphora/dacryocystitis.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "DCR"
+      ],
+      "abbrev": "DCR",
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "allergic-rhinitis-immunotherapy"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "inverted-papilloma",
+      "label": "Inverted Papilloma",
+      "type": "pathology",
+      "subspecialty": "rhinology",
+      "detail": "Benign but locally aggressive Schneiderian papilloma, usually unilateral from the lateral nasal wall/maxillary sinus with a focal osteitic attachment (CT tumor origin); ~10% harbor SCC. Krouse staging; treated by endoscopic resection.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Schneiderian papilloma",
+        "IP"
+      ],
+      "abbrev": "IP",
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sinonasal-tumors"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "esthesioneuroblastoma",
+      "label": "Esthesioneuroblastoma",
+      "type": "pathology",
+      "subspecialty": "rhinology",
+      "detail": "Olfactory neuroblastoma arising from cribriform olfactory neuroepithelium; presents with nasal obstruction/epistaxis and dumbbell tumor crossing the skull base. Hyams grade histologically; treated with craniofacial/endoscopic resection plus radiation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "olfactory neuroblastoma",
+        "ENB"
+      ],
+      "abbrev": "ENB",
+      "structure": null,
+      "region": "skull-base",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sinonasal-tumors"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "kadish-staging",
+      "label": "Kadish Staging",
+      "type": "concept",
+      "subspecialty": "rhinology",
+      "detail": "Clinical staging of esthesioneuroblastoma: A confined to the nasal cavity, B extends to paranasal sinuses, C beyond sinuses (Morita added D for nodal/distant metastasis).",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Kadish-Morita"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sinonasal-tumors"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "dulguerov-staging",
+      "label": "Dulguerov TNM Staging",
+      "type": "concept",
+      "subspecialty": "rhinology",
+      "detail": "TNM system for esthesioneuroblastoma refining T stage by extent of skull base, orbit, and intracranial/dural involvement; considered more prognostic than Kadish for advanced tumors.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Dulguerov classification"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sinonasal-tumors"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "juvenile-nasopharyngeal-angiofibroma",
+      "label": "Juvenile Nasopharyngeal Angiofibroma",
+      "type": "pathology",
+      "subspecialty": "rhinology",
+      "detail": "Benign highly vascular tumor of adolescent males arising near the sphenopalatine foramen; presents with obstruction and epistaxis. Anterior bowing of the posterior maxillary wall (Holman-Miller sign); preop embolization then resection. Biopsy contraindicated.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "JNA",
+        "angiofibroma"
+      ],
+      "abbrev": "JNA",
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sinonasal-tumors"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sinonasal-scc",
+      "label": "Sinonasal Squamous Cell Carcinoma",
+      "type": "pathology",
+      "subspecialty": "rhinology",
+      "detail": "Most common sinonasal malignancy, frequently maxillary sinus; risk factors include smoking and occupational exposures. Often advanced at diagnosis; managed with resection plus adjuvant chemoradiation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "sinonasal carcinoma"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sinonasal-tumors"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "csf-rhinorrhea",
+      "label": "CSF Rhinorrhea",
+      "type": "pathology",
+      "subspecialty": "rhinology",
+      "detail": "Leakage of cerebrospinal fluid into the nose from a skull base defect (traumatic, iatrogenic, or spontaneous with elevated ICP). Beta-2 transferrin confirms; high-resolution CT and MRI/cisternography localize the defect.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CSF leak"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "csf-rhinorrhea-encephalocele"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "beta-2-transferrin",
+      "label": "Beta-2 Transferrin",
+      "type": "concept",
+      "subspecialty": "rhinology",
+      "detail": "Highly specific CSF marker (also beta-trace protein) used to confirm CSF rhinorrhea from clear nasal drainage before localization and repair.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "β2-transferrin",
+        "tau transferrin"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "csf-rhinorrhea-encephalocele"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "encephalocele",
+      "label": "Encephalocele / Meningoencephalocele",
+      "type": "pathology",
+      "subspecialty": "rhinology",
+      "detail": "Herniation of meninges (± brain) through a skull base defect, often at the cribriform/lateral lamella or lateral sphenoid recess; presents as a nasal mass or CSF leak. Repaired endoscopically with multilayer reconstruction.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "meningoencephalocele"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "csf-rhinorrhea-encephalocele"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "nasoseptal-flap",
+      "label": "Nasoseptal Flap",
+      "type": "procedure",
+      "subspecialty": "rhinology",
+      "detail": "Pedicled Hadad-Bassagasteguy vascularized mucoperichondrial flap based on the posterior septal branch of the sphenopalatine artery; workhorse reconstruction for anterior skull base and sellar defects to prevent CSF leak.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Hadad flap",
+        "HBF"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "endoscopic-skull-base-repair",
+      "label": "Endoscopic Skull Base Repair",
+      "type": "procedure",
+      "subspecialty": "rhinology",
+      "detail": "Multilayer endoscopic closure of skull base defects using free grafts (fascia, fat) and/or vascularized nasoseptal flap; lumbar drainage and treatment of raised ICP improve success in spontaneous leaks.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CSF leak repair"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "csf-rhinorrhea-encephalocele"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "anterior-skull-base",
+      "label": "Anterior Skull Base",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Floor of the anterior cranial fossa formed by the frontal bone, cribriform plate/ethmoid roof, and planum sphenoidale; surgical corridor for endoscopic resection of sinonasal and skull base tumors.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ASB"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pituitary-adenoma",
+      "label": "Pituitary Adenoma",
+      "type": "pathology",
+      "subspecialty": "rhinology",
+      "detail": "Benign sellar tumor; macroadenomas compress the optic chiasm causing bitemporal hemianopsia. Functioning types secrete prolactin (prolactinomas—medical first), GH, or ACTH. Removed via endoscopic endonasal transsphenoidal approach.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "pituitary tumor"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "endoscopic-transsphenoidal-approach",
+      "label": "Endoscopic Endonasal Transsphenoidal Approach",
+      "type": "procedure",
+      "subspecialty": "rhinology",
+      "detail": "Minimally invasive corridor through the nostril and sphenoid sinus to the sella for pituitary and parasellar lesions, often a combined ENT-neurosurgery approach with nasoseptal flap reconstruction of the defect.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "EEA",
+        "transsphenoidal surgery"
+      ],
+      "abbrev": "EEA",
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "obstructive-sleep-apnea",
+      "label": "Obstructive Sleep Apnea",
+      "type": "pathology",
+      "subspecialty": "sleep",
+      "detail": "Recurrent upper-airway collapse during sleep causing apneas/hypopneas, oxygen desaturation, and arousals. Associated with hypertension, cardiovascular disease, and daytime somnolence. Multilevel obstruction is common at the velopharynx, oropharyngeal lateral walls, tongue base, and epiglottis.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "OSA",
+        "Obstructive Sleep Apnea Syndrome"
+      ],
+      "abbrev": "OSA",
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "adult-osa-evaluation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "velopharynx",
+      "label": "Velopharynx (Retropalatal Airway)",
+      "type": "anatomy",
+      "subspecialty": "sleep",
+      "detail": "Retropalatal segment behind the soft palate/uvula; the most common site of collapse in OSA. Complete concentric collapse here on DISE predicts poor hypoglossal nerve stimulation response.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Retropalatal segment",
+        "Velum"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "oral-pharynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "adult-osa-evaluation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "soft-palate",
+      "label": "Soft Palate",
+      "type": "anatomy",
+      "subspecialty": "sleep",
+      "detail": "Muscular partition (uvula, levator/tensor veli palatini) forming the anterior velopharynx. Redundant or elongated soft palate contributes to snoring and retropalatal obstruction; target of UPPP and pharyngoplasty.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Velum palatinum"
+      ],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "oral-pharynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "adult-osa-evaluation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "genioglossus-muscle",
+      "label": "Genioglossus Muscle",
+      "type": "anatomy",
+      "subspecialty": "sleep",
+      "detail": "Principal pharyngeal dilator; protrudes the tongue and stiffens the airway. Innervated by the hypoglossal nerve (medial branch), it is the effector target of hypoglossal nerve stimulation therapy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "adult-osa-evaluation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "upper-airway-critical-closing-pressure",
+      "label": "Critical Closing Pressure (Pcrit)",
+      "type": "concept",
+      "subspecialty": "sleep",
+      "detail": "The pharyngeal pressure below which the airway collapses; a physiologic measure of collapsibility. OSA reflects a more positive (less negative) Pcrit; positive airway pressure raises the transmural pressure to keep the airway patent.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Pcrit"
+      ],
+      "abbrev": "Pcrit",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "adult-osa-evaluation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "apnea-hypopnea-index",
+      "label": "Apnea-Hypopnea Index (AHI)",
+      "type": "concept",
+      "subspecialty": "sleep",
+      "detail": "Number of apneas plus hypopneas per hour of sleep. Severity: mild 5-15, moderate 15-30, severe >30. Central/mixed events should be <25% of total AHI to be predominantly obstructive.",
+      "sources": [
+        "AAO-HNSF Core Curriculum",
+        "AASM Scoring Manual"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "AHI"
+      ],
+      "abbrev": "AHI",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "adult-osa-evaluation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "respiratory-disturbance-index",
+      "label": "Respiratory Disturbance Index (RDI)",
+      "type": "concept",
+      "subspecialty": "sleep",
+      "detail": "AHI plus respiratory effort-related arousals (RERAs) per hour; captured on in-lab polysomnography with EEG. RDI ≥ AHI because it includes arousals not meeting apnea/hypopnea criteria.",
+      "sources": [
+        "AASM Scoring Manual"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "RDI",
+        "RERA"
+      ],
+      "abbrev": "RDI",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "adult-osa-evaluation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "polysomnography",
+      "label": "Polysomnography",
+      "type": "procedure",
+      "subspecialty": "sleep",
+      "detail": "Attended in-lab study recording EEG, EOG, EMG, ECG, airflow, respiratory effort, and oximetry; the gold standard for OSA diagnosis and severity staging. Level I study; distinguishes obstructive from central events.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Sleep study",
+        "PSG"
+      ],
+      "abbrev": "PSG",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "adult-osa-evaluation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "home-sleep-apnea-test",
+      "label": "Home Sleep Apnea Test",
+      "type": "procedure",
+      "subspecialty": "sleep",
+      "detail": "Portable limited-channel monitor (airflow, effort, oximetry) for uncomplicated adults with high pretest probability of moderate-severe OSA. May underestimate AHI; a negative test in symptomatic patients warrants in-lab PSG.",
+      "sources": [
+        "AASM Clinical Practice Guideline"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "HSAT",
+        "Home sleep test"
+      ],
+      "abbrev": "HSAT",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "adult-osa-evaluation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "stop-bang-questionnaire",
+      "label": "STOP-BANG Questionnaire",
+      "type": "concept",
+      "subspecialty": "sleep",
+      "detail": "Screening tool: Snoring, Tiredness, Observed apnea, Pressure (HTN), BMI>35, Age>50, Neck>40cm, Gender male. Score ≥3 = intermediate/high risk; ≥5 strongly predicts moderate-severe OSA.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "STOP-BANG"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "adult-osa-evaluation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "friedman-tongue-position",
+      "label": "Friedman Tongue Position & Mallampati",
+      "type": "concept",
+      "subspecialty": "sleep",
+      "detail": "Oropharyngeal crowding grades. Modified Mallampati (I-IV) and Friedman tongue position assess visibility of the palate/uvula with tongue at rest; higher grades plus large tonsils predict multilevel obstruction and worse UPPP outcomes.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Mallampati score",
+        "FTP"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "adult-osa-evaluation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "drug-induced-sleep-endoscopy",
+      "label": "Drug-Induced Sleep Endoscopy (DISE)",
+      "type": "procedure",
+      "subspecialty": "sleep",
+      "detail": "Flexible endoscopy under propofol/dexmedetomidine sedation to observe dynamic collapse. Scored by VOTE (Velum, Oropharynx, Tongue base, Epiglottis). Identifying complete concentric palatal collapse is essential before hypoglossal nerve stimulation.",
+      "sources": [
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC12510267/",
+        "https://iowaprotocols.medicine.uiowa.edu/protocols/drug-induced-sleep-endoscopy-dise"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "DISE",
+        "Sleep endoscopy"
+      ],
+      "abbrev": "DISE",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "adult-osa-evaluation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "vote-classification",
+      "label": "VOTE Classification",
+      "type": "concept",
+      "subspecialty": "sleep",
+      "detail": "DISE grading of collapse at four levels—Velum, Oropharynx lateral walls, Tongue base, Epiglottis—each scored 0 (none), 1 (partial), 2 (complete) with pattern noted (anteroposterior, lateral, or concentric).",
+      "sources": [
+        "https://link.springer.com/article/10.1007/s40136-025-00529-5",
+        "https://www.researchgate.net/publication/51167058_Drug-induced_sleep_endoscopy_The_VOTE_classification"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "VOTE"
+      ],
+      "abbrev": "VOTE",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "adult-osa-evaluation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cpap-therapy",
+      "label": "CPAP / Positive Airway Pressure",
+      "type": "procedure",
+      "subspecialty": "sleep",
+      "detail": "Pneumatic splint delivering continuous positive airway pressure; first-line therapy for moderate-severe OSA and highly efficacious when tolerated. Adherence is the main limitation; auto-titrating and BiPAP variants exist.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CPAP",
+        "PAP",
+        "Positive airway pressure"
+      ],
+      "abbrev": "CPAP",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "adult-osa-evaluation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "mandibular-advancement-device",
+      "label": "Oral Appliance (Mandibular Advancement Device)",
+      "type": "procedure",
+      "subspecialty": "sleep",
+      "detail": "Custom dental appliance advancing the mandible to enlarge the retroglossal airway. Indicated for mild-moderate OSA or CPAP-intolerant patients; side effects include TMJ discomfort and dental changes.",
+      "sources": [
+        "AASM/AADSM Clinical Practice Guideline"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "MAD",
+        "Oral appliance therapy",
+        "Mandibular repositioning device"
+      ],
+      "abbrev": "MAD",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "adult-osa-evaluation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "positional-therapy",
+      "label": "Positional Therapy",
+      "type": "concept",
+      "subspecialty": "sleep",
+      "detail": "Avoidance of supine sleep (positional devices/vibratory trainers) for supine-predominant OSA, where AHI is at least twice as high supine versus non-supine. Adjunctive, not curative for severe disease.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Positional OSA therapy"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "adult-osa-evaluation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "weight-loss-bariatric-therapy",
+      "label": "Weight Loss & Bariatric Surgery",
+      "type": "concept",
+      "subspecialty": "sleep",
+      "detail": "Obesity is the strongest modifiable OSA risk factor; ~10% weight loss can substantially reduce AHI. Bariatric surgery markedly improves OSA in the morbidly obese; GLP-1 agonists are an emerging adjunct.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Weight reduction"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "adult-osa-evaluation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "uvulopalatopharyngoplasty",
+      "label": "Uvulopalatopharyngoplasty (UPPP)",
+      "type": "procedure",
+      "subspecialty": "sleep",
+      "detail": "Resection/repositioning of the uvula, soft palate margin, and tonsils to relieve retropalatal obstruction. Best in Friedman stage I with large tonsils; complications include velopharyngeal insufficiency and nasopharyngeal stenosis.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "UPPP",
+        "UP3"
+      ],
+      "abbrev": "UPPP",
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sleep-surgery-hgns"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "expansion-sphincter-pharyngoplasty",
+      "label": "Expansion Sphincter Pharyngoplasty",
+      "type": "procedure",
+      "subspecialty": "sleep",
+      "detail": "Palatopharyngeus muscle is transposed antero-laterally to splint the lateral pharyngeal walls, addressing lateral wall collapse. A tissue-preserving alternative to classic UPPP with lower VPI risk; barbed reposition pharyngoplasty is a related technique.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ESP",
+        "Lateral pharyngoplasty",
+        "Barbed reposition pharyngoplasty"
+      ],
+      "abbrev": "ESP",
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sleep-surgery-hgns"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "hypoglossal-nerve-stimulation",
+      "label": "Hypoglossal Nerve Stimulation (Inspire/HGNS)",
+      "type": "procedure",
+      "subspecialty": "sleep",
+      "detail": "Implanted stimulator (Inspire) delivers phasic stimulation to the medial hypoglossal branch, protruding the tongue in sync with respiration. FDA candidacy: AHI 15-65, BMI <32-35, CPAP-intolerant, age ≥18-22, central events <25%. Complete concentric palatal collapse on DISE is an exclusion.",
+      "sources": [
+        "https://www.ncbi.nlm.nih.gov/books/NBK594264/",
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC5739331/"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "HGNS",
+        "Inspire",
+        "Upper airway stimulation",
+        "UAS"
+      ],
+      "abbrev": "HGNS",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sleep-surgery-hgns"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "complete-concentric-collapse-palate",
+      "label": "Complete Concentric Collapse (Palate)",
+      "type": "concept",
+      "subspecialty": "sleep",
+      "detail": "Circumferential velopharyngeal collapse on DISE (CCCp), driven by both AP and lateral wall movement. Predicts reduced hypoglossal nerve stimulation efficacy and is a current contraindication/exclusion for Inspire implantation.",
+      "sources": [
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC12510267/",
+        "https://link.springer.com/article/10.1007/s00405-021-06704-w"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CCCp",
+        "CCC",
+        "Concentric collapse"
+      ],
+      "abbrev": "CCCp",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sleep-surgery-hgns"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "maxillomandibular-advancement",
+      "label": "Maxillomandibular Advancement",
+      "type": "procedure",
+      "subspecialty": "sleep",
+      "detail": "Le Fort I plus bilateral sagittal split osteotomies advancing both jaws ~10mm, expanding the entire velo-orohypopharyngeal airway. The most effective surgical alternative to CPAP (success/cure rates approaching 85-90%), reserved for skeletal deficiency or refractory OSA.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "MMA",
+        "Bimaxillary advancement"
+      ],
+      "abbrev": "MMA",
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sleep-surgery-hgns"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "genioglossus-advancement",
+      "label": "Genioglossus Advancement / Hyoid Suspension",
+      "type": "procedure",
+      "subspecialty": "sleep",
+      "detail": "Genial tubercle osteotomy advances the genioglossus to reduce retroglossal collapse; hyoid myotomy-suspension repositions the hyoid anteriorly. Often combined in multilevel phase-I surgery for tongue-base obstruction.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "GGA",
+        "Hyoid suspension",
+        "Hyoid myotomy"
+      ],
+      "abbrev": "GGA",
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sleep-surgery-hgns"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "friedman-staging-system",
+      "label": "Friedman Staging System",
+      "type": "concept",
+      "subspecialty": "sleep",
+      "detail": "Predicts UPPP success from Friedman tongue position, tonsil size, and BMI. Stage I (favorable palatal anatomy, large tonsils) has high UPPP success; stage III predicts poor palate-only surgery, favoring multilevel or alternative therapy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Friedman stage"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sleep-surgery-hgns"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sleep-tracheostomy",
+      "label": "Tracheostomy for OSA",
+      "type": "procedure",
+      "subspecialty": "sleep",
+      "detail": "Bypasses all sites of pharyngeal collapse and is essentially 100% curative for OSA. Now reserved for life-threatening disease refractory to all other therapy or severe craniofacial anomalies.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "sleep-surgery-hgns"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pediatric-osa",
+      "label": "Pediatric Obstructive Sleep Apnea",
+      "type": "pathology",
+      "subspecialty": "sleep",
+      "detail": "Sleep-disordered breathing in children, most often from adenotonsillar hypertrophy. Presents with snoring, witnessed apnea, restless sleep, enuresis, hyperactivity/inattention, and failure to thrive rather than daytime sleepiness. Obesity and craniofacial anomalies are additional risks.",
+      "sources": [
+        "AAO-HNSF Clinical Practice Guideline",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Pediatric OSA",
+        "Childhood OSA"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-osa"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sleep-disordered-breathing",
+      "label": "Sleep-Disordered Breathing",
+      "type": "concept",
+      "subspecialty": "sleep",
+      "detail": "Spectrum from primary snoring and upper airway resistance syndrome to obstructive hypoventilation and OSA. In children, symptomatic sleep-disordered breathing may warrant adenotonsillectomy even without confirmatory polysomnography.",
+      "sources": [
+        "AAO-HNSF Clinical Practice Guideline"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "SDB"
+      ],
+      "abbrev": "SDB",
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-osa"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "adenotonsillar-hypertrophy",
+      "label": "Adenotonsillar Hypertrophy",
+      "type": "pathology",
+      "subspecialty": "sleep",
+      "detail": "Enlargement of the palatine tonsils and adenoids (Waldeyer's ring); the leading cause of pediatric OSA, peaking ages 2-8 when lymphoid tissue is largest relative to airway. Graded by Brodsky (tonsils) and adenoid nasopharyngeal ratio.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Tonsillar hypertrophy",
+        "Adenoid hypertrophy"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-osa"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "adenotonsillectomy",
+      "label": "Adenotonsillectomy",
+      "type": "procedure",
+      "subspecialty": "sleep",
+      "detail": "First-line treatment for pediatric OSA with adenotonsillar hypertrophy; cures/improves the majority. Residual OSA is more common in obese, severe-baseline, or syndromic children, who need postoperative polysomnography and continued monitoring.",
+      "sources": [
+        "AAO-HNSF Clinical Practice Guideline"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "T&A",
+        "Tonsillectomy and adenoidectomy"
+      ],
+      "abbrev": "T&A",
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-osa"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "brodsky-tonsil-grading",
+      "label": "Brodsky Tonsil Grading",
+      "type": "concept",
+      "subspecialty": "sleep",
+      "detail": "Standardized scale of tonsil size by oropharyngeal airway occupied: 0 (in fossa) to 4+ (>75%, 'kissing tonsils'). Larger grades correlate with obstruction and support adenotonsillectomy in sleep-disordered breathing.",
+      "sources": [
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Brodsky scale",
+        "Tonsil grade"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-osa"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pediatric-polysomnography-criteria",
+      "label": "Pediatric Polysomnography Criteria",
+      "type": "concept",
+      "subspecialty": "sleep",
+      "detail": "Children have stricter thresholds: obstructive AHI >1 is abnormal, with severity roughly mild 1-5, moderate 5-10, severe >10. PSG is recommended before adenotonsillectomy in high-risk children (obesity, Down syndrome, craniofacial anomaly, neuromuscular disease).",
+      "sources": [
+        "AAO-HNSF Clinical Practice Guideline",
+        "AASM Scoring Manual"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Pediatric AHI"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "pediatric-osa"
+        ]
+      },
+      "review": false
     }
   ],
   "edges": [
@@ -1520,6 +14854,2832 @@
       "target": "incus",
       "type": "treats",
       "label": "replaces eroded"
+    },
+    {
+      "source": "inferior-thyroid-artery",
+      "target": "parathyroid-glands",
+      "type": "supplies",
+      "label": "dominant parathyroid supply"
+    },
+    {
+      "source": "inferior-thyroid-artery",
+      "target": "thyroid-gland",
+      "type": "supplies"
+    },
+    {
+      "source": "superior-thyroid-artery",
+      "target": "thyroid-gland",
+      "type": "supplies",
+      "label": "superior pole",
+      "direction": "superior"
+    },
+    {
+      "source": "superior-thyroid-artery",
+      "target": "superior-laryngeal-nerve-external-branch",
+      "type": "landmark_for",
+      "label": "at-risk at upper pole"
+    },
+    {
+      "source": "superior-laryngeal-nerve-external-branch",
+      "target": "thyroid-gland",
+      "type": "innervates",
+      "label": "cricothyroid (pitch)"
+    },
+    {
+      "source": "berry-ligament",
+      "target": "thyroid-gland",
+      "type": "suspends",
+      "direction": "posterior"
+    },
+    {
+      "source": "berry-ligament",
+      "target": "recurrent-laryngeal-nerve",
+      "type": "landmark_for",
+      "label": "most common RLN injury site"
+    },
+    {
+      "source": "tubercle-of-zuckerkandl",
+      "target": "recurrent-laryngeal-nerve",
+      "type": "landmark_for",
+      "label": "RLN runs medial/deep",
+      "direction": "medial"
+    },
+    {
+      "source": "recurrent-laryngeal-nerve",
+      "target": "total-thyroidectomy",
+      "type": "landmark_for",
+      "label": "at risk"
+    },
+    {
+      "source": "berry-ligament",
+      "target": "total-thyroidectomy",
+      "type": "landmark_for"
+    },
+    {
+      "source": "thyroid-nodule",
+      "target": "thyroid-gland",
+      "type": "arises_from"
+    },
+    {
+      "source": "fna-thyroid",
+      "target": "thyroid-nodule",
+      "type": "landmark_for",
+      "label": "primary triage test"
+    },
+    {
+      "source": "thyroid-nodule",
+      "target": "bethesda-system",
+      "type": "staged_with"
+    },
+    {
+      "source": "thyroid-nodule",
+      "target": "ti-rads",
+      "type": "staged_with",
+      "label": "sonographic risk"
+    },
+    {
+      "source": "bethesda-iii-aus",
+      "target": "bethesda-system",
+      "type": "part_of"
+    },
+    {
+      "source": "bethesda-iv-follicular-neoplasm",
+      "target": "bethesda-system",
+      "type": "part_of"
+    },
+    {
+      "source": "bethesda-iii-aus",
+      "target": "afirma-gsc",
+      "type": "staged_with",
+      "label": "molecular risk-stratification"
+    },
+    {
+      "source": "bethesda-iii-aus",
+      "target": "thyroseq-v3",
+      "type": "staged_with"
+    },
+    {
+      "source": "bethesda-iv-follicular-neoplasm",
+      "target": "thyroseq-v3",
+      "type": "staged_with"
+    },
+    {
+      "source": "afirma-gsc",
+      "target": "thyroseq-v3",
+      "type": "differentiates_from",
+      "label": "rule-out vs rule-in/out"
+    },
+    {
+      "source": "thyroid-lobectomy",
+      "target": "thyroid-nodule",
+      "type": "treats",
+      "label": "diagnostic/definitive"
+    },
+    {
+      "source": "niftp",
+      "target": "bethesda-iv-follicular-neoplasm",
+      "type": "differentiates_from",
+      "label": "non-malignant reclassification"
+    },
+    {
+      "source": "pth-physiology",
+      "target": "parathyroid-glands",
+      "type": "part_of",
+      "label": "chief-cell PTH secretion"
+    },
+    {
+      "source": "parathyroid-adenoma",
+      "target": "parathyroid-glands",
+      "type": "arises_from"
+    },
+    {
+      "source": "primary-hyperparathyroidism",
+      "target": "parathyroid-adenoma",
+      "type": "arises_from",
+      "label": "~85% of cases"
+    },
+    {
+      "source": "primary-hyperparathyroidism",
+      "target": "secondary-hyperparathyroidism",
+      "type": "differentiates_from"
+    },
+    {
+      "source": "primary-hyperparathyroidism",
+      "target": "familial-hypocalciuric-hypercalcemia",
+      "type": "differentiates_from",
+      "label": "low urinary Ca in FHH"
+    },
+    {
+      "source": "tertiary-hyperparathyroidism",
+      "target": "secondary-hyperparathyroidism",
+      "type": "complication_of",
+      "label": "autonomous progression"
+    },
+    {
+      "source": "sestamibi-scan",
+      "target": "parathyroid-adenoma",
+      "type": "landmark_for",
+      "label": "localization"
+    },
+    {
+      "source": "4d-ct-parathyroid",
+      "target": "parathyroid-adenoma",
+      "type": "landmark_for",
+      "label": "localization / reoperative"
+    },
+    {
+      "source": "parathyroidectomy",
+      "target": "primary-hyperparathyroidism",
+      "type": "treats"
+    },
+    {
+      "source": "parathyroidectomy",
+      "target": "tertiary-hyperparathyroidism",
+      "type": "treats"
+    },
+    {
+      "source": "intraoperative-pth-monitoring",
+      "target": "parathyroidectomy",
+      "type": "part_of",
+      "label": "Miami criterion"
+    },
+    {
+      "source": "inferior-thyroid-artery",
+      "target": "recurrent-laryngeal-nerve",
+      "type": "landmark_for",
+      "label": "variable crossing"
+    },
+    {
+      "source": "medullary-thyroid-carcinoma",
+      "target": "thyroid-gland",
+      "type": "arises_from",
+      "label": "parafollicular C cells"
+    },
+    {
+      "source": "medullary-thyroid-carcinoma",
+      "target": "calcitonin-cea-markers",
+      "type": "staged_with",
+      "label": "surveillance markers"
+    },
+    {
+      "source": "men2a",
+      "target": "ret-protooncogene",
+      "type": "arises_from",
+      "label": "germline RET (codon 634)"
+    },
+    {
+      "source": "men2b",
+      "target": "ret-protooncogene",
+      "type": "arises_from",
+      "label": "RET M918T"
+    },
+    {
+      "source": "familial-mtc",
+      "target": "ret-protooncogene",
+      "type": "arises_from"
+    },
+    {
+      "source": "men2a",
+      "target": "medullary-thyroid-carcinoma",
+      "type": "forms"
+    },
+    {
+      "source": "men2a",
+      "target": "pheochromocytoma",
+      "type": "forms"
+    },
+    {
+      "source": "men2a",
+      "target": "primary-hyperparathyroidism",
+      "type": "forms"
+    },
+    {
+      "source": "men2b",
+      "target": "medullary-thyroid-carcinoma",
+      "type": "forms",
+      "label": "earliest, most aggressive"
+    },
+    {
+      "source": "prophylactic-thyroidectomy",
+      "target": "men2b",
+      "type": "treats",
+      "label": "within first year"
+    },
+    {
+      "source": "prophylactic-thyroidectomy",
+      "target": "men2a",
+      "type": "treats",
+      "label": "risk-reducing"
+    },
+    {
+      "source": "total-thyroidectomy",
+      "target": "medullary-thyroid-carcinoma",
+      "type": "treats",
+      "label": "+ central neck dissection"
+    },
+    {
+      "source": "selpercatinib",
+      "target": "medullary-thyroid-carcinoma",
+      "type": "treats",
+      "label": "RET-mutant, advanced"
+    },
+    {
+      "source": "pheochromocytoma",
+      "target": "medullary-thyroid-carcinoma",
+      "type": "complication_of",
+      "label": "resect pheo first"
+    },
+    {
+      "source": "anaplastic-thyroid-carcinoma",
+      "target": "thyroid-gland",
+      "type": "arises_from"
+    },
+    {
+      "source": "anaplastic-thyroid-carcinoma",
+      "target": "medullary-thyroid-carcinoma",
+      "type": "differentiates_from"
+    },
+    {
+      "source": "dabrafenib-trametinib",
+      "target": "anaplastic-thyroid-carcinoma",
+      "type": "treats",
+      "label": "BRAF V600E"
+    },
+    {
+      "source": "selpercatinib",
+      "target": "anaplastic-thyroid-carcinoma",
+      "type": "treats",
+      "label": "RET fusion-positive"
+    },
+    {
+      "source": "central-neck-dissection",
+      "target": "total-thyroidectomy",
+      "type": "part_of",
+      "label": "level VI"
+    },
+    {
+      "source": "central-neck-dissection",
+      "target": "medullary-thyroid-carcinoma",
+      "type": "treats",
+      "label": "routine in MTC"
+    },
+    {
+      "source": "recurrent-laryngeal-nerve",
+      "target": "parathyroidectomy",
+      "type": "landmark_for",
+      "label": "at risk"
+    },
+    {
+      "source": "facial-nerve-segments",
+      "target": "facial-nerve",
+      "type": "part_of"
+    },
+    {
+      "source": "facial-nerve-segments",
+      "target": "stylomastoid-foramen",
+      "type": "passes_through",
+      "label": "exits skull"
+    },
+    {
+      "source": "facial-nerve-segments",
+      "target": "geniculate-ganglion",
+      "type": "contained_in"
+    },
+    {
+      "source": "bells-palsy",
+      "target": "facial-nerve",
+      "type": "arises_from"
+    },
+    {
+      "source": "house-brackmann-scale",
+      "target": "bells-palsy",
+      "type": "staged_with",
+      "label": "grades"
+    },
+    {
+      "source": "sunnybrook-facial-grading",
+      "target": "synkinesis",
+      "type": "staged_with"
+    },
+    {
+      "source": "facial-nerve-electrodiagnostics",
+      "target": "bells-palsy",
+      "type": "staged_with",
+      "label": "prognosis"
+    },
+    {
+      "source": "synkinesis",
+      "target": "bells-palsy",
+      "type": "complication_of"
+    },
+    {
+      "source": "gracilis-free-muscle-transfer",
+      "target": "bells-palsy",
+      "type": "treats",
+      "label": "smile reanimation"
+    },
+    {
+      "source": "cross-facial-nerve-graft",
+      "target": "gracilis-free-muscle-transfer",
+      "type": "landmark_for",
+      "label": "stage 1 neurotizes"
+    },
+    {
+      "source": "masseteric-nerve-transfer",
+      "target": "gracilis-free-muscle-transfer",
+      "type": "landmark_for",
+      "label": "neurotizes"
+    },
+    {
+      "source": "eyelid-reanimation-gold-weight",
+      "target": "bells-palsy",
+      "type": "treats",
+      "label": "lagophthalmos"
+    },
+    {
+      "source": "le-fort-fractures",
+      "target": "facial-buttresses",
+      "type": "arises_from"
+    },
+    {
+      "source": "zmc-fracture",
+      "target": "zygomaticomaxillary-complex",
+      "type": "arises_from"
+    },
+    {
+      "source": "mandible-fracture",
+      "target": "mandible",
+      "type": "arises_from"
+    },
+    {
+      "source": "orbital-blowout-fracture",
+      "target": "orbital-floor",
+      "type": "arises_from"
+    },
+    {
+      "source": "naso-orbito-ethmoid-fracture",
+      "target": "facial-buttresses",
+      "type": "arises_from",
+      "label": "medial",
+      "direction": "medial"
+    },
+    {
+      "source": "zygomaticomaxillary-complex",
+      "target": "orbital-floor",
+      "type": "forms",
+      "label": "lateral floor"
+    },
+    {
+      "source": "zygomaticomaxillary-complex",
+      "target": "facial-buttresses",
+      "type": "part_of",
+      "label": "lateral vertical"
+    },
+    {
+      "source": "open-reduction-internal-fixation",
+      "target": "zmc-fracture",
+      "type": "treats"
+    },
+    {
+      "source": "open-reduction-internal-fixation",
+      "target": "mandible-fracture",
+      "type": "treats"
+    },
+    {
+      "source": "open-reduction-internal-fixation",
+      "target": "le-fort-fractures",
+      "type": "treats"
+    },
+    {
+      "source": "maxillomandibular-fixation",
+      "target": "mandible-fracture",
+      "type": "treats",
+      "label": "restores occlusion"
+    },
+    {
+      "source": "maxillomandibular-fixation",
+      "target": "open-reduction-internal-fixation",
+      "type": "landmark_for",
+      "label": "precedes fixation"
+    },
+    {
+      "source": "mohs-micrographic-surgery",
+      "target": "rotation-flap",
+      "type": "landmark_for",
+      "label": "defect precedes recon"
+    },
+    {
+      "source": "rotation-flap",
+      "target": "relaxed-skin-tension-lines",
+      "type": "landmark_for",
+      "label": "oriented along"
+    },
+    {
+      "source": "transposition-flap",
+      "target": "relaxed-skin-tension-lines",
+      "type": "landmark_for"
+    },
+    {
+      "source": "advancement-flap",
+      "target": "relaxed-skin-tension-lines",
+      "type": "landmark_for"
+    },
+    {
+      "source": "paramedian-forehead-flap",
+      "target": "nasal-aesthetic-subunits",
+      "type": "landmark_for",
+      "label": "resurfaces subunit"
+    },
+    {
+      "source": "paramedian-forehead-flap",
+      "target": "mohs-micrographic-surgery",
+      "type": "treats",
+      "label": "reconstructs defect"
+    },
+    {
+      "source": "skin-graft-ftsg-stsg",
+      "target": "mohs-micrographic-surgery",
+      "type": "treats"
+    },
+    {
+      "source": "nasal-aesthetic-subunits",
+      "target": "lower-lateral-cartilage",
+      "type": "bounded_by"
+    },
+    {
+      "source": "rhinoplasty",
+      "target": "nasal-septum",
+      "type": "landmark_for"
+    },
+    {
+      "source": "rhinoplasty",
+      "target": "lower-lateral-cartilage",
+      "type": "landmark_for",
+      "label": "tip"
+    },
+    {
+      "source": "rhinoplasty",
+      "target": "nasal-analysis",
+      "type": "staged_with",
+      "label": "planned by"
+    },
+    {
+      "source": "nasal-grafts",
+      "target": "nasal-septum",
+      "type": "arises_from",
+      "label": "septal cartilage donor"
+    },
+    {
+      "source": "nasal-grafts",
+      "target": "rhinoplasty",
+      "type": "part_of"
+    },
+    {
+      "source": "costal-cartilage-graft",
+      "target": "rhinoplasty",
+      "type": "treats",
+      "label": "dorsal augmentation"
+    },
+    {
+      "source": "costal-cartilage-graft",
+      "target": "auricular-reconstruction",
+      "type": "part_of",
+      "label": "framework"
+    },
+    {
+      "source": "fibula-free-flap",
+      "target": "mandible",
+      "type": "treats",
+      "label": "reconstructs"
+    },
+    {
+      "source": "fibula-free-flap",
+      "target": "microvascular-anastomosis",
+      "type": "part_of"
+    },
+    {
+      "source": "radial-forearm-free-flap",
+      "target": "microvascular-anastomosis",
+      "type": "part_of"
+    },
+    {
+      "source": "anterolateral-thigh-flap",
+      "target": "microvascular-anastomosis",
+      "type": "part_of"
+    },
+    {
+      "source": "microtia",
+      "target": "auricular-reconstruction",
+      "type": "treats"
+    },
+    {
+      "source": "auricular-reconstruction",
+      "target": "costal-cartilage-graft",
+      "type": "arises_from"
+    },
+    {
+      "source": "otoplasty",
+      "target": "prominent-ear",
+      "type": "treats"
+    },
+    {
+      "source": "rhytidectomy",
+      "target": "smas",
+      "type": "landmark_for",
+      "label": "resuspends"
+    },
+    {
+      "source": "rhytidectomy",
+      "target": "facial-danger-zones",
+      "type": "complication_of",
+      "label": "nerve injury risk"
+    },
+    {
+      "source": "smas",
+      "target": "facial-nerve",
+      "type": "landmark_for",
+      "label": "branches deep to",
+      "direction": "deep"
+    },
+    {
+      "source": "blepharoplasty",
+      "target": "brow-lift",
+      "type": "staged_with",
+      "label": "combined"
+    },
+    {
+      "source": "brow-lift",
+      "target": "facial-danger-zones",
+      "type": "complication_of",
+      "label": "frontal branch"
+    },
+    {
+      "source": "platysma-muscle",
+      "target": "superficial-cervical-fascia",
+      "type": "contained_in",
+      "label": "within superficial fascia"
+    },
+    {
+      "source": "investing-layer-deep-cervical-fascia",
+      "target": "deep-cervical-fascia",
+      "type": "part_of",
+      "label": "superficial layer",
+      "direction": "superficial"
+    },
+    {
+      "source": "pretracheal-visceral-fascia",
+      "target": "deep-cervical-fascia",
+      "type": "part_of",
+      "label": "middle layer"
+    },
+    {
+      "source": "prevertebral-fascia",
+      "target": "deep-cervical-fascia",
+      "type": "part_of",
+      "label": "deep layer",
+      "direction": "deep"
+    },
+    {
+      "source": "carotid-sheath",
+      "target": "deep-cervical-fascia",
+      "type": "part_of",
+      "label": "formed by all three layers"
+    },
+    {
+      "source": "alar-fascia",
+      "target": "prevertebral-fascia",
+      "type": "part_of",
+      "label": "anterior split of deep layer",
+      "direction": "anterior"
+    },
+    {
+      "source": "retropharyngeal-space",
+      "target": "pretracheal-visceral-fascia",
+      "type": "bounded_by",
+      "label": "anterior wall",
+      "direction": "anterior"
+    },
+    {
+      "source": "retropharyngeal-space",
+      "target": "alar-fascia",
+      "type": "bounded_by",
+      "label": "posterior wall",
+      "direction": "posterior"
+    },
+    {
+      "source": "danger-space",
+      "target": "alar-fascia",
+      "type": "bounded_by",
+      "label": "anterior wall",
+      "direction": "anterior"
+    },
+    {
+      "source": "danger-space",
+      "target": "prevertebral-fascia",
+      "type": "bounded_by",
+      "label": "posterior wall",
+      "direction": "posterior"
+    },
+    {
+      "source": "prevertebral-space",
+      "target": "prevertebral-fascia",
+      "type": "bounded_by",
+      "label": "anterior wall",
+      "direction": "anterior"
+    },
+    {
+      "source": "submandibular-space",
+      "target": "investing-layer-deep-cervical-fascia",
+      "type": "bounded_by",
+      "label": "inferior/superficial wall"
+    },
+    {
+      "source": "masticator-space",
+      "target": "investing-layer-deep-cervical-fascia",
+      "type": "bounded_by",
+      "label": "enclosed by split investing layer"
+    },
+    {
+      "source": "parotid-space",
+      "target": "investing-layer-deep-cervical-fascia",
+      "type": "bounded_by",
+      "label": "enclosed by investing layer"
+    },
+    {
+      "source": "parapharyngeal-space",
+      "target": "carotid-sheath",
+      "type": "landmark_for",
+      "label": "poststyloid compartment",
+      "direction": "posterior"
+    },
+    {
+      "source": "danger-space",
+      "target": "retropharyngeal-space",
+      "type": "continuous_with",
+      "label": "separated by alar fascia",
+      "direction": "posterior"
+    },
+    {
+      "source": "parotid-space",
+      "target": "parapharyngeal-space",
+      "type": "continuous_with",
+      "label": "incomplete medial capsule",
+      "direction": "medial"
+    },
+    {
+      "source": "retropharyngeal-space",
+      "target": "parapharyngeal-space",
+      "type": "continuous_with",
+      "label": "communicate laterally",
+      "direction": "lateral"
+    },
+    {
+      "source": "ludwigs-angina",
+      "target": "submandibular-space",
+      "type": "arises_from",
+      "label": "bilateral submandibular cellulitis"
+    },
+    {
+      "source": "ludwigs-angina",
+      "target": "deep-neck-space-abscess",
+      "type": "part_of",
+      "label": "deep neck infection spectrum"
+    },
+    {
+      "source": "deep-neck-space-abscess",
+      "target": "parapharyngeal-space",
+      "type": "arises_from",
+      "label": "common site"
+    },
+    {
+      "source": "deep-neck-space-abscess",
+      "target": "retropharyngeal-space",
+      "type": "arises_from",
+      "label": "common pediatric site"
+    },
+    {
+      "source": "descending-mediastinitis",
+      "target": "deep-neck-space-abscess",
+      "type": "complication_of",
+      "label": "spread to mediastinum",
+      "direction": "inferior"
+    },
+    {
+      "source": "descending-mediastinitis",
+      "target": "danger-space",
+      "type": "arises_from",
+      "label": "conduit to mediastinum",
+      "direction": "inferior"
+    },
+    {
+      "source": "neck-abscess-incision-drainage",
+      "target": "deep-neck-space-abscess",
+      "type": "treats",
+      "label": "surgical drainage"
+    },
+    {
+      "source": "ampicillin-sulbactam",
+      "target": "deep-neck-space-abscess",
+      "type": "treats",
+      "label": "empiric IV therapy"
+    },
+    {
+      "source": "clindamycin",
+      "target": "ludwigs-angina",
+      "type": "treats",
+      "label": "anaerobic coverage"
+    },
+    {
+      "source": "computed-tomography",
+      "target": "deep-neck-space-abscess",
+      "type": "landmark_for",
+      "label": "ring-enhancing collection"
+    },
+    {
+      "source": "iodinated-contrast",
+      "target": "computed-tomography",
+      "type": "part_of",
+      "label": "vascular/abscess enhancement"
+    },
+    {
+      "source": "gadolinium-contrast",
+      "target": "magnetic-resonance-imaging",
+      "type": "part_of",
+      "label": "T1 enhancement"
+    },
+    {
+      "source": "cricothyrotomy",
+      "target": "cricothyroid-membrane",
+      "type": "passes_through",
+      "label": "incise the membrane"
+    },
+    {
+      "source": "cricothyrotomy",
+      "target": "difficult-airway-algorithm",
+      "type": "part_of",
+      "label": "cannot intubate/oxygenate rescue"
+    },
+    {
+      "source": "endotracheal-intubation",
+      "target": "difficult-airway-algorithm",
+      "type": "part_of",
+      "label": "primary airway"
+    },
+    {
+      "source": "tracheostomy",
+      "target": "difficult-airway-algorithm",
+      "type": "part_of",
+      "label": "surgical airway option"
+    },
+    {
+      "source": "rapid-sequence-induction",
+      "target": "endotracheal-intubation",
+      "type": "part_of",
+      "label": "induction for intubation"
+    },
+    {
+      "source": "difficult-airway-algorithm",
+      "target": "ludwigs-angina",
+      "type": "treats",
+      "label": "airway control in DNI"
+    },
+    {
+      "source": "perioperative-anticoagulation",
+      "target": "coagulation-cascade",
+      "type": "part_of",
+      "label": "targets clotting factors"
+    },
+    {
+      "source": "tranexamic-acid",
+      "target": "coagulation-cascade",
+      "type": "part_of",
+      "label": "antifibrinolytic"
+    },
+    {
+      "source": "von-willebrand-disease",
+      "target": "coagulation-cascade",
+      "type": "complication_of",
+      "label": "impaired primary hemostasis"
+    },
+    {
+      "source": "surgical-antibiotic-prophylaxis",
+      "target": "deep-neck-space-abscess",
+      "type": "differentiates_from",
+      "label": "prophylaxis vs treatment"
+    },
+    {
+      "source": "predictive-values",
+      "target": "sensitivity-specificity",
+      "type": "differentiates_from",
+      "label": "prevalence-dependent vs intrinsic"
+    },
+    {
+      "source": "likelihood-ratios",
+      "target": "sensitivity-specificity",
+      "type": "arises_from",
+      "label": "derived from Sn/Sp"
+    },
+    {
+      "source": "p-value-confidence-interval",
+      "target": "study-designs",
+      "type": "part_of",
+      "label": "inference in trials"
+    },
+    {
+      "source": "oral-cavity-scc",
+      "target": "oral-tongue",
+      "type": "arises_from"
+    },
+    {
+      "source": "oral-cavity-scc",
+      "target": "floor-of-mouth",
+      "type": "arises_from"
+    },
+    {
+      "source": "oral-cavity-scc",
+      "target": "ajcc8-oral-cavity-staging",
+      "type": "staged_with"
+    },
+    {
+      "source": "oral-cavity-scc",
+      "target": "depth-of-invasion",
+      "type": "staged_with",
+      "label": "T category"
+    },
+    {
+      "source": "ajcc8-oral-cavity-staging",
+      "target": "extranodal-extension",
+      "type": "staged_with",
+      "label": "pN3b"
+    },
+    {
+      "source": "glossectomy",
+      "target": "oral-cavity-scc",
+      "type": "treats"
+    },
+    {
+      "source": "oral-cavity-scc",
+      "target": "level-i-neck",
+      "type": "drains_to",
+      "label": "first echelon"
+    },
+    {
+      "source": "oropharyngeal-scc",
+      "target": "palatine-tonsil",
+      "type": "arises_from"
+    },
+    {
+      "source": "oropharyngeal-scc",
+      "target": "base-of-tongue",
+      "type": "arises_from"
+    },
+    {
+      "source": "oropharyngeal-scc",
+      "target": "hpv-p16-scc",
+      "type": "staged_with",
+      "label": "p16 status"
+    },
+    {
+      "source": "oropharyngeal-scc",
+      "target": "ajcc8-hpv-oropharynx-staging",
+      "type": "staged_with"
+    },
+    {
+      "source": "transoral-robotic-surgery",
+      "target": "oropharyngeal-scc",
+      "type": "treats"
+    },
+    {
+      "source": "oropharyngeal-scc",
+      "target": "level-ii-neck",
+      "type": "drains_to"
+    },
+    {
+      "source": "laryngeal-scc",
+      "target": "glottic-cancer",
+      "type": "part_of"
+    },
+    {
+      "source": "laryngeal-scc",
+      "target": "supraglottic-cancer",
+      "type": "part_of"
+    },
+    {
+      "source": "glottic-cancer",
+      "target": "true-vocal-fold",
+      "type": "arises_from"
+    },
+    {
+      "source": "total-laryngectomy",
+      "target": "laryngeal-scc",
+      "type": "treats"
+    },
+    {
+      "source": "transoral-laser-microsurgery",
+      "target": "glottic-cancer",
+      "type": "treats",
+      "label": "early T1-T2"
+    },
+    {
+      "source": "organ-preservation-larynx",
+      "target": "laryngeal-scc",
+      "type": "treats"
+    },
+    {
+      "source": "laryngeal-scc",
+      "target": "level-iii-neck",
+      "type": "drains_to"
+    },
+    {
+      "source": "pleomorphic-adenoma",
+      "target": "parotid-gland",
+      "type": "arises_from"
+    },
+    {
+      "source": "warthin-tumor",
+      "target": "parotid-gland",
+      "type": "arises_from"
+    },
+    {
+      "source": "mucoepidermoid-carcinoma",
+      "target": "parotid-gland",
+      "type": "arises_from"
+    },
+    {
+      "source": "adenoid-cystic-carcinoma",
+      "target": "parotid-gland",
+      "type": "arises_from"
+    },
+    {
+      "source": "parotidectomy",
+      "target": "pleomorphic-adenoma",
+      "type": "treats"
+    },
+    {
+      "source": "parotidectomy",
+      "target": "mucoepidermoid-carcinoma",
+      "type": "treats"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "parotid-gland",
+      "type": "passes_through"
+    },
+    {
+      "source": "adenoid-cystic-carcinoma",
+      "target": "facial-nerve",
+      "type": "landmark_for",
+      "label": "perineural invasion"
+    },
+    {
+      "source": "pleomorphic-adenoma",
+      "target": "warthin-tumor",
+      "type": "differentiates_from"
+    },
+    {
+      "source": "fna-salivary",
+      "target": "pleomorphic-adenoma",
+      "type": "differentiates_from",
+      "label": "cytology"
+    },
+    {
+      "source": "radical-neck-dissection",
+      "target": "neck-dissection",
+      "type": "part_of"
+    },
+    {
+      "source": "selective-neck-dissection",
+      "target": "neck-dissection",
+      "type": "part_of"
+    },
+    {
+      "source": "neck-dissection",
+      "target": "level-ii-neck",
+      "type": "landmark_for"
+    },
+    {
+      "source": "unknown-primary-scc",
+      "target": "level-ii-neck",
+      "type": "drains_to",
+      "label": "cystic node"
+    },
+    {
+      "source": "unknown-primary-scc",
+      "target": "transoral-robotic-surgery",
+      "type": "staged_with",
+      "label": "diagnostic tonsillectomy"
+    },
+    {
+      "source": "extranodal-extension",
+      "target": "concurrent-chemoradiation",
+      "type": "landmark_for",
+      "label": "adjuvant indication"
+    },
+    {
+      "source": "sentinel-lymph-node-biopsy",
+      "target": "cutaneous-melanoma",
+      "type": "staged_with"
+    },
+    {
+      "source": "cutaneous-melanoma",
+      "target": "breslow-thickness",
+      "type": "staged_with",
+      "label": "T category"
+    },
+    {
+      "source": "cutaneous-scc",
+      "target": "parotid-lymph-nodes",
+      "type": "drains_to"
+    },
+    {
+      "source": "cutaneous-melanoma",
+      "target": "parotid-lymph-nodes",
+      "type": "drains_to"
+    },
+    {
+      "source": "parotid-lymph-nodes",
+      "target": "parotid-gland",
+      "type": "contained_in"
+    },
+    {
+      "source": "mohs-surgery",
+      "target": "cutaneous-scc",
+      "type": "treats"
+    },
+    {
+      "source": "nasopharyngeal-carcinoma",
+      "target": "nasopharynx",
+      "type": "arises_from",
+      "label": "fossa of Rosenmuller"
+    },
+    {
+      "source": "nasopharyngeal-carcinoma",
+      "target": "ebv-nasopharyngeal",
+      "type": "arises_from",
+      "label": "EBV-driven"
+    },
+    {
+      "source": "nasopharyngeal-carcinoma",
+      "target": "level-v-neck",
+      "type": "drains_to"
+    },
+    {
+      "source": "concurrent-chemoradiation",
+      "target": "nasopharyngeal-carcinoma",
+      "type": "treats"
+    },
+    {
+      "source": "hypopharyngeal-scc",
+      "target": "pyriform-sinus",
+      "type": "arises_from"
+    },
+    {
+      "source": "pyriform-sinus",
+      "target": "cervical-esophagus",
+      "type": "continuous_with",
+      "direction": "inferior"
+    },
+    {
+      "source": "free-flap-reconstruction",
+      "target": "hypopharyngeal-scc",
+      "type": "treats",
+      "label": "reconstruction"
+    },
+    {
+      "source": "hypopharyngeal-scc",
+      "target": "level-iv-neck",
+      "type": "drains_to"
+    },
+    {
+      "source": "carotid-body-tumor",
+      "target": "paraganglioma",
+      "type": "part_of"
+    },
+    {
+      "source": "glomus-jugulare",
+      "target": "paraganglioma",
+      "type": "part_of"
+    },
+    {
+      "source": "glomus-jugulare",
+      "target": "jacobson-nerve",
+      "type": "arises_from",
+      "label": "tympanicum"
+    },
+    {
+      "source": "paraganglioma",
+      "target": "sdhx-mutation",
+      "type": "arises_from",
+      "label": "hereditary"
+    },
+    {
+      "source": "preoperative-embolization",
+      "target": "carotid-body-tumor",
+      "type": "treats",
+      "label": "reduce blood loss"
+    },
+    {
+      "source": "imrt",
+      "target": "laryngeal-scc",
+      "type": "treats"
+    },
+    {
+      "source": "imrt",
+      "target": "nasopharyngeal-carcinoma",
+      "type": "treats"
+    },
+    {
+      "source": "cisplatin",
+      "target": "concurrent-chemoradiation",
+      "type": "part_of"
+    },
+    {
+      "source": "cetuximab",
+      "target": "laryngeal-scc",
+      "type": "treats",
+      "label": "radiosensitizer"
+    },
+    {
+      "source": "pembrolizumab",
+      "target": "oropharyngeal-scc",
+      "type": "treats",
+      "label": "recurrent/metastatic"
+    },
+    {
+      "source": "pembrolizumab",
+      "target": "oral-cavity-scc",
+      "type": "treats",
+      "label": "recurrent/metastatic"
+    },
+    {
+      "source": "radiation-toxicity-head-neck",
+      "target": "imrt",
+      "type": "complication_of"
+    },
+    {
+      "source": "radiation-toxicity-head-neck",
+      "target": "mandible",
+      "type": "complication_of",
+      "label": "osteoradionecrosis"
+    },
+    {
+      "source": "cricoarytenoid-joint",
+      "target": "cricoid-cartilage",
+      "type": "articulates_with",
+      "direction": "superior"
+    },
+    {
+      "source": "cricoarytenoid-joint",
+      "target": "arytenoid-cartilage",
+      "type": "articulates_with"
+    },
+    {
+      "source": "cricothyroid-joint",
+      "target": "thyroid-cartilage",
+      "type": "articulates_with"
+    },
+    {
+      "source": "cricothyroid-joint",
+      "target": "cricoid-cartilage",
+      "type": "articulates_with"
+    },
+    {
+      "source": "vocal-ligament",
+      "target": "arytenoid-cartilage",
+      "type": "attaches_to",
+      "label": "vocal process",
+      "direction": "posterior"
+    },
+    {
+      "source": "vocal-ligament",
+      "target": "thyroid-cartilage",
+      "type": "attaches_to",
+      "label": "anterior commissure",
+      "direction": "anterior"
+    },
+    {
+      "source": "vocal-ligament",
+      "target": "vocal-fold-lamina-propria",
+      "type": "part_of",
+      "label": "intermediate + deep layers"
+    },
+    {
+      "source": "reinke-space",
+      "target": "vocal-fold-lamina-propria",
+      "type": "part_of",
+      "label": "superficial layer",
+      "direction": "superficial"
+    },
+    {
+      "source": "conus-elasticus",
+      "target": "vocal-ligament",
+      "type": "continuous_with",
+      "label": "free upper margin",
+      "direction": "superior"
+    },
+    {
+      "source": "conus-elasticus",
+      "target": "cricoid-cartilage",
+      "type": "attaches_to",
+      "direction": "inferior"
+    },
+    {
+      "source": "thyroarytenoid-muscle",
+      "target": "arytenoid-cartilage",
+      "type": "attaches_to",
+      "direction": "posterior"
+    },
+    {
+      "source": "thyroarytenoid-muscle",
+      "target": "thyroid-cartilage",
+      "type": "attaches_to",
+      "direction": "anterior"
+    },
+    {
+      "source": "posterior-cricoarytenoid-muscle",
+      "target": "cricoid-cartilage",
+      "type": "attaches_to",
+      "direction": "posterior"
+    },
+    {
+      "source": "posterior-cricoarytenoid-muscle",
+      "target": "arytenoid-cartilage",
+      "type": "attaches_to",
+      "label": "muscular process"
+    },
+    {
+      "source": "lateral-cricoarytenoid-muscle",
+      "target": "cricoid-cartilage",
+      "type": "attaches_to",
+      "direction": "lateral"
+    },
+    {
+      "source": "lateral-cricoarytenoid-muscle",
+      "target": "arytenoid-cartilage",
+      "type": "attaches_to",
+      "label": "muscular process"
+    },
+    {
+      "source": "interarytenoid-muscle",
+      "target": "arytenoid-cartilage",
+      "type": "attaches_to"
+    },
+    {
+      "source": "cricothyroid-muscle",
+      "target": "thyroid-cartilage",
+      "type": "attaches_to"
+    },
+    {
+      "source": "cricothyroid-muscle",
+      "target": "cricoid-cartilage",
+      "type": "attaches_to"
+    },
+    {
+      "source": "cricopharyngeus-muscle",
+      "target": "cricoid-cartilage",
+      "type": "attaches_to"
+    },
+    {
+      "source": "recurrent-laryngeal-nerve",
+      "target": "thyroarytenoid-muscle",
+      "type": "innervates"
+    },
+    {
+      "source": "recurrent-laryngeal-nerve",
+      "target": "posterior-cricoarytenoid-muscle",
+      "type": "innervates"
+    },
+    {
+      "source": "recurrent-laryngeal-nerve",
+      "target": "lateral-cricoarytenoid-muscle",
+      "type": "innervates"
+    },
+    {
+      "source": "recurrent-laryngeal-nerve",
+      "target": "interarytenoid-muscle",
+      "type": "innervates",
+      "label": "bilateral"
+    },
+    {
+      "source": "superior-laryngeal-nerve",
+      "target": "cricothyroid-muscle",
+      "type": "innervates",
+      "label": "external branch"
+    },
+    {
+      "source": "vocal-fold-nodules",
+      "target": "vocal-fold-lamina-propria",
+      "type": "arises_from"
+    },
+    {
+      "source": "vocal-fold-polyp",
+      "target": "reinke-space",
+      "type": "arises_from"
+    },
+    {
+      "source": "vocal-fold-cyst",
+      "target": "vocal-fold-lamina-propria",
+      "type": "arises_from"
+    },
+    {
+      "source": "reinke-edema",
+      "target": "reinke-space",
+      "type": "arises_from"
+    },
+    {
+      "source": "vocal-fold-nodules",
+      "target": "vocal-fold-polyp",
+      "type": "differentiates_from"
+    },
+    {
+      "source": "vocal-fold-cyst",
+      "target": "vocal-fold-polyp",
+      "type": "differentiates_from"
+    },
+    {
+      "source": "vocal-fold-microflap",
+      "target": "vocal-fold-polyp",
+      "type": "treats"
+    },
+    {
+      "source": "vocal-fold-microflap",
+      "target": "vocal-fold-cyst",
+      "type": "treats"
+    },
+    {
+      "source": "vocal-fold-microflap",
+      "target": "reinke-edema",
+      "type": "treats"
+    },
+    {
+      "source": "vocal-fold-paralysis",
+      "target": "recurrent-laryngeal-nerve",
+      "type": "complication_of",
+      "label": "RLN injury"
+    },
+    {
+      "source": "vocal-fold-paralysis",
+      "target": "total-thyroidectomy",
+      "type": "complication_of"
+    },
+    {
+      "source": "vocal-fold-paralysis",
+      "target": "cricoarytenoid-joint",
+      "type": "differentiates_from",
+      "label": "vs joint fixation"
+    },
+    {
+      "source": "medialization-thyroplasty",
+      "target": "vocal-fold-paralysis",
+      "type": "treats"
+    },
+    {
+      "source": "injection-laryngoplasty",
+      "target": "vocal-fold-paralysis",
+      "type": "treats"
+    },
+    {
+      "source": "laryngeal-reinnervation",
+      "target": "vocal-fold-paralysis",
+      "type": "treats"
+    },
+    {
+      "source": "medialization-thyroplasty",
+      "target": "thyroid-cartilage",
+      "type": "landmark_for",
+      "label": "cartilage window"
+    },
+    {
+      "source": "laryngeal-emg",
+      "target": "vocal-fold-paralysis",
+      "type": "landmark_for",
+      "label": "diagnosis/prognosis"
+    },
+    {
+      "source": "subglottic-stenosis",
+      "target": "cricoid-cartilage",
+      "type": "arises_from"
+    },
+    {
+      "source": "subglottic-stenosis",
+      "target": "cotton-myer-classification",
+      "type": "staged_with"
+    },
+    {
+      "source": "endoscopic-airway-dilation",
+      "target": "subglottic-stenosis",
+      "type": "treats"
+    },
+    {
+      "source": "cricotracheal-resection",
+      "target": "subglottic-stenosis",
+      "type": "treats"
+    },
+    {
+      "source": "laryngotracheal-reconstruction",
+      "target": "subglottic-stenosis",
+      "type": "treats"
+    },
+    {
+      "source": "zenker-diverticulum",
+      "target": "killian-dehiscence",
+      "type": "arises_from"
+    },
+    {
+      "source": "zenker-diverticulum",
+      "target": "cricopharyngeal-dysfunction",
+      "type": "complication_of"
+    },
+    {
+      "source": "cricopharyngeal-dysfunction",
+      "target": "cricopharyngeus-muscle",
+      "type": "arises_from"
+    },
+    {
+      "source": "cricopharyngeal-myotomy",
+      "target": "cricopharyngeus-muscle",
+      "type": "landmark_for",
+      "label": "muscle divided"
+    },
+    {
+      "source": "cricopharyngeal-myotomy",
+      "target": "zenker-diverticulum",
+      "type": "treats"
+    },
+    {
+      "source": "cricopharyngeal-myotomy",
+      "target": "cricopharyngeal-dysfunction",
+      "type": "treats"
+    },
+    {
+      "source": "endoscopic-diverticulotomy",
+      "target": "zenker-diverticulum",
+      "type": "treats"
+    },
+    {
+      "source": "laryngopharyngeal-reflux",
+      "target": "reflux-symptom-index",
+      "type": "staged_with"
+    },
+    {
+      "source": "laryngopharyngeal-reflux",
+      "target": "reflux-finding-score",
+      "type": "staged_with"
+    },
+    {
+      "source": "proton-pump-inhibitor",
+      "target": "laryngopharyngeal-reflux",
+      "type": "treats"
+    },
+    {
+      "source": "proton-pump-inhibitor",
+      "target": "chronic-cough",
+      "type": "treats"
+    },
+    {
+      "source": "laryngopharyngeal-reflux",
+      "target": "chronic-cough",
+      "type": "differentiates_from"
+    },
+    {
+      "source": "spasmodic-dysphonia",
+      "target": "muscle-tension-dysphonia",
+      "type": "differentiates_from"
+    },
+    {
+      "source": "spasmodic-dysphonia",
+      "target": "essential-vocal-tremor",
+      "type": "differentiates_from"
+    },
+    {
+      "source": "botulinum-toxin",
+      "target": "spasmodic-dysphonia",
+      "type": "treats"
+    },
+    {
+      "source": "botulinum-toxin",
+      "target": "thyroarytenoid-muscle",
+      "type": "landmark_for",
+      "label": "injection target"
+    },
+    {
+      "source": "botulinum-toxin",
+      "target": "cricopharyngeal-dysfunction",
+      "type": "treats"
+    },
+    {
+      "source": "laryngeal-emg",
+      "target": "spasmodic-dysphonia",
+      "type": "landmark_for",
+      "label": "injection guidance"
+    },
+    {
+      "source": "caustic-ingestion",
+      "target": "zargar-classification",
+      "type": "staged_with"
+    },
+    {
+      "source": "esophageal-stricture",
+      "target": "caustic-ingestion",
+      "type": "complication_of"
+    },
+    {
+      "source": "esophagoscopy",
+      "target": "caustic-ingestion",
+      "type": "landmark_for",
+      "label": "grades injury"
+    },
+    {
+      "source": "esophageal-dilation",
+      "target": "esophageal-stricture",
+      "type": "treats"
+    },
+    {
+      "source": "vestibular-schwannoma",
+      "target": "cerebellopontine-angle",
+      "type": "contained_in",
+      "direction": "medial"
+    },
+    {
+      "source": "cerebellopontine-angle",
+      "target": "internal-auditory-canal",
+      "type": "continuous_with",
+      "direction": "lateral"
+    },
+    {
+      "source": "koos-classification",
+      "target": "vestibular-schwannoma",
+      "type": "staged_with"
+    },
+    {
+      "source": "vestibular-schwannoma",
+      "target": "neurofibromatosis-type-2",
+      "type": "complication_of",
+      "label": "bilateral VS"
+    },
+    {
+      "source": "translabyrinthine-approach",
+      "target": "vestibular-schwannoma",
+      "type": "treats"
+    },
+    {
+      "source": "retrosigmoid-approach",
+      "target": "vestibular-schwannoma",
+      "type": "treats"
+    },
+    {
+      "source": "middle-cranial-fossa-approach",
+      "target": "vestibular-schwannoma",
+      "type": "treats"
+    },
+    {
+      "source": "stereotactic-radiosurgery",
+      "target": "vestibular-schwannoma",
+      "type": "treats"
+    },
+    {
+      "source": "translabyrinthine-approach",
+      "target": "facial-nerve",
+      "type": "landmark_for",
+      "label": "identify at fundus"
+    },
+    {
+      "source": "translabyrinthine-approach",
+      "target": "mastoid",
+      "type": "passes_through"
+    },
+    {
+      "source": "cholesteatoma",
+      "target": "retraction-pocket",
+      "type": "arises_from"
+    },
+    {
+      "source": "retraction-pocket",
+      "target": "eustachian-tube-dysfunction",
+      "type": "arises_from"
+    },
+    {
+      "source": "cholesteatoma",
+      "target": "chronic-otitis-media",
+      "type": "complication_of"
+    },
+    {
+      "source": "cholesteatoma",
+      "target": "epitympanum",
+      "type": "contained_in",
+      "label": "Prussak space / attic"
+    },
+    {
+      "source": "canal-wall-management",
+      "target": "mastoidectomy",
+      "type": "part_of"
+    },
+    {
+      "source": "chronic-otitis-media",
+      "target": "eustachian-tube-dysfunction",
+      "type": "complication_of"
+    },
+    {
+      "source": "eustachian-tube-dysfunction",
+      "target": "eustachian-tube",
+      "type": "arises_from"
+    },
+    {
+      "source": "congenital-cholesteatoma",
+      "target": "tympanic-membrane",
+      "type": "landmark_for",
+      "label": "behind intact TM, anterosuperior"
+    },
+    {
+      "source": "tympanoplasty",
+      "target": "tympanic-membrane-perforation",
+      "type": "treats"
+    },
+    {
+      "source": "acute-mastoiditis",
+      "target": "chronic-otitis-media",
+      "type": "complication_of"
+    },
+    {
+      "source": "acute-mastoiditis",
+      "target": "mastoid",
+      "type": "contained_in"
+    },
+    {
+      "source": "mastoidectomy",
+      "target": "acute-mastoiditis",
+      "type": "treats",
+      "label": "coalescent disease"
+    },
+    {
+      "source": "otogenic-facial-nerve-palsy",
+      "target": "chronic-otitis-media",
+      "type": "complication_of"
+    },
+    {
+      "source": "otogenic-facial-nerve-palsy",
+      "target": "facial-nerve",
+      "type": "arises_from",
+      "label": "dehiscent tympanic segment"
+    },
+    {
+      "source": "sigmoid-sinus-thrombosis",
+      "target": "acute-mastoiditis",
+      "type": "complication_of"
+    },
+    {
+      "source": "sigmoid-sinus-thrombosis",
+      "target": "sigmoid-sinus",
+      "type": "contained_in"
+    },
+    {
+      "source": "otogenic-intracranial-abscess",
+      "target": "acute-mastoiditis",
+      "type": "complication_of"
+    },
+    {
+      "source": "subperiosteal-abscess",
+      "target": "acute-mastoiditis",
+      "type": "complication_of"
+    },
+    {
+      "source": "petrous-apicitis",
+      "target": "chronic-otitis-media",
+      "type": "complication_of",
+      "label": "Gradenigo triad"
+    },
+    {
+      "source": "oral-corticosteroids-snhl",
+      "target": "sudden-sensorineural-hearing-loss",
+      "type": "treats",
+      "label": "initial therapy"
+    },
+    {
+      "source": "intratympanic-steroid-injection",
+      "target": "sudden-sensorineural-hearing-loss",
+      "type": "treats",
+      "label": "salvage"
+    },
+    {
+      "source": "intratympanic-steroid-injection",
+      "target": "round-window",
+      "type": "passes_through",
+      "label": "RW membrane diffusion"
+    },
+    {
+      "source": "sudden-sensorineural-hearing-loss",
+      "target": "cochlea",
+      "type": "arises_from",
+      "label": "cochlear/retrocochlear"
+    },
+    {
+      "source": "sudden-sensorineural-hearing-loss",
+      "target": "vestibular-schwannoma",
+      "type": "differentiates_from",
+      "label": "MRI to exclude"
+    },
+    {
+      "source": "sudden-sensorineural-hearing-loss",
+      "target": "sensorineural-hearing-loss",
+      "type": "part_of"
+    },
+    {
+      "source": "weber-rinne-tuning-fork",
+      "target": "conductive-hearing-loss",
+      "type": "differentiates_from",
+      "label": "SNHL vs CHL"
+    },
+    {
+      "source": "menieres-disease",
+      "target": "endolymphatic-hydrops",
+      "type": "arises_from"
+    },
+    {
+      "source": "endolymphatic-hydrops",
+      "target": "cochlea",
+      "type": "contained_in",
+      "label": "scala media distension"
+    },
+    {
+      "source": "menieres-disease",
+      "target": "electrocochleography",
+      "type": "differentiates_from",
+      "label": "SP/AP ratio supports hydrops"
+    },
+    {
+      "source": "intratympanic-gentamicin",
+      "target": "menieres-disease",
+      "type": "treats",
+      "label": "chemical labyrinthectomy"
+    },
+    {
+      "source": "intratympanic-gentamicin",
+      "target": "round-window",
+      "type": "passes_through"
+    },
+    {
+      "source": "endolymphatic-sac-decompression",
+      "target": "menieres-disease",
+      "type": "treats"
+    },
+    {
+      "source": "betahistine-diuretic-therapy",
+      "target": "menieres-disease",
+      "type": "treats",
+      "label": "first-line"
+    },
+    {
+      "source": "menieres-disease",
+      "target": "benign-paroxysmal-positional-vertigo",
+      "type": "differentiates_from",
+      "label": "episodic vertigo"
+    },
+    {
+      "source": "benign-paroxysmal-positional-vertigo",
+      "target": "semicircular-canals",
+      "type": "arises_from",
+      "label": "posterior canal otoconia"
+    },
+    {
+      "source": "benign-paroxysmal-positional-vertigo",
+      "target": "dix-hallpike-maneuver",
+      "type": "differentiates_from",
+      "label": "positive provocative test"
+    },
+    {
+      "source": "epley-maneuver",
+      "target": "benign-paroxysmal-positional-vertigo",
+      "type": "treats"
+    },
+    {
+      "source": "benign-paroxysmal-positional-vertigo",
+      "target": "temporal-bone-fracture",
+      "type": "complication_of",
+      "label": "post-traumatic BPPV"
+    },
+    {
+      "source": "videonystagmography",
+      "target": "lateral-semicircular-canal",
+      "type": "landmark_for",
+      "label": "caloric tests horizontal canal"
+    },
+    {
+      "source": "video-head-impulse-test",
+      "target": "lateral-semicircular-canal",
+      "type": "landmark_for",
+      "label": "high-frequency VOR gain"
+    },
+    {
+      "source": "otosclerosis",
+      "target": "fissula-ante-fenestram",
+      "type": "arises_from"
+    },
+    {
+      "source": "otosclerosis",
+      "target": "oval-window",
+      "type": "contained_in",
+      "label": "anterior margin",
+      "direction": "anterior"
+    },
+    {
+      "source": "carhart-notch",
+      "target": "otosclerosis",
+      "type": "landmark_for",
+      "label": "2 kHz BC dip"
+    },
+    {
+      "source": "conductive-hearing-loss",
+      "target": "otosclerosis",
+      "type": "complication_of"
+    },
+    {
+      "source": "stapedotomy",
+      "target": "otosclerosis",
+      "type": "treats"
+    },
+    {
+      "source": "stapedotomy",
+      "target": "oval-window",
+      "type": "passes_through",
+      "label": "piston through footplate"
+    },
+    {
+      "source": "fissula-ante-fenestram",
+      "target": "oval-window",
+      "type": "landmark_for",
+      "direction": "anterior"
+    },
+    {
+      "source": "cochlear-implant",
+      "target": "sensorineural-hearing-loss",
+      "type": "treats",
+      "label": "severe-profound"
+    },
+    {
+      "source": "cochlear-implant-candidacy",
+      "target": "cochlear-implant",
+      "type": "staged_with"
+    },
+    {
+      "source": "cochlear-implant-electrode-array",
+      "target": "cochlear-implant",
+      "type": "part_of"
+    },
+    {
+      "source": "cochlear-implant-electrode-array",
+      "target": "cochlea",
+      "type": "contained_in",
+      "label": "scala tympani"
+    },
+    {
+      "source": "cochlear-implant",
+      "target": "round-window",
+      "type": "passes_through",
+      "label": "electrode insertion"
+    },
+    {
+      "source": "cochlear-implant-mapping",
+      "target": "cochlear-implant",
+      "type": "part_of"
+    },
+    {
+      "source": "traumatic-facial-nerve-paralysis",
+      "target": "temporal-bone-fracture",
+      "type": "complication_of"
+    },
+    {
+      "source": "traumatic-facial-nerve-paralysis",
+      "target": "geniculate-ganglion",
+      "type": "arises_from",
+      "label": "perigeniculate injury"
+    },
+    {
+      "source": "csf-otorrhea",
+      "target": "temporal-bone-fracture",
+      "type": "complication_of"
+    },
+    {
+      "source": "csf-otorrhea",
+      "target": "tegmen-tympani",
+      "type": "passes_through",
+      "label": "tegmen breach",
+      "direction": "superior"
+    },
+    {
+      "source": "hemotympanum",
+      "target": "temporal-bone-fracture",
+      "type": "complication_of"
+    },
+    {
+      "source": "hemotympanum",
+      "target": "tympanic-membrane",
+      "type": "landmark_for",
+      "label": "blood behind drum",
+      "direction": "deep"
+    },
+    {
+      "source": "tympanic-membrane-graft",
+      "target": "tympanoplasty",
+      "type": "part_of"
+    },
+    {
+      "source": "tympanic-membrane-graft",
+      "target": "tympanic-membrane",
+      "type": "attaches_to"
+    },
+    {
+      "source": "ossicular-prosthesis",
+      "target": "ossiculoplasty",
+      "type": "part_of"
+    },
+    {
+      "source": "ossicular-prosthesis",
+      "target": "stapes",
+      "type": "articulates_with",
+      "label": "PORP on stapes head"
+    },
+    {
+      "source": "ossicular-prosthesis",
+      "target": "oval-window",
+      "type": "attaches_to",
+      "label": "TORP on footplate"
+    },
+    {
+      "source": "wullstein-classification",
+      "target": "tympanoplasty",
+      "type": "staged_with"
+    },
+    {
+      "source": "myringoplasty",
+      "target": "tympanic-membrane-perforation",
+      "type": "treats"
+    },
+    {
+      "source": "ossiculoplasty",
+      "target": "conductive-hearing-loss",
+      "type": "treats"
+    },
+    {
+      "source": "superior-canal-dehiscence",
+      "target": "semicircular-canals",
+      "type": "arises_from",
+      "label": "superior canal",
+      "direction": "superior"
+    },
+    {
+      "source": "superior-canal-dehiscence",
+      "target": "tegmen-tympani",
+      "type": "bounded_by",
+      "label": "middle fossa floor",
+      "direction": "superior"
+    },
+    {
+      "source": "superior-canal-dehiscence",
+      "target": "third-window-physiology",
+      "type": "arises_from"
+    },
+    {
+      "source": "superior-canal-dehiscence",
+      "target": "vestibular-evoked-myogenic-potential",
+      "type": "differentiates_from",
+      "label": "low cVEMP threshold"
+    },
+    {
+      "source": "superior-canal-plugging",
+      "target": "superior-canal-dehiscence",
+      "type": "treats"
+    },
+    {
+      "source": "superior-canal-dehiscence",
+      "target": "otosclerosis",
+      "type": "differentiates_from",
+      "label": "low-freq CHL with intact reflexes"
+    },
+    {
+      "source": "enlarged-vestibular-aqueduct",
+      "target": "vestibule",
+      "type": "part_of"
+    },
+    {
+      "source": "tympanostomy-tubes",
+      "target": "otitis-media-with-effusion",
+      "type": "treats"
+    },
+    {
+      "source": "tympanostomy-tubes",
+      "target": "tympanic-membrane",
+      "type": "passes_through"
+    },
+    {
+      "source": "otitis-media-with-effusion",
+      "target": "eustachian-tube",
+      "type": "arises_from",
+      "label": "ETD"
+    },
+    {
+      "source": "supraglottoplasty",
+      "target": "laryngomalacia",
+      "type": "treats"
+    },
+    {
+      "source": "laryngomalacia",
+      "target": "pediatric-stridor",
+      "type": "differentiates_from",
+      "label": "inspiratory"
+    },
+    {
+      "source": "pediatric-subglottic-stenosis",
+      "target": "cotton-myer-grading",
+      "type": "staged_with"
+    },
+    {
+      "source": "laryngotracheal-reconstruction",
+      "target": "pediatric-subglottic-stenosis",
+      "type": "treats"
+    },
+    {
+      "source": "rigid-bronchoscopy",
+      "target": "pediatric-subglottic-stenosis",
+      "type": "landmark_for",
+      "label": "airway eval"
+    },
+    {
+      "source": "vascular-ring",
+      "target": "tracheomalacia",
+      "type": "complication_of",
+      "label": "compression"
+    },
+    {
+      "source": "subglottic-hemangioma",
+      "target": "infantile-hemangioma",
+      "type": "part_of"
+    },
+    {
+      "source": "propranolol-hemangioma",
+      "target": "subglottic-hemangioma",
+      "type": "treats"
+    },
+    {
+      "source": "propranolol-hemangioma",
+      "target": "infantile-hemangioma",
+      "type": "treats",
+      "label": "first-line"
+    },
+    {
+      "source": "sistrunk-procedure",
+      "target": "thyroglossal-duct-cyst",
+      "type": "treats"
+    },
+    {
+      "source": "infantile-hemangioma",
+      "target": "issva-classification",
+      "type": "staged_with",
+      "label": "tumor"
+    },
+    {
+      "source": "lymphatic-malformation",
+      "target": "issva-classification",
+      "type": "staged_with",
+      "label": "malformation"
+    },
+    {
+      "source": "venous-malformation",
+      "target": "issva-classification",
+      "type": "staged_with",
+      "label": "low-flow malformation"
+    },
+    {
+      "source": "sirolimus",
+      "target": "lymphatic-malformation",
+      "type": "treats"
+    },
+    {
+      "source": "rigid-bronchoscopy",
+      "target": "airway-foreign-body",
+      "type": "treats"
+    },
+    {
+      "source": "airway-foreign-body",
+      "target": "pediatric-stridor",
+      "type": "differentiates_from"
+    },
+    {
+      "source": "esophageal-foreign-body",
+      "target": "button-battery-ingestion",
+      "type": "differentiates_from"
+    },
+    {
+      "source": "button-battery-ingestion",
+      "target": "pediatric-caustic-ingestion",
+      "type": "differentiates_from",
+      "label": "liquefactive injury"
+    },
+    {
+      "source": "choanal-atresia",
+      "target": "charge-syndrome",
+      "type": "part_of",
+      "label": "association"
+    },
+    {
+      "source": "pierre-robin-sequence",
+      "target": "cleft-palate",
+      "type": "part_of"
+    },
+    {
+      "source": "mandibular-distraction-osteogenesis",
+      "target": "pierre-robin-sequence",
+      "type": "treats",
+      "label": "tongue-base obstruction"
+    },
+    {
+      "source": "treacher-collins-syndrome",
+      "target": "microtia",
+      "type": "complication_of"
+    },
+    {
+      "source": "craniosynostosis",
+      "target": "pediatric-osa",
+      "type": "complication_of",
+      "label": "midface hypoplasia"
+    },
+    {
+      "source": "orbital-cellulitis",
+      "target": "pediatric-acute-sinusitis",
+      "type": "complication_of",
+      "label": "ethmoid spread"
+    },
+    {
+      "source": "periorbital-cellulitis",
+      "target": "orbital-cellulitis",
+      "type": "differentiates_from",
+      "label": "septum"
+    },
+    {
+      "source": "orbital-cellulitis",
+      "target": "chandler-classification",
+      "type": "staged_with"
+    },
+    {
+      "source": "subperiosteal-abscess",
+      "target": "chandler-classification",
+      "type": "staged_with",
+      "label": "stage III"
+    },
+    {
+      "source": "subperiosteal-abscess",
+      "target": "lamina-papyracea",
+      "type": "bounded_by",
+      "direction": "medial"
+    },
+    {
+      "source": "velopharyngeal-insufficiency",
+      "target": "cleft-palate",
+      "type": "complication_of"
+    },
+    {
+      "source": "pharyngeal-flap",
+      "target": "velopharyngeal-insufficiency",
+      "type": "treats"
+    },
+    {
+      "source": "cleft-palate",
+      "target": "otitis-media-with-effusion",
+      "type": "complication_of",
+      "label": "ETD"
+    },
+    {
+      "source": "salivary-botulinum-toxin",
+      "target": "pediatric-sialorrhea",
+      "type": "treats"
+    },
+    {
+      "source": "pediatric-dise",
+      "target": "pediatric-osa",
+      "type": "landmark_for",
+      "label": "localize obstruction"
+    },
+    {
+      "source": "uncinate-process",
+      "target": "ostiomeatal-complex",
+      "type": "part_of"
+    },
+    {
+      "source": "maxillary-sinus",
+      "target": "ostiomeatal-complex",
+      "type": "drains_to",
+      "label": "via middle meatus"
+    },
+    {
+      "source": "ethmoid-sinus",
+      "target": "ostiomeatal-complex",
+      "type": "drains_to"
+    },
+    {
+      "source": "middle-turbinate",
+      "target": "ostiomeatal-complex",
+      "type": "landmark_for",
+      "direction": "medial"
+    },
+    {
+      "source": "ostiomeatal-complex",
+      "target": "acute-bacterial-rhinosinusitis",
+      "type": "landmark_for",
+      "label": "obstruction causes sinusitis"
+    },
+    {
+      "source": "acute-bacterial-rhinosinusitis",
+      "target": "chronic-rhinosinusitis",
+      "type": "differentiates_from",
+      "label": "duration <4 vs >12 weeks"
+    },
+    {
+      "source": "amoxicillin-clavulanate",
+      "target": "acute-bacterial-rhinosinusitis",
+      "type": "treats",
+      "label": "first-line"
+    },
+    {
+      "source": "chronic-rhinosinusitis",
+      "target": "ostiomeatal-complex",
+      "type": "arises_from"
+    },
+    {
+      "source": "nasal-polyposis",
+      "target": "chronic-rhinosinusitis",
+      "type": "part_of",
+      "label": "CRSwNP phenotype"
+    },
+    {
+      "source": "nasal-polyposis",
+      "target": "ethmoid-sinus",
+      "type": "arises_from"
+    },
+    {
+      "source": "allergic-fungal-rhinosinusitis",
+      "target": "nasal-polyposis",
+      "type": "arises_from"
+    },
+    {
+      "source": "bent-kuhn-criteria",
+      "target": "allergic-fungal-rhinosinusitis",
+      "type": "staged_with",
+      "label": "diagnostic criteria"
+    },
+    {
+      "source": "lund-mackay-score",
+      "target": "chronic-rhinosinusitis",
+      "type": "staged_with",
+      "label": "CT severity"
+    },
+    {
+      "source": "functional-endoscopic-sinus-surgery",
+      "target": "chronic-rhinosinusitis",
+      "type": "treats"
+    },
+    {
+      "source": "functional-endoscopic-sinus-surgery",
+      "target": "nasal-polyposis",
+      "type": "treats"
+    },
+    {
+      "source": "functional-endoscopic-sinus-surgery",
+      "target": "allergic-fungal-rhinosinusitis",
+      "type": "treats",
+      "label": "debridement"
+    },
+    {
+      "source": "functional-endoscopic-sinus-surgery",
+      "target": "uncinate-process",
+      "type": "part_of",
+      "label": "uncinectomy step"
+    },
+    {
+      "source": "intranasal-corticosteroids",
+      "target": "chronic-rhinosinusitis",
+      "type": "treats"
+    },
+    {
+      "source": "intranasal-corticosteroids",
+      "target": "allergic-rhinitis",
+      "type": "treats",
+      "label": "first-line"
+    },
+    {
+      "source": "dupilumab",
+      "target": "nasal-polyposis",
+      "type": "treats",
+      "label": "anti-IL-4Rα"
+    },
+    {
+      "source": "omalizumab",
+      "target": "nasal-polyposis",
+      "type": "treats",
+      "label": "anti-IgE"
+    },
+    {
+      "source": "mepolizumab",
+      "target": "nasal-polyposis",
+      "type": "treats",
+      "label": "anti-IL-5"
+    },
+    {
+      "source": "lamina-papyracea",
+      "target": "ethmoid-sinus",
+      "type": "bounded_by",
+      "direction": "lateral"
+    },
+    {
+      "source": "orbital-cellulitis",
+      "target": "ethmoid-sinus",
+      "type": "complication_of",
+      "label": "via lamina papyracea"
+    },
+    {
+      "source": "orbital-cellulitis",
+      "target": "lamina-papyracea",
+      "type": "passes_through"
+    },
+    {
+      "source": "subperiosteal-abscess",
+      "target": "orbital-cellulitis",
+      "type": "complication_of"
+    },
+    {
+      "source": "chandler-classification",
+      "target": "orbital-cellulitis",
+      "type": "staged_with"
+    },
+    {
+      "source": "chandler-classification",
+      "target": "subperiosteal-abscess",
+      "type": "staged_with"
+    },
+    {
+      "source": "pott-puffy-tumor",
+      "target": "frontal-sinus",
+      "type": "complication_of"
+    },
+    {
+      "source": "cavernous-sinus-thrombosis",
+      "target": "sphenoid-sinus",
+      "type": "complication_of"
+    },
+    {
+      "source": "functional-endoscopic-sinus-surgery",
+      "target": "subperiosteal-abscess",
+      "type": "treats",
+      "label": "endoscopic drainage"
+    },
+    {
+      "source": "sphenopalatine-artery",
+      "target": "sphenopalatine-foramen",
+      "type": "passes_through"
+    },
+    {
+      "source": "sphenopalatine-artery",
+      "target": "kiesselbach-plexus",
+      "type": "supplies"
+    },
+    {
+      "source": "anterior-ethmoidal-artery",
+      "target": "kiesselbach-plexus",
+      "type": "supplies"
+    },
+    {
+      "source": "anterior-ethmoidal-artery",
+      "target": "fovea-ethmoidalis",
+      "type": "passes_through"
+    },
+    {
+      "source": "epistaxis",
+      "target": "kiesselbach-plexus",
+      "type": "arises_from",
+      "label": "anterior bleeds"
+    },
+    {
+      "source": "epistaxis",
+      "target": "woodruff-plexus",
+      "type": "arises_from",
+      "label": "posterior bleeds"
+    },
+    {
+      "source": "epistaxis",
+      "target": "sphenopalatine-artery",
+      "type": "arises_from",
+      "label": "posterior bleeds"
+    },
+    {
+      "source": "hereditary-hemorrhagic-telangiectasia",
+      "target": "epistaxis",
+      "type": "complication_of"
+    },
+    {
+      "source": "nasal-packing",
+      "target": "epistaxis",
+      "type": "treats"
+    },
+    {
+      "source": "sphenopalatine-artery-ligation",
+      "target": "epistaxis",
+      "type": "treats",
+      "label": "posterior"
+    },
+    {
+      "source": "sphenopalatine-artery-ligation",
+      "target": "sphenopalatine-artery",
+      "type": "part_of"
+    },
+    {
+      "source": "allergen-immunotherapy",
+      "target": "allergic-rhinitis",
+      "type": "treats",
+      "label": "disease-modifying"
+    },
+    {
+      "source": "allergic-rhinitis",
+      "target": "inferior-turbinate",
+      "type": "arises_from",
+      "label": "turbinate hypertrophy"
+    },
+    {
+      "source": "nasolacrimal-duct",
+      "target": "inferior-turbinate",
+      "type": "drains_to",
+      "label": "inferior meatus"
+    },
+    {
+      "source": "dacryocystorhinostomy",
+      "target": "nasolacrimal-duct",
+      "type": "treats",
+      "label": "obstruction"
+    },
+    {
+      "source": "inverted-papilloma",
+      "target": "maxillary-sinus",
+      "type": "arises_from"
+    },
+    {
+      "source": "juvenile-nasopharyngeal-angiofibroma",
+      "target": "sphenopalatine-foramen",
+      "type": "arises_from"
+    },
+    {
+      "source": "esthesioneuroblastoma",
+      "target": "cribriform-plate",
+      "type": "arises_from",
+      "label": "olfactory epithelium"
+    },
+    {
+      "source": "kadish-staging",
+      "target": "esthesioneuroblastoma",
+      "type": "staged_with"
+    },
+    {
+      "source": "dulguerov-staging",
+      "target": "esthesioneuroblastoma",
+      "type": "staged_with"
+    },
+    {
+      "source": "kadish-staging",
+      "target": "dulguerov-staging",
+      "type": "differentiates_from"
+    },
+    {
+      "source": "sinonasal-scc",
+      "target": "inverted-papilloma",
+      "type": "arises_from",
+      "label": "~10% malignant transformation"
+    },
+    {
+      "source": "cribriform-plate",
+      "target": "anterior-skull-base",
+      "type": "part_of"
+    },
+    {
+      "source": "fovea-ethmoidalis",
+      "target": "anterior-skull-base",
+      "type": "part_of"
+    },
+    {
+      "source": "csf-rhinorrhea",
+      "target": "cribriform-plate",
+      "type": "arises_from",
+      "label": "lateral lamella"
+    },
+    {
+      "source": "beta-2-transferrin",
+      "target": "csf-rhinorrhea",
+      "type": "staged_with",
+      "label": "confirmatory test"
+    },
+    {
+      "source": "encephalocele",
+      "target": "csf-rhinorrhea",
+      "type": "complication_of"
+    },
+    {
+      "source": "endoscopic-skull-base-repair",
+      "target": "csf-rhinorrhea",
+      "type": "treats"
+    },
+    {
+      "source": "endoscopic-skull-base-repair",
+      "target": "encephalocele",
+      "type": "treats"
+    },
+    {
+      "source": "nasoseptal-flap",
+      "target": "endoscopic-skull-base-repair",
+      "type": "part_of"
+    },
+    {
+      "source": "nasoseptal-flap",
+      "target": "sphenopalatine-artery",
+      "type": "branches_from",
+      "label": "posterior septal branch"
+    },
+    {
+      "source": "nasoseptal-flap",
+      "target": "nasal-septum",
+      "type": "arises_from"
+    },
+    {
+      "source": "sella-turcica",
+      "target": "sphenoid-sinus",
+      "type": "bounded_by",
+      "direction": "superior"
+    },
+    {
+      "source": "pituitary-adenoma",
+      "target": "sella-turcica",
+      "type": "arises_from"
+    },
+    {
+      "source": "endoscopic-transsphenoidal-approach",
+      "target": "pituitary-adenoma",
+      "type": "treats"
+    },
+    {
+      "source": "endoscopic-transsphenoidal-approach",
+      "target": "sphenoid-sinus",
+      "type": "passes_through"
+    },
+    {
+      "source": "endoscopic-transsphenoidal-approach",
+      "target": "nasoseptal-flap",
+      "type": "part_of",
+      "label": "reconstruction"
+    },
+    {
+      "source": "obstructive-sleep-apnea",
+      "target": "velopharynx",
+      "type": "arises_from",
+      "label": "retropalatal collapse"
+    },
+    {
+      "source": "obstructive-sleep-apnea",
+      "target": "base-of-tongue",
+      "type": "arises_from",
+      "label": "retroglossal collapse"
+    },
+    {
+      "source": "obstructive-sleep-apnea",
+      "target": "epiglottis",
+      "type": "arises_from",
+      "label": "epiglottic collapse"
+    },
+    {
+      "source": "velopharynx",
+      "target": "soft-palate",
+      "type": "bounded_by",
+      "label": "anterior wall",
+      "direction": "anterior"
+    },
+    {
+      "source": "base-of-tongue",
+      "target": "genioglossus-muscle",
+      "type": "part_of"
+    },
+    {
+      "source": "obstructive-sleep-apnea",
+      "target": "upper-airway-critical-closing-pressure",
+      "type": "staged_with",
+      "label": "collapsibility"
+    },
+    {
+      "source": "obstructive-sleep-apnea",
+      "target": "apnea-hypopnea-index",
+      "type": "staged_with",
+      "label": "severity"
+    },
+    {
+      "source": "obstructive-sleep-apnea",
+      "target": "respiratory-disturbance-index",
+      "type": "staged_with"
+    },
+    {
+      "source": "polysomnography",
+      "target": "apnea-hypopnea-index",
+      "type": "landmark_for",
+      "label": "measures"
+    },
+    {
+      "source": "home-sleep-apnea-test",
+      "target": "obstructive-sleep-apnea",
+      "type": "landmark_for",
+      "label": "screens"
+    },
+    {
+      "source": "stop-bang-questionnaire",
+      "target": "obstructive-sleep-apnea",
+      "type": "landmark_for",
+      "label": "screens"
+    },
+    {
+      "source": "friedman-tongue-position",
+      "target": "obstructive-sleep-apnea",
+      "type": "landmark_for",
+      "label": "exam"
+    },
+    {
+      "source": "drug-induced-sleep-endoscopy",
+      "target": "vote-classification",
+      "type": "staged_with"
+    },
+    {
+      "source": "drug-induced-sleep-endoscopy",
+      "target": "obstructive-sleep-apnea",
+      "type": "landmark_for",
+      "label": "localizes collapse"
+    },
+    {
+      "source": "vote-classification",
+      "target": "velopharynx",
+      "type": "landmark_for",
+      "label": "velum"
+    },
+    {
+      "source": "vote-classification",
+      "target": "base-of-tongue",
+      "type": "landmark_for",
+      "label": "tongue base"
+    },
+    {
+      "source": "vote-classification",
+      "target": "epiglottis",
+      "type": "landmark_for",
+      "label": "epiglottis"
+    },
+    {
+      "source": "cpap-therapy",
+      "target": "obstructive-sleep-apnea",
+      "type": "treats",
+      "label": "first-line"
+    },
+    {
+      "source": "mandibular-advancement-device",
+      "target": "obstructive-sleep-apnea",
+      "type": "treats"
+    },
+    {
+      "source": "positional-therapy",
+      "target": "obstructive-sleep-apnea",
+      "type": "treats",
+      "label": "supine-predominant"
+    },
+    {
+      "source": "weight-loss-bariatric-therapy",
+      "target": "obstructive-sleep-apnea",
+      "type": "treats"
+    },
+    {
+      "source": "uvulopalatopharyngoplasty",
+      "target": "obstructive-sleep-apnea",
+      "type": "treats",
+      "label": "retropalatal"
+    },
+    {
+      "source": "uvulopalatopharyngoplasty",
+      "target": "soft-palate",
+      "type": "attaches_to"
+    },
+    {
+      "source": "expansion-sphincter-pharyngoplasty",
+      "target": "obstructive-sleep-apnea",
+      "type": "treats",
+      "label": "lateral wall"
+    },
+    {
+      "source": "hypoglossal-nerve-stimulation",
+      "target": "obstructive-sleep-apnea",
+      "type": "treats",
+      "label": "CPAP-intolerant"
+    },
+    {
+      "source": "complete-concentric-collapse-palate",
+      "target": "hypoglossal-nerve-stimulation",
+      "type": "complication_of",
+      "label": "exclusion criterion"
+    },
+    {
+      "source": "complete-concentric-collapse-palate",
+      "target": "velopharynx",
+      "type": "arises_from"
+    },
+    {
+      "source": "maxillomandibular-advancement",
+      "target": "obstructive-sleep-apnea",
+      "type": "treats",
+      "label": "skeletal advancement"
+    },
+    {
+      "source": "genioglossus-advancement",
+      "target": "base-of-tongue",
+      "type": "treats"
+    },
+    {
+      "source": "friedman-staging-system",
+      "target": "uvulopalatopharyngoplasty",
+      "type": "landmark_for",
+      "label": "predicts success"
+    },
+    {
+      "source": "sleep-tracheostomy",
+      "target": "obstructive-sleep-apnea",
+      "type": "treats",
+      "label": "definitive"
+    },
+    {
+      "source": "pediatric-osa",
+      "target": "adenotonsillar-hypertrophy",
+      "type": "arises_from",
+      "label": "leading cause"
+    },
+    {
+      "source": "pediatric-osa",
+      "target": "sleep-disordered-breathing",
+      "type": "part_of"
+    },
+    {
+      "source": "adenotonsillectomy",
+      "target": "pediatric-osa",
+      "type": "treats",
+      "label": "first-line"
+    },
+    {
+      "source": "adenotonsillectomy",
+      "target": "adenotonsillar-hypertrophy",
+      "type": "treats"
+    },
+    {
+      "source": "brodsky-tonsil-grading",
+      "target": "adenotonsillar-hypertrophy",
+      "type": "staged_with"
+    },
+    {
+      "source": "pediatric-polysomnography-criteria",
+      "target": "pediatric-osa",
+      "type": "staged_with"
     }
   ]
 }

--- a/data/kag-graph.json
+++ b/data/kag-graph.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "updated": "2026-07-02T19:25:43.159Z",
+  "updated": "2026-07-02T19:40:51.998Z",
   "status": "SEED — vetted temporal-bone otology core. Authored expansion nodes (later phases) carry review:false until owner review.",
   "sources": [
     "Cummings Otolaryngology 7e"
@@ -20,14 +20,27 @@
         "box": 1,
         "nextReview": "2026-07-02"
       },
-      "aliases": [],
+      "aliases": [
+        "ear canal",
+        "EAC",
+        "external acoustic meatus"
+      ],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "space",
+      "region": "external-ear",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "pediatrics",
+            "concept": "EAC"
+          },
+          {
+            "module": "pediatrics",
+            "concept": "external-ear"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -46,14 +59,26 @@
         "box": 1,
         "nextReview": "2026-07-02"
       },
-      "aliases": [],
+      "aliases": [
+        "eardrum",
+        "TM"
+      ],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "membrane",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "ta-tubes",
+            "concept": "tm-anatomy"
+          },
+          {
+            "module": "pediatrics",
+            "concept": "middle-ear"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -74,12 +99,17 @@
       },
       "aliases": [],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "pediatrics",
+            "concept": "ossicles"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -100,12 +130,17 @@
       },
       "aliases": [],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "pediatrics",
+            "concept": "ossicles"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -126,12 +161,17 @@
       },
       "aliases": [],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "pediatrics",
+            "concept": "ossicles"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -152,9 +192,9 @@
       },
       "aliases": [],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "foramen",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
         "concepts": [],
@@ -178,12 +218,17 @@
       },
       "aliases": [],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "foramen",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "pediatrics",
+            "concept": "CI"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -202,14 +247,25 @@
         "box": 1,
         "nextReview": "2026-07-02"
       },
-      "aliases": [],
+      "aliases": [
+        "bony cochlea"
+      ],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "pediatrics",
+            "concept": "inner-ear"
+          },
+          {
+            "module": "pediatrics",
+            "concept": "tonotopy"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -230,12 +286,17 @@
       },
       "aliases": [],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "pediatrics",
+            "concept": "vestibular"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -256,12 +317,17 @@
       },
       "aliases": [],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "pediatrics",
+            "concept": "vestibular"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -280,15 +346,28 @@
         "box": 1,
         "nextReview": "2026-07-02"
       },
-      "aliases": [],
+      "aliases": [
+        "CN VII"
+      ],
       "abbrev": null,
       "structure": null,
-      "region": null,
-      "laterality": null,
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
-        "topics": []
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "nerve-segments"
+          },
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "facial-nerve"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
       },
       "review": true
     },
@@ -309,11 +388,16 @@
       "aliases": [],
       "abbrev": null,
       "structure": null,
-      "region": null,
-      "laterality": null,
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "mastoid-branches"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -332,14 +416,21 @@
         "box": 1,
         "nextReview": "2026-07-02"
       },
-      "aliases": [],
+      "aliases": [
+        "GSPN"
+      ],
       "abbrev": null,
       "structure": null,
-      "region": null,
-      "laterality": null,
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "geniculate-branches"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -358,14 +449,21 @@
         "box": 1,
         "nextReview": "2026-07-02"
       },
-      "aliases": [],
+      "aliases": [
+        "CN VIII"
+      ],
       "abbrev": null,
       "structure": null,
-      "region": null,
-      "laterality": null,
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "tumor-origin"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -384,14 +482,26 @@
         "box": 1,
         "nextReview": "2026-07-02"
       },
-      "aliases": [],
+      "aliases": [
+        "IAC",
+        "internal acoustic meatus"
+      ],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "foramen",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "IAC"
+          },
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "nerve-quadrants"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -412,9 +522,9 @@
       },
       "aliases": [],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
         "concepts": [],
@@ -436,11 +546,13 @@
         "box": 1,
         "nextReview": "2026-07-02"
       },
-      "aliases": [],
+      "aliases": [
+        "mastoid process"
+      ],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
         "concepts": [],
@@ -462,11 +574,13 @@
         "box": 1,
         "nextReview": "2026-07-02"
       },
-      "aliases": [],
+      "aliases": [
+        "attic"
+      ],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "space",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
         "concepts": [],
@@ -490,9 +604,9 @@
       },
       "aliases": [],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "space",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
         "concepts": [],
@@ -516,9 +630,9 @@
       },
       "aliases": [],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "space",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
         "concepts": [],
@@ -542,9 +656,9 @@
       },
       "aliases": [],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
         "concepts": [],
@@ -568,9 +682,9 @@
       },
       "aliases": [],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "muscle",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
         "concepts": [],
@@ -594,9 +708,9 @@
       },
       "aliases": [],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "muscle",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
         "concepts": [],
@@ -618,14 +732,22 @@
         "box": 1,
         "nextReview": "2026-07-02"
       },
-      "aliases": [],
+      "aliases": [
+        "auditory tube",
+        "pharyngotympanic tube"
+      ],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "space",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "ta-tubes",
+            "concept": "eustachian-tube"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -647,8 +769,8 @@
       "aliases": [],
       "abbrev": null,
       "structure": null,
-      "region": null,
-      "laterality": null,
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
         "concepts": [],
@@ -673,8 +795,8 @@
       "aliases": [],
       "abbrev": null,
       "structure": null,
-      "region": null,
-      "laterality": null,
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
         "concepts": [],
@@ -699,11 +821,16 @@
       "aliases": [],
       "abbrev": null,
       "structure": null,
-      "region": null,
+      "region": "temporal-bone",
       "laterality": null,
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "pediatrics",
+            "concept": "cholesteatoma"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -725,7 +852,7 @@
       "aliases": [],
       "abbrev": null,
       "structure": null,
-      "region": null,
+      "region": "temporal-bone",
       "laterality": null,
       "oksat": {
         "modules": [],
@@ -751,7 +878,7 @@
       "aliases": [],
       "abbrev": null,
       "structure": null,
-      "region": null,
+      "region": "temporal-bone",
       "laterality": null,
       "oksat": {
         "modules": [],
@@ -764,7 +891,7 @@
       "id": "vestibular-schwannoma",
       "label": "Vestibular Schwannoma",
       "type": "pathology",
-      "subspecialty": "skull-base",
+      "subspecialty": "otology",
       "detail": "Benign tumor of Schwann cells on CN VIII (usually superior vestibular division). Most common CPA tumor. Bilateral = NF2. Presents with asymmetric SNHL.",
       "sources": [
         "Cummings 7e"
@@ -774,15 +901,27 @@
         "box": 1,
         "nextReview": "2026-07-02"
       },
-      "aliases": [],
+      "aliases": [
+        "acoustic neuroma",
+        "VS"
+      ],
       "abbrev": null,
       "structure": null,
-      "region": null,
+      "region": "skull-base",
       "laterality": null,
       "oksat": {
-        "modules": [],
-        "concepts": [],
-        "topics": []
+        "modules": [
+          "vestibular-schwannoma"
+        ],
+        "concepts": [
+          {
+            "module": "vestibular-schwannoma",
+            "concept": "tumor-origin"
+          }
+        ],
+        "topics": [
+          "vestibular-schwannoma"
+        ]
       },
       "review": true
     },
@@ -803,7 +942,7 @@
       "aliases": [],
       "abbrev": null,
       "structure": null,
-      "region": null,
+      "region": "temporal-bone",
       "laterality": null,
       "oksat": {
         "modules": [],
@@ -829,7 +968,7 @@
       "aliases": [],
       "abbrev": null,
       "structure": null,
-      "region": null,
+      "region": "temporal-bone",
       "laterality": null,
       "oksat": {
         "modules": [],
@@ -855,7 +994,7 @@
       "aliases": [],
       "abbrev": null,
       "structure": null,
-      "region": null,
+      "region": "temporal-bone",
       "laterality": null,
       "oksat": {
         "modules": [],
@@ -878,14 +1017,25 @@
         "box": 1,
         "nextReview": "2026-07-02"
       },
-      "aliases": [],
+      "aliases": [
+        "CI"
+      ],
       "abbrev": null,
       "structure": null,
-      "region": null,
+      "region": "temporal-bone",
       "laterality": null,
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "pediatrics",
+            "concept": "CI"
+          },
+          {
+            "module": "ta-tubes",
+            "concept": "cochlear-implant"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -907,7 +1057,7 @@
       "aliases": [],
       "abbrev": null,
       "structure": null,
-      "region": null,
+      "region": "temporal-bone",
       "laterality": null,
       "oksat": {
         "modules": [],
@@ -932,12 +1082,17 @@
       },
       "aliases": [],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "pediatrics",
+            "concept": "vestibular"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -959,11 +1114,16 @@
       "aliases": [],
       "abbrev": null,
       "structure": null,
-      "region": null,
-      "laterality": null,
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "geniculate-branches"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -985,11 +1145,20 @@
       "aliases": [],
       "abbrev": null,
       "structure": null,
-      "region": null,
-      "laterality": null,
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "pediatrics",
+            "concept": "physiology"
+          },
+          {
+            "module": "pediatrics",
+            "concept": "inner-ear"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -1011,11 +1180,16 @@
       "aliases": [],
       "abbrev": null,
       "structure": null,
-      "region": null,
-      "laterality": null,
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "ta-tubes",
+            "concept": "cranial-nerves"
+          }
+        ],
         "topics": []
       },
       "review": true
@@ -1036,12 +1210,17 @@
       },
       "aliases": [],
       "abbrev": null,
-      "structure": null,
-      "region": null,
-      "laterality": null,
+      "structure": "foramen",
+      "region": "temporal-bone",
+      "laterality": "paired",
       "oksat": {
         "modules": [],
-        "concepts": [],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "extratemporal"
+          }
+        ],
         "topics": []
       },
       "review": true

--- a/data/kag-graph.json
+++ b/data/kag-graph.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "updated": "2026-07-02T20:28:23.725Z",
+  "updated": "2026-07-02T20:50:34.275Z",
   "status": "DRAFT expansion — 40-node temporal-bone seed is vetted (review:true); all other nodes are subagent-authored scaffolding (review:false) pending owner stress-test against curated source text.",
   "sources": [
     "Cummings Otolaryngology 7e",
@@ -19661,6 +19661,3493 @@
         "topics": []
       },
       "review": false
+    },
+    {
+      "id": "oculomotor-nerve",
+      "label": "Oculomotor Nerve (CN III)",
+      "type": "nerve",
+      "subspecialty": "rhinology",
+      "detail": "Motor to all extraocular muscles except superior oblique and lateral rectus, plus levator palpebrae and parasympathetic pupillary constriction. Traverses the cavernous sinus and superior orbital fissure; palsy gives ptosis and a 'down-and-out' eye.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CN III",
+        "third cranial nerve"
+      ],
+      "abbrev": "CN III",
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "orbital-intracranial-sinus-complications"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "trochlear-nerve",
+      "label": "Trochlear Nerve (CN IV)",
+      "type": "nerve",
+      "subspecialty": "rhinology",
+      "detail": "Thinnest cranial nerve; only one exiting dorsally and the sole crossed nerve. Motor to superior oblique. Runs in the lateral cavernous sinus wall to the superior orbital fissure; palsy causes vertical diplopia and head tilt.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CN IV",
+        "fourth cranial nerve"
+      ],
+      "abbrev": "CN IV",
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "orbital-intracranial-sinus-complications"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "ophthalmic-nerve",
+      "label": "Ophthalmic Nerve (V1)",
+      "type": "nerve",
+      "subspecialty": "rhinology",
+      "detail": "Purely sensory first division of CN V. Enters the orbit via the superior orbital fissure; gives frontal, lacrimal and nasociliary branches. Anterior ethmoidal branch of nasociliary is the afferent limb of the sneeze reflex and supplies the anterior skull base.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Netter Atlas of Human Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "V1",
+        "first trigeminal division"
+      ],
+      "abbrev": "V1",
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "orbital-intracranial-sinus-complications"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "inferior-alveolar-nerve",
+      "label": "Inferior Alveolar Nerve",
+      "type": "nerve",
+      "subspecialty": "fprs",
+      "detail": "V3 branch entering the mandibular foramen to supply lower teeth, exiting the mental foramen as the mental nerve. At risk in mandibular fractures, third-molar surgery, sagittal split osteotomy and marginal mandibulectomy; injury causes lower-lip and chin numbness.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "IAN"
+      ],
+      "abbrev": "IAN",
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "lingual-nerve",
+      "label": "Lingual Nerve",
+      "type": "nerve",
+      "subspecialty": "hn_onc",
+      "detail": "V3 branch carrying general sensation to the anterior two-thirds of tongue plus taste and parasympathetic fibres from chorda tympani. In the floor of mouth it loops under and crosses the submandibular duct (twice); protect it during submandibular gland excision and floor-of-mouth resection.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "salivary-gland-neoplasms"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "auriculotemporal-nerve",
+      "label": "Auriculotemporal Nerve",
+      "type": "nerve",
+      "subspecialty": "hn_onc",
+      "detail": "V3 branch that encircles the middle meningeal artery, supplies the TMJ, external auditory canal and scalp, and conveys otic-ganglion parasympathetic secretomotor fibres to the parotid. Aberrant reinnervation after parotidectomy causes Frey syndrome (gustatory sweating).",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ATN"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "salivary-gland-neoplasms"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "infraorbital-nerve",
+      "label": "Infraorbital Nerve",
+      "type": "nerve",
+      "subspecialty": "fprs",
+      "detail": "Terminal V2 branch running in the orbital floor and exiting the infraorbital foramen to supply the cheek, lower eyelid, lateral nose and upper lip. Commonly injured/entrapped in orbital-floor (blowout) and zygomaticomaxillary-complex fractures.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ION"
+      ],
+      "abbrev": "ION",
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "greater-palatine-nerve",
+      "label": "Greater Palatine Nerve",
+      "type": "nerve",
+      "subspecialty": "rhinology",
+      "detail": "V2 branch descending through the greater palatine canal to supply the hard palate and postganglionic parasympathetic fibres from the pterygopalatine ganglion. The greater palatine foramen (near the second molar) is the landmark for a maxillary nerve block.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "anterior palatine nerve"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "lesser-palatine-nerve",
+      "label": "Lesser Palatine Nerve",
+      "type": "nerve",
+      "subspecialty": "rhinology",
+      "detail": "V2 branch supplying the soft palate and tonsillar region via the lesser palatine foramen; carries taste from the soft palate back to the geniculate ganglion via the greater petrosal nerve.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "abducens-nerve",
+      "label": "Abducens Nerve (CN VI)",
+      "type": "nerve",
+      "subspecialty": "rhinology",
+      "detail": "Motor to lateral rectus. Longest intracranial course makes it vulnerable to raised ICP; uniquely runs THROUGH the cavernous sinus adjacent to the ICA (not in the wall), so it is the first nerve affected in cavernous sinus/petrous apex (Gradenigo) pathology. Palsy gives horizontal diplopia.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CN VI",
+        "sixth cranial nerve"
+      ],
+      "abbrev": "CN VI",
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "orbital-intracranial-sinus-complications"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "temporal-branch-facial-nerve",
+      "label": "Temporal (Frontal) Branch of Facial Nerve",
+      "type": "nerve",
+      "subspecialty": "fprs",
+      "detail": "Terminal facial branch to frontalis, corrugator and orbicularis oculi (upper). Runs within the temporoparietal fascia along the Pitanguy line; considered a 'terminal' branch with little cross-innervation, so injury causes permanent brow ptosis. Deep to SMAS over the zygomatic arch.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Facial Plastic and Reconstructive Surgery (Papel)"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "frontal branch"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "extratemporal"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "zygomatic-branch-facial-nerve",
+      "label": "Zygomatic Branch of Facial Nerve",
+      "type": "nerve",
+      "subspecialty": "fprs",
+      "detail": "Terminal facial branch to orbicularis oculi and midface; rich arborization with the buccal branch means isolated injury is often compensated. Key motor supply for eye closure alongside temporal branch.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Facial Plastic and Reconstructive Surgery (Papel)"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "extratemporal"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "buccal-branch-facial-nerve",
+      "label": "Buccal Branch of Facial Nerve",
+      "type": "nerve",
+      "subspecialty": "fprs",
+      "detail": "Terminal facial branch to buccinator, orbicularis oris and midface elevators; runs near the parotid duct (parallel/just above it) - the duct is a surgical landmark to find it during parotidectomy. Extensive cross-innervation with zygomatic branch.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Facial Plastic and Reconstructive Surgery (Papel)"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "extratemporal"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "marginal-mandibular-nerve",
+      "label": "Marginal Mandibular Branch of Facial Nerve",
+      "type": "nerve",
+      "subspecialty": "fprs",
+      "detail": "Terminal facial branch to the depressors of the lower lip. In up to 20% it dips below the mandibular border; it runs deep to platysma and superficial to the facial vessels. Protect it during submandibular gland excision by ligating the facial vein low and elevating the flap above the gland (Hayes-Martin manoeuvre).",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Facial Plastic and Reconstructive Surgery (Papel)"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "marginal mandibular nerve",
+        "MMN"
+      ],
+      "abbrev": "MMN",
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "extratemporal"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cervical-branch-facial-nerve",
+      "label": "Cervical Branch of Facial Nerve",
+      "type": "nerve",
+      "subspecialty": "fprs",
+      "detail": "Terminal facial branch descending into the neck to innervate platysma; can be mistaken for the marginal mandibular branch but weakening it only affects the platysma/lower-lip depressor synergy. Exits the parotid tail near the angle of the mandible.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Facial Plastic and Reconstructive Surgery (Papel)"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "extratemporal"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "tragal-pointer",
+      "label": "Tragal Pointer",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Surgical landmark for the facial nerve trunk in parotidectomy: the pointed medial end of tragal cartilage. The nerve lies roughly 1 cm deep and inferior/anteromedial to the pointer - a soft landmark, so use it with the tympanomastoid suture and posterior digastric belly.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "tragal cartilage pointer"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "surface-landmarks"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "tympanomastoid-suture",
+      "label": "Tympanomastoid Suture",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "The most reliable landmark for the extratemporal facial nerve trunk: the nerve emerges from the stylomastoid foramen roughly 6-8 mm deep to the inferior end of this suture line between the tympanic and mastoid bone.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "tympanomastoid fissure"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "surface-landmarks"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "posterior-belly-digastric",
+      "label": "Posterior Belly of Digastric Muscle",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Key operative landmark. Its superior/upper border points to the facial nerve trunk in parotid surgery; deep to it lie the internal jugular vein, ICA and cranial nerves IX-XII. Marks the superior limit of level II and separates level I from level II in neck dissection.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "posterior digastric belly"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pitanguy-line",
+      "label": "Pitanguy Line",
+      "type": "concept",
+      "subspecialty": "fprs",
+      "detail": "Surface guide to the temporal (frontal) branch of the facial nerve: a line from 0.5 cm below the tragus to 1.5 cm above the lateral eyebrow. The branch crosses the zygomatic arch deep to SMAS/temporoparietal fascia along this line and must be protected in facelift and browlift.",
+      "sources": [
+        "Facial Plastic and Reconstructive Surgery (Papel)",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Pitanguy's line"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "surface-landmarks"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "external-branch-superior-laryngeal-nerve",
+      "label": "External Branch of Superior Laryngeal Nerve",
+      "type": "nerve",
+      "subspecialty": "endocrine",
+      "detail": "Motor branch to cricothyroid; the Cernea classification describes its relation to the superior thyroid pole. To protect it during thyroidectomy, ligate superior pole vessels low and individually on the thyroid capsule. Injury lowers vocal pitch and projection.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "AAO-HNSF Core Curriculum"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "EBSLN"
+      ],
+      "abbrev": "EBSLN",
+      "structure": null,
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "internal-branch-superior-laryngeal-nerve",
+      "label": "Internal Branch of Superior Laryngeal Nerve",
+      "type": "nerve",
+      "subspecialty": "laryngology",
+      "detail": "Sensory branch piercing the thyrohyoid membrane to supply the supraglottic larynx; afferent limb of the laryngeal adductor (cough) reflex. Its injury causes aspiration from supraglottic anaesthesia. Landmark for a superior laryngeal nerve block.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "IBSLN"
+      ],
+      "abbrev": "IBSLN",
+      "structure": null,
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pterygopalatine-ganglion",
+      "label": "Pterygopalatine Ganglion",
+      "type": "nerve",
+      "subspecialty": "rhinology",
+      "detail": "Largest parasympathetic ganglion, suspended from V2 in the pterygopalatine fossa. Parasympathetic root is the greater petrosal (from CN VII); relays secretomotor fibres to the lacrimal gland and nasal/palatine mucosa. Target for sphenopalatine block in epistaxis and cluster headache.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "sphenopalatine ganglion",
+        "Meckel's ganglion"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "epistaxis-hht"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "otic-ganglion",
+      "label": "Otic Ganglion",
+      "type": "nerve",
+      "subspecialty": "hn_onc",
+      "detail": "Parasympathetic ganglion below foramen ovale on the medial V3. Preganglionic input is the lesser petrosal nerve (from CN IX via the tympanic plexus); postganglionic secretomotor fibres hitchhike on the auriculotemporal nerve to the parotid - the basis of Frey syndrome after parotidectomy.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "salivary-gland-neoplasms"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "submandibular-ganglion",
+      "label": "Submandibular Ganglion",
+      "type": "nerve",
+      "subspecialty": "hn_onc",
+      "detail": "Parasympathetic ganglion suspended from the lingual nerve in the floor of mouth. Preganglionic fibres arrive via chorda tympani (CN VII); postganglionic fibres are secretomotor to the submandibular and sublingual glands. Encountered when the lingual nerve is dissected off the submandibular gland/duct.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "salivary-gland-neoplasms"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "non-recurrent-laryngeal-nerve",
+      "label": "Non-Recurrent Laryngeal Nerve",
+      "type": "concept",
+      "subspecialty": "laryngology",
+      "detail": "Rare variant (~0.5-1%) almost always on the RIGHT, associated with an aberrant right subclavian artery (arteria lusoria). The nerve branches directly off the cervical vagus and passes medially to the larynx without looping under the subclavian — an important cause of unexpected intraoperative RLN injury during thyroidectomy.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Bailey's Head and Neck Surgery"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "non-recurrent nerve"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "dtc-risk-stratification",
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sln-internal-branch",
+      "label": "Internal Branch of Superior Laryngeal Nerve",
+      "type": "nerve",
+      "subspecialty": "laryngology",
+      "detail": "Sensory branch that pierces the thyrohyoid membrane with the superior laryngeal vessels to supply mucosal sensation of the supraglottic larynx down to the vocal folds. Injury impairs the laryngeal adductor (cough) reflex and predisposes to aspiration.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Netter Atlas of Human Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "internal SLN"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sln-external-branch",
+      "label": "External Branch of Superior Laryngeal Nerve",
+      "type": "nerve",
+      "subspecialty": "laryngology",
+      "detail": "Motor branch to the cricothyroid muscle, controlling vocal-fold lengthening and pitch. It runs alongside the superior thyroid pedicle and is at risk during ligation of the superior thyroid artery (Cernea classification); injury causes voice fatigue and loss of high-pitch (the 'voice of professional singers').",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Bailey's Head and Neck Surgery"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "external SLN",
+        "EBSLN"
+      ],
+      "abbrev": "EBSLN",
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis",
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "thyroid-isthmus",
+      "label": "Thyroid Isthmus",
+      "type": "anatomy",
+      "subspecialty": "endocrine",
+      "detail": "Midline bridge of thyroid tissue crossing the 2nd-4th tracheal rings, connecting the two lobes. Divided or retracted to expose the trachea during tracheostomy.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Netter Atlas of Human Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pyramidal-lobe",
+      "label": "Pyramidal Lobe",
+      "type": "anatomy",
+      "subspecialty": "endocrine",
+      "detail": "Superiorly projecting lobe arising from the isthmus (usually left of midline), a remnant of the distal thyroglossal duct. Present in ~50% and must be resected in total thyroidectomy to prevent residual uptake.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "zuckerkandl-tubercle",
+      "label": "Tubercle of Zuckerkandl",
+      "type": "anatomy",
+      "subspecialty": "endocrine",
+      "detail": "Posterolateral projection of the thyroid lobe; when enlarged it points like an arrow to the recurrent laryngeal nerve, which usually lies just medial/deep to it. A key intraoperative landmark for RLN identification, and the tubercle typically overlies the nerve and the superior parathyroid.",
+      "sources": [
+        "Bailey's Head and Neck Surgery",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Zuckerkandl tubercle"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "tracheoesophageal-groove",
+      "label": "Tracheoesophageal Groove",
+      "type": "anatomy",
+      "subspecialty": "endocrine",
+      "detail": "Longitudinal groove between the trachea and esophagus housing the ascending recurrent laryngeal nerve. The left RLN lies more consistently within the groove; the right approaches more obliquely from lateral. Central compartment (level VI) node dissection tracks this groove.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Bailey's Head and Neck Surgery"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "TE groove"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "superior-parathyroid-gland",
+      "label": "Superior Parathyroid Gland",
+      "type": "anatomy",
+      "subspecialty": "endocrine",
+      "detail": "Derived from the 4th pharyngeal pouch; more constant in position, typically posterior to the mid-upper lobe, superior to the RLN-inferior thyroid artery crossing (dorsal to the coronal plane of the RLN). Blood supply is chiefly from the inferior thyroid artery.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Bailey's Head and Neck Surgery"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hyperparathyroidism",
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "inferior-parathyroid-gland",
+      "label": "Inferior Parathyroid Gland",
+      "type": "anatomy",
+      "subspecialty": "endocrine",
+      "detail": "Derived from the 3rd pharyngeal pouch (descends with the thymus), so it is more variable in location and lies anterior/ventral to the RLN, often near the lower thyroid pole or in the thyrothymic tract. Blood supply is from the inferior thyroid artery — preserve the branch by ligating vessels on the thyroid capsule to avoid devascularization.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Bailey's Head and Neck Surgery"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hyperparathyroidism",
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "superior-thyroid-vein",
+      "label": "Superior Thyroid Vein",
+      "type": "vessel",
+      "subspecialty": "endocrine",
+      "detail": "Drains the upper pole to the internal jugular vein, accompanying the superior thyroid artery.",
+      "sources": [
+        "Netter Atlas of Human Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "middle-thyroid-vein",
+      "label": "Middle Thyroid Vein",
+      "type": "vessel",
+      "subspecialty": "endocrine",
+      "detail": "Short vein draining the lateral lobe directly to the internal jugular vein; ligated early to allow medial rotation of the lobe and exposure of the tracheoesophageal groove.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Netter Atlas of Human Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "inferior-thyroid-vein",
+      "label": "Inferior Thyroid Vein",
+      "type": "vessel",
+      "subspecialty": "endocrine",
+      "detail": "Drains the lower pole/isthmus, descending anterior to the trachea to the brachiocephalic (innominate) veins; a source of troublesome bleeding during tracheostomy and low thyroidectomy.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Netter Atlas of Human Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "dtc-risk-stratification"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "trachea",
+      "label": "Trachea",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Fibrocartilaginous airway of ~18-22 C-shaped rings beginning at the cricoid. The cricothyroid membrane (below the thyroid, above the cricoid) is the surface landmark for emergency cricothyrotomy; tracheostomy is placed through the 2nd-3rd rings, below the isthmus.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "airway-management-anesthesia"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "anterior-triangle-neck",
+      "label": "Anterior Cervical Triangle",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "Bounded by inferior border of mandible (superior), anterior border of sternocleidomastoid (posterior) and the anterior midline of the neck. Subdivided by the digastric and omohyoid into submental, submandibular, carotid and muscular triangles.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "anterior triangle"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "posterior-triangle-neck",
+      "label": "Posterior Cervical Triangle",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "Bounded by posterior border of SCM (anterior), anterior border of trapezius (posterior) and the middle third of clavicle (inferior). The inferior omohyoid belly splits it into occipital and subclavian (supraclavicular) triangles; corresponds to nodal level V.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "posterior triangle"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "submental-triangle",
+      "label": "Submental Triangle",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "Suprahyoid midline triangle bounded by the two anterior bellies of digastric laterally and the hyoid inferiorly; floor is mylohyoid. Contains submental (level IA) nodes; drains anterior floor of mouth, lower lip and tongue tip.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "submandibular-triangle",
+      "label": "Submandibular (Digastric) Triangle",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "Bounded by anterior and posterior bellies of digastric and the inferior border of the mandible. Contains the submandibular gland, facial vessels, and the lingual, hypoglossal and marginal mandibular nerves — the key at-risk structures during gland excision (level IB).",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "digastric triangle"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "carotid-triangle",
+      "label": "Carotid Triangle",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "Bounded by superior belly of omohyoid (anteroinferior), posterior belly of digastric (superior) and anterior border of SCM (posterior). Contains the carotid bifurcation, internal jugular vein, vagus and hypoglossal nerves and the ansa cervicalis — the classic surgical exposure of the great vessels.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "muscular-triangle",
+      "label": "Muscular (Omotracheal) Triangle",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "Bounded by superior belly of omohyoid (superolateral), anterior border of SCM (inferolateral) and the midline. Contains the infrahyoid strap muscles overlying the thyroid gland, larynx and trachea — the access corridor for thyroidectomy and central-compartment (level VI) dissection.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "occipital-triangle",
+      "label": "Occipital Triangle",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "Superior subdivision of the posterior triangle, above the inferior belly of omohyoid. The spinal accessory nerve crosses its roof, exiting the posterior border of SCM near Erb's point — the principal danger point of level V dissection.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "subclavian-triangle",
+      "label": "Subclavian (Supraclavicular/Omoclavicular) Triangle",
+      "type": "concept",
+      "subspecialty": "fundamentals",
+      "detail": "Inferior subdivision of the posterior triangle, below the omohyoid inferior belly, above the clavicle. Contains the third part of the subclavian artery, brachial plexus trunks, external jugular vein and (on the left) the thoracic duct terminus.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "supraclavicular triangle",
+        "omoclavicular triangle"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "trapezius-muscle",
+      "label": "Trapezius Muscle",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Forms the posterior border of the posterior triangle; innervated by the spinal accessory nerve (CN XI) with C3-C4 proprioceptive contribution. Denervation causes shoulder syndrome — lateral scapular winging, drooped shoulder and painful abduction.",
+      "sources": [
+        "Netter Atlas of Human Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "anterior-scalene-muscle",
+      "label": "Anterior Scalene Muscle",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Arises from anterior tubercles of C3-C6 transverse processes, inserts on the scalene tubercle of the first rib. The phrenic nerve descends vertically on its anterior surface (deep to prevertebral fascia); the brachial plexus and subclavian artery emerge between it and the middle scalene (interscalene triangle).",
+      "sources": [
+        "Netter Atlas of Human Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "scalenus anterior"
+      ],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "middle-scalene-muscle",
+      "label": "Middle Scalene Muscle",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Largest scalene, from posterior tubercles of cervical transverse processes to the first rib behind the subclavian groove. Its anterior border, with the anterior scalene, bounds the interscalene triangle transmitting the brachial plexus roots and subclavian artery.",
+      "sources": [
+        "Netter Atlas of Human Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "scalenus medius"
+      ],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "longus-colli-muscle",
+      "label": "Longus Colli Muscle",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Prevertebral flexor running along the anterolateral vertebral bodies from C1 to T3, deep to the prevertebral fascia. The cervical sympathetic chain lies on its surface — dissection here (e.g. anterior spine, node clearance) risks Horner syndrome.",
+      "sources": [
+        "Netter Atlas of Human Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "longus cervicis"
+      ],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "omohyoid-intermediate-tendon",
+      "label": "Omohyoid Intermediate Tendon",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Central tendon linking the superior and inferior bellies of omohyoid, tethered to the clavicle by a fascial sling. It crosses the internal jugular vein and carotid sheath and marks the level III/IV nodal boundary — a reliable intraoperative landmark for the IJV and the omohyoid may be divided for exposure.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "phrenic-nerve",
+      "label": "Phrenic Nerve",
+      "type": "nerve",
+      "subspecialty": "hn_onc",
+      "detail": "C3-C4-C5 ('keeps the diaphragm alive'); descends vertically on the anterior surface of the anterior scalene, deep to the prevertebral fascia. Injury during posterior-triangle or supraclavicular dissection causes hemidiaphragm paralysis — keep dissection superficial to prevertebral fascia.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cervical-plexus",
+      "label": "Cervical Plexus",
+      "type": "nerve",
+      "subspecialty": "hn_onc",
+      "detail": "Sensory (C1-C4) plexus emerging at the posterior border of mid-SCM (Erb's point); gives great auricular, lesser occipital, transverse cervical and supraclavicular nerves plus the motor ansa cervicalis. Its cutaneous branches are commonly sacrificed in neck dissection, numbing the auricle/neck skin.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "great-auricular-nerve",
+      "label": "Great Auricular Nerve",
+      "type": "nerve",
+      "subspecialty": "hn_onc",
+      "detail": "Largest ascending branch of the cervical plexus (C2-C3); curves around the posterior border of SCM to run superficial to it toward the parotid/auricle. A reliable landmark for the external jugular vein and for the nerve graft in facial reanimation; sacrifice numbs the lower ear lobule.",
+      "sources": [
+        "Netter Atlas of Human Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cervical-sympathetic-chain",
+      "label": "Cervical Sympathetic Chain",
+      "type": "nerve",
+      "subspecialty": "hn_onc",
+      "detail": "Paravertebral chain of superior, middle and inferior (stellate) ganglia lying on longus colli, deep to the prevertebral/carotid sheath — medial and posterior to the carotid. Injury produces Horner syndrome (ptosis, miosis, anhidrosis); can be mistaken for the vagus in a parapharyngeal/retrostyloid dissection.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "sympathetic trunk"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "brachial-plexus",
+      "label": "Brachial Plexus",
+      "type": "nerve",
+      "subspecialty": "hn_onc",
+      "detail": "C5-T1 roots emerging between the anterior and middle scalenes and traversing the subclavian triangle deep to the prevertebral fascia. Encountered at the floor of a level V/Vb dissection — kept safe by not violating the prevertebral fascia.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "thoracic-duct",
+      "label": "Thoracic Duct",
+      "type": "vessel",
+      "subspecialty": "hn_onc",
+      "detail": "Terminates in the left venous angle (junction of internal jugular and subclavian veins) at the base of level IV; a smaller right lymphatic duct exists on the right. Injury during lower-neck dissection causes a chyle leak — inspect and ligate; manage with low-fat/MCT diet or re-exploration.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "ansa-cervicalis",
+      "label": "Ansa Cervicalis",
+      "type": "nerve",
+      "subspecialty": "hn_onc",
+      "detail": "Motor loop of the cervical plexus (superior root C1 via hypoglossal, inferior root C2-C3) on the anterolateral carotid sheath; supplies the infrahyoid strap muscles. Its superior root can be traced to help identify the hypoglossal nerve and is a donor for laryngeal reinnervation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "level-iib-sublevel",
+      "label": "Nodal Sublevel IIb (Submuscular Recess)",
+      "type": "concept",
+      "subspecialty": "hn_onc",
+      "detail": "Upper jugular nodes superolateral (posterosuperior) to the spinal accessory nerve. Clearing IIb requires skeletonizing and retracting CN XI; dissect it only when indicated and avoid nerve traction to reduce shoulder morbidity.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "parotid-superficial-lobe",
+      "label": "Superficial Lobe of Parotid",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "~80% of parotid mass; lies lateral to the facial nerve plane. Superficial parotidectomy removes it while preserving the nerve — the standard operation for benign lateral-lobe tumors such as pleomorphic adenoma.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Lateral lobe"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "salivary-gland-neoplasms"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "parotid-deep-lobe",
+      "label": "Deep Lobe of Parotid",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Portion medial to the facial nerve plane, adjacent to the retromandibular vein and parapharyngeal space. Deep-lobe tumors can present as a dumbbell parapharyngeal mass and require total parotidectomy with facial nerve dissection.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Medial lobe"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "salivary-gland-neoplasms"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "stensens-duct",
+      "label": "Stensen's Duct (Parotid Duct)",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Surface landmark: runs along a line from the mid-tragus to the mid-philtrum (middle third of that line). Pierces the buccinator to open opposite the maxillary second molar; buccal branch of VII runs parallel to it.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Parotid duct"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "salivary-gland-neoplasms"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "retromandibular-vein",
+      "label": "Retromandibular Vein",
+      "type": "vessel",
+      "subspecialty": "hn_onc",
+      "detail": "Formed by superficial temporal + maxillary veins within the gland. Lies just deep to the facial nerve — a reliable DEEP landmark for the nerve trunk and its divisions; the temporofacial/cervicofacial split lies lateral to it.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Posterior facial vein"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "salivary-gland-neoplasms"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "accessory-parotid",
+      "label": "Accessory Parotid",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Detached islet of parotid tissue found in ~20% of people, lying on the masseter along Stensen's duct anterior to the main gland. Can be a site of tumor and must be addressed via a facelift/parotid approach, not a direct cheek incision.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Accessory parotid gland"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "salivary-gland-neoplasms"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pes-anserinus",
+      "label": "Pes Anserinus",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "The \"goose's foot\" — the branching point where the extratemporal facial nerve trunk splits into the temporofacial (upper) and cervicofacial (lower) divisions within the parotid, typically ~1.3 cm from the stylomastoid foramen.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Pes anserinus of facial nerve"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "extratemporal"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "temporofacial-division",
+      "label": "Temporofacial Division (VII)",
+      "type": "nerve",
+      "subspecialty": "fprs",
+      "detail": "Upper division from the pes anserinus giving temporal, zygomatic and (usually) buccal branches. Innervates the periocular and upper-face musculature; the frontal/temporal branch is a danger point over the zygomatic arch.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Upper division of facial nerve"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "extratemporal"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cervicofacial-division",
+      "label": "Cervicofacial Division (VII)",
+      "type": "nerve",
+      "subspecialty": "fprs",
+      "detail": "Lower division from the pes anserinus giving (buccal), marginal mandibular and cervical branches. Supplies the perioral and platysmal musculature; the marginal mandibular branch it carries is the classic danger nerve of the lower face.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Lower division of facial nerve"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "extratemporal"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "frontalis",
+      "label": "Frontalis",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Frontal belly of occipitofrontalis; elevates brow and wrinkles forehead. Sole innervation from the temporal (frontal) branch of VII, which has minimal cross-innervation — injury causes permanent brow ptosis.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Frontal belly"
+      ],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "orbicularis-oculi",
+      "label": "Orbicularis Oculi",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Sphincter of the eyelids; closes the eye and drives the blink/lacrimal pump. Innervated by temporal and zygomatic branches of VII — paralysis produces lagophthalmos and exposure keratopathy.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "orbicularis-oris",
+      "label": "Orbicularis Oris",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Sphincter of the mouth; closes and purses the lips for oral competence and speech. Innervated by buccal and marginal mandibular branches of VII.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "zygomaticus-major",
+      "label": "Zygomaticus Major",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Runs from zygomatic bone to the modiolus; principal smile elevator drawing the oral commissure up and back. Key target for smile reanimation (e.g., masseteric-to-buccal transfer). Innervated by zygomatic/buccal branches of VII.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "zygomaticus-minor",
+      "label": "Zygomaticus Minor",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "From zygomatic bone to the upper lip; elevates the lip and deepens the nasolabial fold. Innervated by zygomatic/buccal branches of VII.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "platysma",
+      "label": "Platysma",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Broad subcutaneous sheet of the neck/lower face, part of the SMAS. Depresses the mandible/lower lip and tenses neck skin. Innervated by the cervical branch of VII — its flap is elevated first in parotid and neck surgery.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "depressor-anguli-oris",
+      "label": "Depressor Anguli Oris",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "From the mandible to the modiolus; depresses the oral commissure (frown). Innervated by the marginal mandibular branch of VII — its unopposed contralateral pull causes the classic asymmetry when the marginal branch is injured.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "DAO"
+      ],
+      "abbrev": "DAO",
+      "structure": "muscle",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "masseter",
+      "label": "Masseter",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Powerful elevator of the mandible (jaw closure) running from the zygomatic arch to the lateral ramus/angle. Innervated by the masseteric nerve from V3 — a common donor for smile reanimation nerve transfers.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "temporalis",
+      "label": "Temporalis",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Fan-shaped muscle from the temporal fossa inserting on the coronoid process; elevates and retracts the mandible. Innervated by deep temporal nerves of V3; its tendon/flap is used in temporalis transfer for dynamic reanimation.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "medial-pterygoid",
+      "label": "Medial Pterygoid",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "From the pterygoid plate/fossa to the medial angle of the mandible; elevates the jaw and mirrors the masseter internally (pterygomasseteric sling). Innervated by V3. Trismus after infiltration reflects its involvement.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "lateral-pterygoid",
+      "label": "Lateral Pterygoid",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Two heads from the greater wing/lateral pterygoid plate to the condylar neck and TMJ disc; protrudes the mandible and opens/deviates the jaw. Innervated by V3 — its pull displaces high condylar fractures anteromedially.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "marginal-mandibular-branch",
+      "label": "Marginal Mandibular Branch (VII)",
+      "type": "nerve",
+      "subspecialty": "fprs",
+      "detail": "Danger nerve of the lower face. Runs deep to platysma; may dip below the mandibular border (posteriorly it can lie ~1–2 cm below) before crossing the facial vessels. Protected by ligating the facial vein and raising the flap deep to it (Hayes-Martin maneuver). Injury causes lower-lip weakness.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Marginal mandibular nerve",
+        "MMN"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [
+          "facial-reanimation"
+        ],
+        "concepts": [
+          {
+            "module": "facial-reanimation",
+            "concept": "extratemporal"
+          }
+        ],
+        "topics": [
+          "facial-reanimation"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "frey-syndrome",
+      "label": "Frey Syndrome",
+      "type": "pathology",
+      "subspecialty": "hn_onc",
+      "detail": "Gustatory sweating/flushing over the parotid skin after parotidectomy, from aberrant reinnervation of cutaneous sweat glands by auriculotemporal secretomotor fibers. Confirmed with the Minor starch-iodine test; prevented/treated with interposition grafts (SMAS, dermis) and botulinum toxin.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Gustatory sweating",
+        "Auriculotemporal syndrome"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "salivary-gland-neoplasms"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pterygopalatine-fossa",
+      "label": "Pterygopalatine Fossa",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Fat-filled surgical crossroads between the maxillary sinus (anterior), pterygoid plates (posterior) and palatine bone (medial). Contents: V2, the pterygopalatine (sphenopalatine) ganglion and the terminal third of the internal maxillary artery. Communicates with the middle cranial fossa via foramen rotundum, the nasal cavity via the sphenopalatine foramen, the orbit via the inferior orbital fissure, the pterygoid canal (vidian) and the greater/lesser palatine canals — a common tumor spread route (JNA, ACC perineural).",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "PPF"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary",
+          "sinonasal-tumors"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sphenopalatine-ganglion",
+      "label": "Sphenopalatine (Pterygopalatine) Ganglion",
+      "type": "nerve",
+      "subspecialty": "rhinology",
+      "detail": "Largest parasympathetic ganglion of the head, suspended from V2 in the pterygopalatine fossa. Parasympathetic secretomotor fibers arrive via the greater superficial petrosal nerve (as part of the vidian nerve) and synapse here to supply the lacrimal gland and nasal/palatine mucosal glands; sympathetic fibers pass through without synapsing.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "pterygopalatine ganglion",
+        "SPG"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "internal-maxillary-artery",
+      "label": "Internal Maxillary Artery",
+      "type": "vessel",
+      "subspecialty": "rhinology",
+      "detail": "Larger terminal branch of the external carotid; its third (pterygopalatine) part enters the fossa and divides into the sphenopalatine, descending palatine, infraorbital and posterior superior alveolar arteries. Proximal control here (or transantral ligation) is a classic maneuver for intractable posterior epistaxis and the feeding supply of a juvenile nasopharyngeal angiofibroma.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "maxillary artery",
+        "IMAX"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "epistaxis-hht",
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "vidian-nerve",
+      "label": "Vidian Nerve",
+      "type": "nerve",
+      "subspecialty": "rhinology",
+      "detail": "Nerve of the pterygoid canal, formed by the greater superficial petrosal (parasympathetic) plus the deep petrosal (sympathetic) nerves. Runs anteriorly through the vidian canal to reach the sphenopalatine ganglion. Endoscopic vidian neurectomy is used for refractory vasomotor rhinitis; the canal is a reliable landmark to the second genu of the petrous internal carotid artery.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "nerve of pterygoid canal"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "vidian-canal",
+      "label": "Vidian Canal",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Bony canal through the sphenoid base transmitting the vidian nerve and artery; runs from the anterior aspect of foramen lacerum to the pterygopalatine fossa. Endoscopically it sits at the floor of the sphenoid sinus and points to the petrous ICA — a key skull-base drilling landmark.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "pterygoid canal"
+      ],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "foramen-lacerum",
+      "label": "Foramen Lacerum",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Cartilage-filled gap at the petrous apex–sphenoid junction; the internal carotid artery crosses its superior surface (does not truly pass through it) as it transitions from the petrous to the cavernous segment. The vidian canal opens onto its anterior margin, making it an ICA landmark in expanded endonasal approaches.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "posterior-ethmoidal-artery",
+      "label": "Posterior Ethmoidal Artery",
+      "type": "vessel",
+      "subspecialty": "rhinology",
+      "detail": "Branch of the ophthalmic artery crossing the skull base ~2–3 mm anterior to the optic canal, roughly 12 mm posterior to the anterior ethmoidal artery. Injury during posterior ethmoidectomy risks retraction into the orbit and retrobulbar hematoma; it lies closer to the optic nerve than the AEA, so posterior dissection here demands caution.",
+      "sources": [
+        "Stammberger Functional Endoscopic Sinus Surgery"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "PEA"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "crs-polyps-afrs-biologics",
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "onodi-cell",
+      "label": "Onodi Cell",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "A posterior ethmoid cell that pneumatizes superolaterally over/above the sphenoid sinus. Pearl: when present, the optic nerve and internal carotid artery are intimately related to (and may dehisce into) the Onodi cell rather than the sphenoid — unrecognized, it is a classic cause of optic-nerve injury during posterior ethmoidectomy. Always identify it on preoperative CT.",
+      "sources": [
+        "Stammberger Functional Endoscopic Sinus Surgery"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "sphenoethmoidal cell"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "crs-polyps-afrs-biologics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "keros-classification",
+      "label": "Keros Classification",
+      "type": "concept",
+      "subspecialty": "rhinology",
+      "detail": "Grades the depth of the olfactory fossa by the vertical height of the lateral lamella of the cribriform plate: Keros I 1–3 mm, II 4–7 mm, III 8–16 mm. A deeper fossa (Keros III) and a thin lateral lamella carry the highest risk of iatrogenic CSF leak/skull-base injury during ethmoidectomy; asymmetry between sides is an added danger sign.",
+      "sources": [
+        "Stammberger Functional Endoscopic Sinus Surgery"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Keros grade"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "csf-rhinorrhea-encephalocele",
+          "crs-polyps-afrs-biologics"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "crista-ethmoidalis",
+      "label": "Crista Ethmoidalis",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Small bony crest of the perpendicular process of the palatine bone, located just anterior to the sphenopalatine foramen. It is the constant surgical landmark for identifying and ligating/cauterizing the sphenopalatine artery as it exits onto the lateral nasal wall.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ethmoidal crest"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "epistaxis-hht"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cavernous-sinus",
+      "label": "Cavernous Sinus",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Paired dural venous sinus lateral to the sphenoid sinus and sella. Within its lumen run the internal carotid artery and abducens nerve (CN VI — the only cranial nerve that travels free within the sinus, adjacent to the ICA); its lateral wall carries CN III, IV, V1 and V2 in a superior-to-inferior order. Cavernous sinus thrombosis is a dreaded complication of sphenoid/facial infection.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "space",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "orbital-intracranial-sinus-complications",
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "orbital-apex",
+      "label": "Orbital Apex",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Convergence of the optic canal and superior orbital fissure at the posterior orbit, with the annulus of Zinn as the common origin of the rectus muscles. Orbital apex syndrome = superior orbital fissure syndrome (CN III, IV, V1, VI) plus optic-nerve (CN II) involvement; can complicate invasive fungal sinusitis or posterior ethmoid/sphenoid disease.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "space",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "orbital-intracranial-sinus-complications"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "ophthalmic-artery",
+      "label": "Ophthalmic Artery",
+      "type": "vessel",
+      "subspecialty": "rhinology",
+      "detail": "First intradural branch of the internal carotid; enters the orbit through the optic canal (inferolateral to the nerve) and gives the anterior and posterior ethmoidal arteries that supply the anterior skull base. This ICA–ECA anastomosis is why external carotid embolization for epistaxis carries a risk of retrograde central retinal artery occlusion.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "epistaxis-hht",
+          "orbital-intracranial-sinus-complications"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "posterior-septal-artery",
+      "label": "Posterior Septal Artery",
+      "type": "vessel",
+      "subspecialty": "rhinology",
+      "detail": "Terminal septal branch of the sphenopalatine artery that crosses the anterior face of the sphenoid (between the sinus ostium and the choana) to supply the posterior nasal septum. It is the vascular pedicle of the Hadad-Bassagasteguy nasoseptal flap — the workhorse reconstruction for endoscopic skull-base defects; its pedicle must be preserved and the flap raised before sphenoidotomy in planned skull-base cases.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "posterior septal branch"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary",
+          "csf-rhinorrhea-encephalocele"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "retrobulbar-hematoma",
+      "label": "Retrobulbar Hematoma",
+      "type": "pathology",
+      "subspecialty": "rhinology",
+      "detail": "Orbital compartment syndrome from bleeding (classically a retracted, transected anterior/posterior ethmoidal artery) during endoscopic sinus surgery. Presents with proptosis, tense orbit, decreasing vision and a relative afferent pupillary defect; a surgical emergency requiring urgent lateral canthotomy and inferior cantholysis to prevent permanent blindness.",
+      "sources": [
+        "Stammberger Functional Endoscopic Sinus Surgery"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "retro-orbital hematoma",
+        "orbital hematoma"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "orbital-intracranial-sinus-complications"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "common-carotid-artery",
+      "label": "Common Carotid Artery",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "Right arises from brachiocephalic trunk, left directly from the aortic arch. Ascends within the carotid sheath with no branches until it bifurcates near the superior border of the thyroid cartilage (C3–C4). Digital compression against the carotid (Chassaignac) tubercle of C6 is a temporizing maneuver for control.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "CCA"
+      ],
+      "abbrev": "CCA",
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "paraganglioma-vascular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "carotid-bifurcation",
+      "label": "Carotid Bifurcation",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "Division of the common carotid into internal and external carotid arteries, typically at C3–C4 (upper thyroid cartilage). Site of the carotid body (chemoreceptor, origin of carotid body paraganglioma splaying the vessels in a 'lyre sign') and carotid sinus (baroreceptor). Key landmark in neck dissection and carotid endarterectomy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "paraganglioma-vascular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "external-carotid-artery",
+      "label": "External Carotid Artery",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "Anteromedial branch of the bifurcation supplying the face, scalp, and neck via eight branches. Distinguished from the ICA by its cervical branches (the ICA has none in the neck). Ligation for hemorrhage should be placed distal to the superior thyroid artery to reduce collateral steal and preserve flow to distal branches.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "ECA"
+      ],
+      "abbrev": "ECA",
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "paraganglioma-vascular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "ascending-pharyngeal-artery",
+      "label": "Ascending Pharyngeal Artery",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "Small posteromedial ECA branch (the only medial branch), often arising near the bifurcation. Supplies the pharynx, prevertebral muscles, and meninges; a frequent feeder of jugulotympanic paragangliomas and a target during preoperative embolization.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "paraganglioma-vascular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "lingual-artery",
+      "label": "Lingual Artery",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "Second anterior ECA branch supplying the tongue and floor of mouth. Passes deep to hyoglossus; loops within the submandibular triangle where it is a landmark in transoral base-of-tongue surgery (TORS) and can be ligated for tongue hemorrhage. Hyoglossus separates the artery (deep) from the hypoglossal nerve (superficial).",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "oral-cavity-cancer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "facial-artery",
+      "label": "Facial Artery",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "Third anterior ECA branch that grooves the posterior submandibular gland before crossing the mandibular border anterior to the masseter (palpable pulse). Ligated during level I neck dissection and submandibular gland excision; marks the facial vein and the marginal mandibular nerve, which lies superficial to it.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "external maxillary artery"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "occipital-artery",
+      "label": "Occipital Artery",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "Posterior ECA branch supplying the posterior scalp. Crosses superficial to the internal carotid and internal jugular and gives the sternocleidomastoid branch, under which the hypoglossal nerve loops — a bleeding pitfall when mobilizing CN XII in upper neck dissection.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "posterior-auricular-artery",
+      "label": "Posterior Auricular Artery",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "Small posterior ECA branch supplying the auricle, postauricular scalp, and (via the stylomastoid branch) the facial nerve within the fallopian canal. Basis of postauricular/retroauricular flaps and a source of bleeding during mastoid and parotid surgery.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "external-ear",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "local-flaps-mohs-reconstruction"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "maxillary-artery",
+      "label": "Maxillary Artery (Internal Maxillary)",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "Larger terminal ECA branch arising deep to the mandibular neck in the infratemporal fossa. Passes into the pterygopalatine fossa and supplies the deep face, nasal cavity, and dura. Principal artery of posterior epistaxis (via sphenopalatine) and a control point in transantral ligation and JNA surgery.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "internal maxillary artery",
+        "IMAX"
+      ],
+      "abbrev": "IMAX",
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "epistaxis-hht"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "superficial-temporal-artery",
+      "label": "Superficial Temporal Artery",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "Smaller terminal ECA branch ascending anterior to the tragus (palpable preauricular pulse) into the temporoparietal scalp. Biopsy target in giant cell arteritis, axis of the temporoparietal fascia flap, and a landmark exiting the superior parotid.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "STA"
+      ],
+      "abbrev": "STA",
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "local-flaps-mohs-reconstruction"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cervical-ica-segment",
+      "label": "ICA — Cervical Segment",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "C1 segment from the bifurcation to the carotid canal, giving no branches. Lies in the carotid sheath; a medialized (retropharyngeal/aberrant) course is a hazard during tonsillectomy and adenoidectomy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "paraganglioma-vascular"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "petrous-ica-segment",
+      "label": "ICA — Petrous Segment",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "C2 segment traversing the carotid canal of the temporal bone with vertical then horizontal (genu) portions. Lies medial to the eustachian tube and anteroinferior to the cochlea — at risk in petrous apex and infratemporal/skull-base approaches.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "temporal-bone-trauma"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cavernous-ica-segment",
+      "label": "ICA — Cavernous Segment",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "C4 segment coursing through the cavernous sinus in an S-shaped siphon, adjacent to CN III, IV, V1, V2, and VI. A key landmark and danger point lateral to the sphenoid sinus in endoscopic skull-base surgery; dehiscent bony coverage is common.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "carotid siphon"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "supraclinoid-ica-segment",
+      "label": "ICA — Supraclinoid Segment",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "C6–C7 intradural segment above the anterior clinoid giving the ophthalmic artery (source of the ethmoidal arteries), then terminating into the anterior and middle cerebral arteries. Ophthalmic origin explains why posterior epistaxis from ethmoidal arteries arises from the ICA, not the ECA.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "inferior-alveolar-artery",
+      "label": "Inferior Alveolar Artery",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "First-part (mandibular) branch of the maxillary artery entering the mandibular foramen with the inferior alveolar nerve to supply the lower teeth. A source of brisk bleeding in mandibular osteotomy, sagittal split, and body/angle fracture fixation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "descending-palatine-artery",
+      "label": "Descending Palatine Artery",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "Pterygopalatine branch of the maxillary artery descending the greater palatine canal to become the greater palatine artery at the hard palate. Encountered in Le Fort I down-fracture and cleft/palatal surgery; supplies the palate and contributes to the nasal septal (Kiesselbach) plexus.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "greater palatine artery"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "epistaxis-hht"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "external-jugular-vein",
+      "label": "External Jugular Vein",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "Formed by the posterior division of the retromandibular vein and the posterior auricular vein; crosses the sternocleidomastoid superficially to drain into the subclavian vein. Superficial landmark encountered raising a cervical skin flap; drains the scalp and face.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "EJV"
+      ],
+      "abbrev": "EJV",
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "facial-vein",
+      "label": "Facial Vein",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "Drains the anterior face; joins the anterior division of the retromandibular vein to form the common facial vein, which empties into the internal jugular. Communicates with the cavernous sinus via the ophthalmic veins (valveless), a route for retrograde facial-infection spread. Its crossing of the mandible marks the marginal mandibular nerve.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "common facial vein"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "neck-dissection-unknown-primary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "lingual-vein",
+      "label": "Lingual Vein",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "Drains the tongue and floor of mouth; the accompanying vein (vena comitans of the hypoglossal nerve) and dorsal lingual veins empty into the internal jugular. Encountered during glossectomy and floor-of-mouth resection.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "oral-cavity-cancer"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pterygoid-plexus",
+      "label": "Pterygoid Venous Plexus",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "Valveless venous network in the infratemporal fossa around the lateral pterygoid, draining to the maxillary/retromandibular vein and communicating with the cavernous sinus. A source of troublesome venous bleeding in infratemporal fossa and maxillary surgery and a route of infection to the cavernous sinus.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "epistaxis-hht"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "thyrocervical-trunk",
+      "label": "Thyrocervical Trunk",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "Short branch of the first part of the subclavian artery giving the inferior thyroid, transverse cervical, and suprascapular arteries. Origin landmark at the medial supraclavicular fossa in low neck dissection and central compartment surgery.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "hyperparathyroidism"
+        ]
+      },
+      "review": false
     }
   ],
   "edges": [
@@ -25004,6 +28491,1665 @@
       "target": "level-iv-neck",
       "type": "continuous_with",
       "direction": "superior"
+    },
+    {
+      "source": "olfactory-nerve",
+      "target": "cribriform-plate",
+      "type": "passes_through",
+      "label": "fila olfactoria",
+      "direction": "superior"
+    },
+    {
+      "source": "optic-nerve",
+      "target": "optic-canal",
+      "type": "passes_through"
+    },
+    {
+      "source": "oculomotor-nerve",
+      "target": "superior-orbital-fissure",
+      "type": "passes_through"
+    },
+    {
+      "source": "trochlear-nerve",
+      "target": "superior-orbital-fissure",
+      "type": "passes_through"
+    },
+    {
+      "source": "abducens-nerve",
+      "target": "superior-orbital-fissure",
+      "type": "passes_through"
+    },
+    {
+      "source": "ophthalmic-nerve",
+      "target": "trigeminal-nerve",
+      "type": "branches_from",
+      "label": "V1"
+    },
+    {
+      "source": "maxillary-nerve",
+      "target": "trigeminal-nerve",
+      "type": "branches_from",
+      "label": "V2"
+    },
+    {
+      "source": "mandibular-nerve",
+      "target": "trigeminal-nerve",
+      "type": "branches_from",
+      "label": "V3"
+    },
+    {
+      "source": "ophthalmic-nerve",
+      "target": "superior-orbital-fissure",
+      "type": "passes_through"
+    },
+    {
+      "source": "maxillary-nerve",
+      "target": "foramen-rotundum",
+      "type": "passes_through"
+    },
+    {
+      "source": "mandibular-nerve",
+      "target": "foramen-ovale",
+      "type": "passes_through"
+    },
+    {
+      "source": "inferior-alveolar-nerve",
+      "target": "mandibular-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "lingual-nerve",
+      "target": "mandibular-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "auriculotemporal-nerve",
+      "target": "mandibular-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "infraorbital-nerve",
+      "target": "maxillary-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "greater-palatine-nerve",
+      "target": "maxillary-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "lesser-palatine-nerve",
+      "target": "maxillary-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "chorda-tympani",
+      "target": "lingual-nerve",
+      "type": "continuous_with",
+      "label": "taste + parasympathetic"
+    },
+    {
+      "source": "lingual-nerve",
+      "target": "submandibular-space",
+      "type": "landmark_for",
+      "label": "crosses submandibular duct"
+    },
+    {
+      "source": "auriculotemporal-nerve",
+      "target": "parotid-gland",
+      "type": "landmark_for",
+      "label": "Frey syndrome"
+    },
+    {
+      "source": "maxillary-nerve",
+      "target": "pterygopalatine-ganglion",
+      "type": "landmark_for",
+      "label": "ganglion suspended from V2"
+    },
+    {
+      "source": "temporal-branch-facial-nerve",
+      "target": "facial-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "zygomatic-branch-facial-nerve",
+      "target": "facial-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "buccal-branch-facial-nerve",
+      "target": "facial-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "marginal-mandibular-nerve",
+      "target": "facial-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "cervical-branch-facial-nerve",
+      "target": "facial-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "cervical-branch-facial-nerve",
+      "target": "platysma-muscle",
+      "type": "innervates"
+    },
+    {
+      "source": "marginal-mandibular-nerve",
+      "target": "submandibular-space",
+      "type": "landmark_for",
+      "label": "protect in submandibular approach",
+      "direction": "inferior"
+    },
+    {
+      "source": "tragal-pointer",
+      "target": "facial-nerve",
+      "type": "landmark_for"
+    },
+    {
+      "source": "tympanomastoid-suture",
+      "target": "facial-nerve",
+      "type": "landmark_for",
+      "label": "most reliable"
+    },
+    {
+      "source": "posterior-belly-digastric",
+      "target": "facial-nerve",
+      "type": "landmark_for"
+    },
+    {
+      "source": "pitanguy-line",
+      "target": "temporal-branch-facial-nerve",
+      "type": "landmark_for"
+    },
+    {
+      "source": "greater-superficial-petrosal",
+      "target": "facial-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "greater-superficial-petrosal",
+      "target": "geniculate-ganglion",
+      "type": "arises_from"
+    },
+    {
+      "source": "greater-superficial-petrosal",
+      "target": "pterygopalatine-ganglion",
+      "type": "continuous_with",
+      "label": "parasympathetic root"
+    },
+    {
+      "source": "chorda-tympani",
+      "target": "facial-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "glossopharyngeal-nerve",
+      "target": "jugular-foramen",
+      "type": "passes_through"
+    },
+    {
+      "source": "jacobson-nerve",
+      "target": "glossopharyngeal-nerve",
+      "type": "branches_from",
+      "label": "tympanic branch"
+    },
+    {
+      "source": "otic-ganglion",
+      "target": "glossopharyngeal-nerve",
+      "type": "continuous_with",
+      "label": "lesser petrosal"
+    },
+    {
+      "source": "otic-ganglion",
+      "target": "parotid-gland",
+      "type": "innervates",
+      "label": "secretomotor"
+    },
+    {
+      "source": "otic-ganglion",
+      "target": "auriculotemporal-nerve",
+      "type": "continuous_with",
+      "label": "postganglionic hitchhike"
+    },
+    {
+      "source": "vagus-nerve",
+      "target": "jugular-foramen",
+      "type": "passes_through"
+    },
+    {
+      "source": "superior-laryngeal-nerve",
+      "target": "vagus-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "external-branch-superior-laryngeal-nerve",
+      "target": "superior-laryngeal-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "internal-branch-superior-laryngeal-nerve",
+      "target": "superior-laryngeal-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "recurrent-laryngeal-nerve",
+      "target": "vagus-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "recurrent-laryngeal-nerve",
+      "target": "berry-ligament",
+      "type": "landmark_for",
+      "label": "at ligament of Berry"
+    },
+    {
+      "source": "accessory-nerve",
+      "target": "jugular-foramen",
+      "type": "passes_through"
+    },
+    {
+      "source": "accessory-nerve",
+      "target": "level-v-neck",
+      "type": "landmark_for",
+      "label": "most superficial in posterior triangle"
+    },
+    {
+      "source": "accessory-nerve",
+      "target": "level-ii-neck",
+      "type": "landmark_for"
+    },
+    {
+      "source": "hypoglossal-nerve",
+      "target": "hypoglossal-canal",
+      "type": "passes_through"
+    },
+    {
+      "source": "hypoglossal-nerve",
+      "target": "posterior-belly-digastric",
+      "type": "landmark_for",
+      "label": "runs deep to it",
+      "direction": "deep"
+    },
+    {
+      "source": "hypoglossal-nerve",
+      "target": "level-i-neck",
+      "type": "landmark_for"
+    },
+    {
+      "source": "submandibular-ganglion",
+      "target": "lingual-nerve",
+      "type": "continuous_with",
+      "label": "suspended from lingual nerve"
+    },
+    {
+      "source": "submandibular-ganglion",
+      "target": "submandibular-space",
+      "type": "landmark_for"
+    },
+    {
+      "source": "chorda-tympani",
+      "target": "submandibular-ganglion",
+      "type": "continuous_with",
+      "label": "preganglionic parasympathetic"
+    },
+    {
+      "source": "sln-internal-branch",
+      "target": "superior-laryngeal-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "sln-external-branch",
+      "target": "superior-laryngeal-nerve",
+      "type": "branches_from"
+    },
+    {
+      "source": "sln-external-branch",
+      "target": "cricothyroid-muscle",
+      "type": "innervates",
+      "label": "only intrinsic muscle not RLN-supplied"
+    },
+    {
+      "source": "sln-internal-branch",
+      "target": "thyrohyoid-membrane",
+      "type": "passes_through",
+      "label": "with superior laryngeal vessels",
+      "direction": "anterior"
+    },
+    {
+      "source": "non-recurrent-laryngeal-nerve",
+      "target": "recurrent-laryngeal-nerve",
+      "type": "differentiates_from",
+      "label": "right-sided, arteria lusoria"
+    },
+    {
+      "source": "zuckerkandl-tubercle",
+      "target": "recurrent-laryngeal-nerve",
+      "type": "landmark_for",
+      "label": "points to the RLN",
+      "direction": "medial"
+    },
+    {
+      "source": "tracheoesophageal-groove",
+      "target": "recurrent-laryngeal-nerve",
+      "type": "landmark_for"
+    },
+    {
+      "source": "recurrent-laryngeal-nerve",
+      "target": "tracheoesophageal-groove",
+      "type": "contained_in"
+    },
+    {
+      "source": "inferior-thyroid-artery",
+      "target": "superior-parathyroid-gland",
+      "type": "supplies"
+    },
+    {
+      "source": "inferior-thyroid-artery",
+      "target": "inferior-parathyroid-gland",
+      "type": "supplies"
+    },
+    {
+      "source": "superior-thyroid-artery",
+      "target": "external-carotid-artery",
+      "type": "branches_from"
+    },
+    {
+      "source": "inferior-thyroid-artery",
+      "target": "thyrocervical-trunk",
+      "type": "branches_from"
+    },
+    {
+      "source": "superior-thyroid-artery",
+      "target": "sln-external-branch",
+      "type": "landmark_for",
+      "label": "EBSLN at risk during pedicle ligation"
+    },
+    {
+      "source": "superior-thyroid-vein",
+      "target": "internal-jugular-vein",
+      "type": "drains_to"
+    },
+    {
+      "source": "middle-thyroid-vein",
+      "target": "internal-jugular-vein",
+      "type": "drains_to"
+    },
+    {
+      "source": "superior-thyroid-vein",
+      "target": "thyroid-gland",
+      "type": "drains_to"
+    },
+    {
+      "source": "middle-thyroid-vein",
+      "target": "thyroid-gland",
+      "type": "drains_to"
+    },
+    {
+      "source": "inferior-thyroid-vein",
+      "target": "thyroid-gland",
+      "type": "drains_to"
+    },
+    {
+      "source": "thyroid-isthmus",
+      "target": "thyroid-gland",
+      "type": "part_of"
+    },
+    {
+      "source": "pyramidal-lobe",
+      "target": "thyroid-gland",
+      "type": "part_of",
+      "direction": "superior"
+    },
+    {
+      "source": "zuckerkandl-tubercle",
+      "target": "thyroid-gland",
+      "type": "part_of",
+      "direction": "posterior"
+    },
+    {
+      "source": "berry-ligament",
+      "target": "cricoid-cartilage",
+      "type": "attaches_to",
+      "direction": "medial"
+    },
+    {
+      "source": "berry-ligament",
+      "target": "trachea",
+      "type": "attaches_to"
+    },
+    {
+      "source": "thyroid-gland",
+      "target": "trachea",
+      "type": "contained_in",
+      "label": "invested by pretracheal fascia"
+    },
+    {
+      "source": "superior-parathyroid-gland",
+      "target": "thyroid-gland",
+      "type": "attaches_to",
+      "direction": "posterior"
+    },
+    {
+      "source": "inferior-parathyroid-gland",
+      "target": "thyroid-gland",
+      "type": "attaches_to",
+      "direction": "inferior"
+    },
+    {
+      "source": "trachea",
+      "target": "cricoid-cartilage",
+      "type": "continuous_with",
+      "direction": "superior"
+    },
+    {
+      "source": "cricothyroid-membrane",
+      "target": "trachea",
+      "type": "landmark_for",
+      "label": "emergency cricothyrotomy site"
+    },
+    {
+      "source": "thyroid-isthmus",
+      "target": "trachea",
+      "type": "attaches_to",
+      "label": "overlies 2nd-4th rings"
+    },
+    {
+      "source": "submental-triangle",
+      "target": "anterior-triangle-neck",
+      "type": "part_of"
+    },
+    {
+      "source": "submandibular-triangle",
+      "target": "anterior-triangle-neck",
+      "type": "part_of"
+    },
+    {
+      "source": "carotid-triangle",
+      "target": "anterior-triangle-neck",
+      "type": "part_of"
+    },
+    {
+      "source": "muscular-triangle",
+      "target": "anterior-triangle-neck",
+      "type": "part_of"
+    },
+    {
+      "source": "occipital-triangle",
+      "target": "posterior-triangle-neck",
+      "type": "part_of"
+    },
+    {
+      "source": "subclavian-triangle",
+      "target": "posterior-triangle-neck",
+      "type": "part_of"
+    },
+    {
+      "source": "anterior-triangle-neck",
+      "target": "mandible",
+      "type": "bounded_by",
+      "label": "inferior border of mandible",
+      "direction": "superior"
+    },
+    {
+      "source": "posterior-triangle-neck",
+      "target": "trapezius-muscle",
+      "type": "bounded_by",
+      "label": "anterior border of trapezius",
+      "direction": "posterior"
+    },
+    {
+      "source": "posterior-triangle-neck",
+      "target": "omohyoid-muscle",
+      "type": "bounded_by",
+      "label": "inferior belly divides it",
+      "direction": "inferior"
+    },
+    {
+      "source": "submental-triangle",
+      "target": "digastric-anterior-belly",
+      "type": "bounded_by",
+      "label": "anterior bellies of digastric",
+      "direction": "lateral"
+    },
+    {
+      "source": "submental-triangle",
+      "target": "hyoid-bone",
+      "type": "bounded_by",
+      "direction": "inferior"
+    },
+    {
+      "source": "submandibular-triangle",
+      "target": "digastric-anterior-belly",
+      "type": "bounded_by",
+      "direction": "anterior"
+    },
+    {
+      "source": "submandibular-triangle",
+      "target": "digastric-posterior-belly",
+      "type": "bounded_by",
+      "direction": "posterior"
+    },
+    {
+      "source": "submandibular-triangle",
+      "target": "mandible",
+      "type": "bounded_by",
+      "direction": "superior"
+    },
+    {
+      "source": "submandibular-triangle",
+      "target": "lingual-nerve",
+      "type": "landmark_for",
+      "label": "at-risk in gland excision"
+    },
+    {
+      "source": "submandibular-triangle",
+      "target": "hypoglossal-nerve",
+      "type": "landmark_for",
+      "label": "in floor of triangle"
+    },
+    {
+      "source": "submandibular-triangle",
+      "target": "marginal-mandibular-nerve",
+      "type": "landmark_for",
+      "label": "overlies triangle"
+    },
+    {
+      "source": "carotid-triangle",
+      "target": "omohyoid-muscle",
+      "type": "bounded_by",
+      "label": "superior belly",
+      "direction": "anterior"
+    },
+    {
+      "source": "carotid-triangle",
+      "target": "digastric-posterior-belly",
+      "type": "bounded_by",
+      "direction": "superior"
+    },
+    {
+      "source": "carotid-triangle",
+      "target": "carotid-sheath",
+      "type": "landmark_for",
+      "label": "exposes great vessels"
+    },
+    {
+      "source": "carotid-triangle",
+      "target": "vagus-nerve",
+      "type": "landmark_for"
+    },
+    {
+      "source": "carotid-triangle",
+      "target": "hypoglossal-nerve",
+      "type": "landmark_for",
+      "label": "crosses ICA/ECA"
+    },
+    {
+      "source": "muscular-triangle",
+      "target": "omohyoid-muscle",
+      "type": "bounded_by",
+      "label": "superior belly",
+      "direction": "superolateral"
+    },
+    {
+      "source": "muscular-triangle",
+      "target": "sternohyoid-muscle",
+      "type": "landmark_for",
+      "label": "straps overlie thyroid"
+    },
+    {
+      "source": "occipital-triangle",
+      "target": "omohyoid-muscle",
+      "type": "bounded_by",
+      "label": "inferior belly",
+      "direction": "inferior"
+    },
+    {
+      "source": "subclavian-triangle",
+      "target": "omohyoid-muscle",
+      "type": "bounded_by",
+      "label": "inferior belly",
+      "direction": "superior"
+    },
+    {
+      "source": "subclavian-triangle",
+      "target": "brachial-plexus",
+      "type": "landmark_for",
+      "label": "in floor"
+    },
+    {
+      "source": "subclavian-triangle",
+      "target": "thoracic-duct",
+      "type": "landmark_for",
+      "label": "terminates on left"
+    },
+    {
+      "source": "ansa-cervicalis",
+      "target": "omohyoid-muscle",
+      "type": "innervates"
+    },
+    {
+      "source": "ansa-cervicalis",
+      "target": "sternohyoid-muscle",
+      "type": "innervates"
+    },
+    {
+      "source": "ansa-cervicalis",
+      "target": "hypoglossal-nerve",
+      "type": "landmark_for",
+      "label": "superior root identifies CN XII"
+    },
+    {
+      "source": "omohyoid-intermediate-tendon",
+      "target": "omohyoid-muscle",
+      "type": "part_of"
+    },
+    {
+      "source": "omohyoid-intermediate-tendon",
+      "target": "internal-jugular-vein",
+      "type": "landmark_for",
+      "label": "crosses IJV; level III/IV boundary"
+    },
+    {
+      "source": "digastric-posterior-belly",
+      "target": "mastoid",
+      "type": "attaches_to",
+      "label": "mastoid notch",
+      "direction": "posterior"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "digastric-posterior-belly",
+      "type": "innervates"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "platysma-muscle",
+      "type": "innervates",
+      "label": "cervical branch"
+    },
+    {
+      "source": "anterior-scalene-muscle",
+      "target": "transverse-process",
+      "type": "attaches_to",
+      "label": "anterior tubercles C3-C6"
+    },
+    {
+      "source": "middle-scalene-muscle",
+      "target": "transverse-process",
+      "type": "attaches_to",
+      "label": "posterior tubercles"
+    },
+    {
+      "source": "anterior-scalene-muscle",
+      "target": "phrenic-nerve",
+      "type": "landmark_for",
+      "label": "phrenic on its anterior surface"
+    },
+    {
+      "source": "anterior-scalene-muscle",
+      "target": "brachial-plexus",
+      "type": "landmark_for",
+      "label": "interscalene triangle",
+      "direction": "lateral"
+    },
+    {
+      "source": "middle-scalene-muscle",
+      "target": "brachial-plexus",
+      "type": "landmark_for",
+      "label": "interscalene triangle",
+      "direction": "medial"
+    },
+    {
+      "source": "longus-colli-muscle",
+      "target": "cervical-vertebra",
+      "type": "attaches_to",
+      "label": "anterolateral vertebral bodies"
+    },
+    {
+      "source": "longus-colli-muscle",
+      "target": "cervical-sympathetic-chain",
+      "type": "landmark_for",
+      "label": "chain lies on longus colli — Horner risk"
+    },
+    {
+      "source": "great-auricular-nerve",
+      "target": "cervical-plexus",
+      "type": "branches_from"
+    },
+    {
+      "source": "vagus-nerve",
+      "target": "carotid-sheath",
+      "type": "contained_in"
+    },
+    {
+      "source": "lingual-nerve",
+      "target": "submandibular-triangle",
+      "type": "contained_in"
+    },
+    {
+      "source": "phrenic-nerve",
+      "target": "anterior-scalene-muscle",
+      "type": "landmark_for",
+      "label": "descends on anterior scalene"
+    },
+    {
+      "source": "submental-triangle",
+      "target": "level-i-neck",
+      "type": "part_of",
+      "label": "sublevel IA"
+    },
+    {
+      "source": "submandibular-triangle",
+      "target": "level-i-neck",
+      "type": "part_of",
+      "label": "sublevel IB"
+    },
+    {
+      "source": "level-i-neck",
+      "target": "marginal-mandibular-nerve",
+      "type": "landmark_for",
+      "label": "protect in level I dissection"
+    },
+    {
+      "source": "digastric-posterior-belly",
+      "target": "level-ii-neck",
+      "type": "landmark_for",
+      "label": "upper limit of level II"
+    },
+    {
+      "source": "omohyoid-intermediate-tendon",
+      "target": "level-iv-neck",
+      "type": "landmark_for",
+      "label": "III/IV boundary"
+    },
+    {
+      "source": "thoracic-duct",
+      "target": "level-iv-neck",
+      "type": "landmark_for",
+      "label": "chyle leak risk",
+      "direction": "left"
+    },
+    {
+      "source": "posterior-triangle-neck",
+      "target": "level-v-neck",
+      "type": "part_of"
+    },
+    {
+      "source": "level-v-neck",
+      "target": "trapezius-muscle",
+      "type": "bounded_by",
+      "direction": "posterior"
+    },
+    {
+      "source": "level-vi-neck",
+      "target": "recurrent-laryngeal-nerve",
+      "type": "landmark_for",
+      "label": "central compartment"
+    },
+    {
+      "source": "level-vi-neck",
+      "target": "carotid-sheath",
+      "type": "bounded_by",
+      "direction": "lateral"
+    },
+    {
+      "source": "level-iib-sublevel",
+      "target": "level-ii-neck",
+      "type": "part_of"
+    },
+    {
+      "source": "parotid-superficial-lobe",
+      "target": "parotid-gland",
+      "type": "part_of",
+      "label": "superficial lobe",
+      "direction": "superficial"
+    },
+    {
+      "source": "parotid-deep-lobe",
+      "target": "parotid-gland",
+      "type": "part_of",
+      "label": "deep lobe",
+      "direction": "deep"
+    },
+    {
+      "source": "accessory-parotid",
+      "target": "parotid-gland",
+      "type": "part_of",
+      "label": "accessory tissue",
+      "direction": "anterior"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "parotid-gland",
+      "type": "contained_in",
+      "label": "surgical plane splitting lobes"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "parotid-superficial-lobe",
+      "type": "landmark_for",
+      "label": "defines superficial lobe",
+      "direction": "deep"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "parotid-deep-lobe",
+      "type": "landmark_for",
+      "label": "defines deep lobe",
+      "direction": "superficial"
+    },
+    {
+      "source": "stensens-duct",
+      "target": "parotid-gland",
+      "type": "contained_in",
+      "label": "drains gland",
+      "direction": "anterior"
+    },
+    {
+      "source": "stensens-duct",
+      "target": "buccinator",
+      "type": "landmark_for",
+      "label": "pierces to open at 2nd molar"
+    },
+    {
+      "source": "retromandibular-vein",
+      "target": "parotid-gland",
+      "type": "contained_in",
+      "direction": "deep"
+    },
+    {
+      "source": "retromandibular-vein",
+      "target": "facial-nerve",
+      "type": "landmark_for",
+      "label": "deep landmark for trunk/divisions",
+      "direction": "deep"
+    },
+    {
+      "source": "styloid-process",
+      "target": "facial-nerve",
+      "type": "landmark_for",
+      "label": "nerve is lateral to styloid",
+      "direction": "lateral"
+    },
+    {
+      "source": "pes-anserinus",
+      "target": "facial-nerve",
+      "type": "landmark_for",
+      "label": "trunk bifurcation"
+    },
+    {
+      "source": "temporofacial-division",
+      "target": "facial-nerve",
+      "type": "branches_from",
+      "label": "upper division at pes",
+      "direction": "superior"
+    },
+    {
+      "source": "cervicofacial-division",
+      "target": "facial-nerve",
+      "type": "branches_from",
+      "label": "lower division at pes",
+      "direction": "inferior"
+    },
+    {
+      "source": "marginal-mandibular-branch",
+      "target": "cervicofacial-division",
+      "type": "branches_from",
+      "direction": "inferior"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "frontalis",
+      "type": "innervates",
+      "label": "temporal branch"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "orbicularis-oculi",
+      "type": "innervates",
+      "label": "temporal/zygomatic"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "orbicularis-oris",
+      "type": "innervates",
+      "label": "buccal/marginal"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "zygomaticus-major",
+      "type": "innervates",
+      "label": "zygomatic/buccal"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "zygomaticus-minor",
+      "type": "innervates",
+      "label": "zygomatic/buccal"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "buccinator",
+      "type": "innervates",
+      "label": "buccal branch"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "platysma",
+      "type": "innervates",
+      "label": "cervical branch"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "depressor-anguli-oris",
+      "type": "innervates",
+      "label": "marginal mandibular"
+    },
+    {
+      "source": "temporofacial-division",
+      "target": "frontalis",
+      "type": "innervates"
+    },
+    {
+      "source": "temporofacial-division",
+      "target": "orbicularis-oculi",
+      "type": "innervates"
+    },
+    {
+      "source": "cervicofacial-division",
+      "target": "platysma",
+      "type": "innervates"
+    },
+    {
+      "source": "cervicofacial-division",
+      "target": "orbicularis-oris",
+      "type": "innervates"
+    },
+    {
+      "source": "marginal-mandibular-branch",
+      "target": "depressor-anguli-oris",
+      "type": "innervates"
+    },
+    {
+      "source": "mandibular-nerve",
+      "target": "masseter",
+      "type": "innervates",
+      "label": "masseteric nerve"
+    },
+    {
+      "source": "mandibular-nerve",
+      "target": "temporalis",
+      "type": "innervates",
+      "label": "deep temporal nerves"
+    },
+    {
+      "source": "mandibular-nerve",
+      "target": "medial-pterygoid",
+      "type": "innervates"
+    },
+    {
+      "source": "mandibular-nerve",
+      "target": "lateral-pterygoid",
+      "type": "innervates"
+    },
+    {
+      "source": "masseter",
+      "target": "mandible",
+      "type": "attaches_to",
+      "label": "ramus/angle"
+    },
+    {
+      "source": "masseter",
+      "target": "zygoma",
+      "type": "attaches_to",
+      "label": "zygomatic arch origin"
+    },
+    {
+      "source": "temporalis",
+      "target": "mandible",
+      "type": "attaches_to",
+      "label": "coronoid process"
+    },
+    {
+      "source": "medial-pterygoid",
+      "target": "mandible",
+      "type": "attaches_to",
+      "label": "medial angle"
+    },
+    {
+      "source": "lateral-pterygoid",
+      "target": "mandible",
+      "type": "attaches_to",
+      "label": "condylar neck"
+    },
+    {
+      "source": "auriculotemporal-nerve",
+      "target": "parotid-gland",
+      "type": "innervates",
+      "label": "secretomotor (parasympathetic)"
+    },
+    {
+      "source": "frey-syndrome",
+      "target": "auriculotemporal-nerve",
+      "type": "arises_from",
+      "label": "aberrant reinnervation"
+    },
+    {
+      "source": "frey-syndrome",
+      "target": "parotidectomy",
+      "type": "complication_of",
+      "label": "gustatory sweating"
+    },
+    {
+      "source": "great-auricular-nerve",
+      "target": "parotid-gland",
+      "type": "landmark_for",
+      "label": "crosses SCM below gland",
+      "direction": "inferior"
+    },
+    {
+      "source": "maxillary-nerve",
+      "target": "pterygopalatine-fossa",
+      "type": "contained_in"
+    },
+    {
+      "source": "sphenopalatine-ganglion",
+      "target": "pterygopalatine-fossa",
+      "type": "contained_in"
+    },
+    {
+      "source": "internal-maxillary-artery",
+      "target": "pterygopalatine-fossa",
+      "type": "contained_in",
+      "label": "terminal (third) part"
+    },
+    {
+      "source": "sphenopalatine-ganglion",
+      "target": "maxillary-nerve",
+      "type": "suspends",
+      "direction": "inferior"
+    },
+    {
+      "source": "pterygopalatine-fossa",
+      "target": "foramen-rotundum",
+      "type": "continuous_with",
+      "direction": "posterior"
+    },
+    {
+      "source": "pterygopalatine-fossa",
+      "target": "sphenopalatine-foramen",
+      "type": "continuous_with",
+      "direction": "medial"
+    },
+    {
+      "source": "pterygopalatine-fossa",
+      "target": "vidian-canal",
+      "type": "continuous_with",
+      "direction": "posterior"
+    },
+    {
+      "source": "vidian-nerve",
+      "target": "vidian-canal",
+      "type": "passes_through"
+    },
+    {
+      "source": "vidian-canal",
+      "target": "vidian-nerve",
+      "type": "transmits"
+    },
+    {
+      "source": "vidian-nerve",
+      "target": "sphenopalatine-ganglion",
+      "type": "continuous_with",
+      "label": "GSP + deep petrosal"
+    },
+    {
+      "source": "vidian-canal",
+      "target": "foramen-lacerum",
+      "type": "continuous_with",
+      "direction": "posterior"
+    },
+    {
+      "source": "vidian-nerve",
+      "target": "internal-carotid-artery",
+      "type": "landmark_for",
+      "label": "points to petrous genu"
+    },
+    {
+      "source": "foramen-lacerum",
+      "target": "internal-carotid-artery",
+      "type": "landmark_for"
+    },
+    {
+      "source": "sphenopalatine-artery",
+      "target": "internal-maxillary-artery",
+      "type": "branches_from",
+      "direction": "medial"
+    },
+    {
+      "source": "ophthalmic-artery",
+      "target": "internal-carotid-artery",
+      "type": "branches_from"
+    },
+    {
+      "source": "internal-maxillary-artery",
+      "target": "epistaxis",
+      "type": "landmark_for",
+      "label": "posterior epistaxis control"
+    },
+    {
+      "source": "anterior-ethmoidal-artery",
+      "target": "ophthalmic-artery",
+      "type": "branches_from"
+    },
+    {
+      "source": "posterior-ethmoidal-artery",
+      "target": "ophthalmic-artery",
+      "type": "branches_from"
+    },
+    {
+      "source": "posterior-ethmoidal-artery",
+      "target": "fovea-ethmoidalis",
+      "type": "passes_through"
+    },
+    {
+      "source": "anterior-ethmoidal-artery",
+      "target": "functional-endoscopic-sinus-surgery",
+      "type": "landmark_for"
+    },
+    {
+      "source": "posterior-ethmoidal-artery",
+      "target": "functional-endoscopic-sinus-surgery",
+      "type": "landmark_for"
+    },
+    {
+      "source": "retrobulbar-hematoma",
+      "target": "functional-endoscopic-sinus-surgery",
+      "type": "complication_of"
+    },
+    {
+      "source": "retrobulbar-hematoma",
+      "target": "anterior-ethmoidal-artery",
+      "type": "arises_from"
+    },
+    {
+      "source": "lamina-papyracea",
+      "target": "retrobulbar-hematoma",
+      "type": "landmark_for",
+      "label": "medial orbital wall breach"
+    },
+    {
+      "source": "onodi-cell",
+      "target": "optic-nerve",
+      "type": "landmark_for"
+    },
+    {
+      "source": "onodi-cell",
+      "target": "internal-carotid-artery",
+      "type": "landmark_for"
+    },
+    {
+      "source": "onodi-cell",
+      "target": "sphenoid-sinus",
+      "type": "continuous_with",
+      "direction": "superior"
+    },
+    {
+      "source": "sphenoid-sinus",
+      "target": "internal-carotid-artery",
+      "type": "landmark_for",
+      "label": "parasellar bulge"
+    },
+    {
+      "source": "sphenoid-sinus",
+      "target": "optic-nerve",
+      "type": "landmark_for",
+      "label": "lateral wall bulge"
+    },
+    {
+      "source": "keros-classification",
+      "target": "cribriform-plate",
+      "type": "landmark_for",
+      "label": "lateral lamella height"
+    },
+    {
+      "source": "keros-classification",
+      "target": "fovea-ethmoidalis",
+      "type": "landmark_for"
+    },
+    {
+      "source": "keros-classification",
+      "target": "csf-rhinorrhea",
+      "type": "staged_with",
+      "label": "iatrogenic CSF-leak risk"
+    },
+    {
+      "source": "crista-ethmoidalis",
+      "target": "sphenopalatine-artery",
+      "type": "landmark_for"
+    },
+    {
+      "source": "crista-ethmoidalis",
+      "target": "sphenopalatine-foramen",
+      "type": "landmark_for",
+      "direction": "anterior"
+    },
+    {
+      "source": "oculomotor-nerve",
+      "target": "cavernous-sinus",
+      "type": "contained_in",
+      "label": "lateral wall"
+    },
+    {
+      "source": "trochlear-nerve",
+      "target": "cavernous-sinus",
+      "type": "contained_in",
+      "label": "lateral wall"
+    },
+    {
+      "source": "ophthalmic-nerve",
+      "target": "cavernous-sinus",
+      "type": "contained_in",
+      "label": "lateral wall"
+    },
+    {
+      "source": "maxillary-nerve",
+      "target": "cavernous-sinus",
+      "type": "contained_in",
+      "label": "lateral wall"
+    },
+    {
+      "source": "abducens-nerve",
+      "target": "cavernous-sinus",
+      "type": "contained_in",
+      "label": "free within lumen"
+    },
+    {
+      "source": "internal-carotid-artery",
+      "target": "cavernous-sinus",
+      "type": "contained_in"
+    },
+    {
+      "source": "cavernous-sinus",
+      "target": "sphenoid-sinus",
+      "type": "bounded_by",
+      "direction": "medial"
+    },
+    {
+      "source": "cavernous-sinus",
+      "target": "superior-orbital-fissure",
+      "type": "continuous_with",
+      "direction": "anterior"
+    },
+    {
+      "source": "superior-orbital-fissure",
+      "target": "oculomotor-nerve",
+      "type": "transmits"
+    },
+    {
+      "source": "superior-orbital-fissure",
+      "target": "trochlear-nerve",
+      "type": "transmits"
+    },
+    {
+      "source": "superior-orbital-fissure",
+      "target": "ophthalmic-nerve",
+      "type": "transmits"
+    },
+    {
+      "source": "superior-orbital-fissure",
+      "target": "abducens-nerve",
+      "type": "transmits"
+    },
+    {
+      "source": "optic-canal",
+      "target": "orbital-apex",
+      "type": "part_of"
+    },
+    {
+      "source": "superior-orbital-fissure",
+      "target": "orbital-apex",
+      "type": "part_of"
+    },
+    {
+      "source": "ophthalmic-artery",
+      "target": "optic-canal",
+      "type": "passes_through",
+      "label": "with optic nerve"
+    },
+    {
+      "source": "crista-galli",
+      "target": "anterior-skull-base",
+      "type": "part_of",
+      "direction": "anterior"
+    },
+    {
+      "source": "crista-galli",
+      "target": "cribriform-plate",
+      "type": "landmark_for",
+      "direction": "anterior"
+    },
+    {
+      "source": "olfactory-nerve",
+      "target": "cribriform-plate",
+      "type": "landmark_for"
+    },
+    {
+      "source": "posterior-septal-artery",
+      "target": "sphenopalatine-artery",
+      "type": "branches_from"
+    },
+    {
+      "source": "posterior-septal-artery",
+      "target": "nasoseptal-flap",
+      "type": "supplies",
+      "label": "flap pedicle"
+    },
+    {
+      "source": "posterior-septal-artery",
+      "target": "nasoseptal-flap",
+      "type": "landmark_for"
+    },
+    {
+      "source": "common-carotid-artery",
+      "target": "carotid-bifurcation",
+      "type": "continuous_with",
+      "label": "bifurcates at C3-C4",
+      "direction": "superior"
+    },
+    {
+      "source": "carotid-bifurcation",
+      "target": "internal-carotid-artery",
+      "type": "landmark_for",
+      "label": "ICA lies posterolateral",
+      "direction": "posterior"
+    },
+    {
+      "source": "carotid-bifurcation",
+      "target": "external-carotid-artery",
+      "type": "landmark_for",
+      "label": "ECA lies anteromedial",
+      "direction": "anterior"
+    },
+    {
+      "source": "external-carotid-artery",
+      "target": "common-carotid-artery",
+      "type": "branches_from",
+      "label": "terminal branch",
+      "direction": "anterior"
+    },
+    {
+      "source": "internal-carotid-artery",
+      "target": "common-carotid-artery",
+      "type": "branches_from",
+      "label": "terminal branch",
+      "direction": "posterior"
+    },
+    {
+      "source": "ascending-pharyngeal-artery",
+      "target": "external-carotid-artery",
+      "type": "branches_from",
+      "label": "medial branch",
+      "direction": "medial"
+    },
+    {
+      "source": "lingual-artery",
+      "target": "external-carotid-artery",
+      "type": "branches_from",
+      "label": "2nd anterior branch"
+    },
+    {
+      "source": "facial-artery",
+      "target": "external-carotid-artery",
+      "type": "branches_from",
+      "label": "3rd anterior branch"
+    },
+    {
+      "source": "occipital-artery",
+      "target": "external-carotid-artery",
+      "type": "branches_from",
+      "label": "posterior branch",
+      "direction": "posterior"
+    },
+    {
+      "source": "posterior-auricular-artery",
+      "target": "external-carotid-artery",
+      "type": "branches_from",
+      "label": "posterior branch",
+      "direction": "posterior"
+    },
+    {
+      "source": "maxillary-artery",
+      "target": "external-carotid-artery",
+      "type": "branches_from",
+      "label": "terminal branch",
+      "direction": "anterior"
+    },
+    {
+      "source": "superficial-temporal-artery",
+      "target": "external-carotid-artery",
+      "type": "branches_from",
+      "label": "terminal branch",
+      "direction": "superior"
+    },
+    {
+      "source": "superior-thyroid-artery",
+      "target": "external-carotid-artery",
+      "type": "landmark_for",
+      "label": "ligate ECA distal to this branch to preserve distal flow"
+    },
+    {
+      "source": "ascending-pharyngeal-artery",
+      "target": "nasopharynx",
+      "type": "supplies"
+    },
+    {
+      "source": "lingual-artery",
+      "target": "hypoglossal-nerve",
+      "type": "landmark_for",
+      "label": "artery deep to hyoglossus, CN XII superficial",
+      "direction": "deep"
+    },
+    {
+      "source": "occipital-artery",
+      "target": "hypoglossal-nerve",
+      "type": "landmark_for",
+      "label": "SCM branch loops over CN XII"
+    },
+    {
+      "source": "posterior-auricular-artery",
+      "target": "facial-nerve",
+      "type": "supplies",
+      "label": "stylomastoid branch"
+    },
+    {
+      "source": "superficial-temporal-artery",
+      "target": "parotid-gland",
+      "type": "landmark_for",
+      "label": "exits superior parotid, preauricular pulse",
+      "direction": "superior"
+    },
+    {
+      "source": "cervical-ica-segment",
+      "target": "internal-carotid-artery",
+      "type": "part_of",
+      "label": "C1",
+      "direction": "inferior"
+    },
+    {
+      "source": "petrous-ica-segment",
+      "target": "internal-carotid-artery",
+      "type": "part_of",
+      "label": "C2"
+    },
+    {
+      "source": "cavernous-ica-segment",
+      "target": "internal-carotid-artery",
+      "type": "part_of",
+      "label": "C4"
+    },
+    {
+      "source": "supraclinoid-ica-segment",
+      "target": "internal-carotid-artery",
+      "type": "part_of",
+      "label": "C6-C7",
+      "direction": "superior"
+    },
+    {
+      "source": "petrous-ica-segment",
+      "target": "carotid-canal",
+      "type": "passes_through"
+    },
+    {
+      "source": "cavernous-ica-segment",
+      "target": "cavernous-sinus",
+      "type": "contained_in",
+      "label": "carotid siphon"
+    },
+    {
+      "source": "middle-meningeal-artery",
+      "target": "maxillary-artery",
+      "type": "branches_from",
+      "label": "1st (mandibular) part"
+    },
+    {
+      "source": "inferior-alveolar-artery",
+      "target": "maxillary-artery",
+      "type": "branches_from",
+      "label": "1st (mandibular) part"
+    },
+    {
+      "source": "sphenopalatine-artery",
+      "target": "maxillary-artery",
+      "type": "branches_from",
+      "label": "terminal (pterygopalatine) branch"
+    },
+    {
+      "source": "descending-palatine-artery",
+      "target": "maxillary-artery",
+      "type": "branches_from",
+      "label": "pterygopalatine part",
+      "direction": "inferior"
+    },
+    {
+      "source": "middle-meningeal-artery",
+      "target": "foramen-spinosum",
+      "type": "passes_through"
+    },
+    {
+      "source": "inferior-alveolar-artery",
+      "target": "inferior-alveolar-nerve",
+      "type": "landmark_for",
+      "label": "enters mandibular foramen together"
+    },
+    {
+      "source": "anterior-ethmoidal-artery",
+      "target": "supraclinoid-ica-segment",
+      "type": "branches_from",
+      "label": "via ophthalmic artery (ICA)"
+    },
+    {
+      "source": "posterior-ethmoidal-artery",
+      "target": "supraclinoid-ica-segment",
+      "type": "branches_from",
+      "label": "via ophthalmic artery (ICA)"
+    },
+    {
+      "source": "anterior-ethmoidal-artery",
+      "target": "anterior-skull-base",
+      "type": "landmark_for",
+      "label": "skull-base bleeding danger; may retract into orbit"
+    },
+    {
+      "source": "posterior-ethmoidal-artery",
+      "target": "anterior-skull-base",
+      "type": "landmark_for",
+      "label": "~2-4 mm anterior to optic nerve",
+      "direction": "posterior"
+    },
+    {
+      "source": "retromandibular-vein",
+      "target": "external-jugular-vein",
+      "type": "drains_to",
+      "label": "posterior division",
+      "direction": "inferior"
+    },
+    {
+      "source": "facial-vein",
+      "target": "internal-jugular-vein",
+      "type": "drains_to",
+      "label": "via common facial vein",
+      "direction": "inferior"
+    },
+    {
+      "source": "facial-vein",
+      "target": "cavernous-sinus",
+      "type": "continuous_with",
+      "label": "valveless ophthalmic communication",
+      "direction": "superior"
+    },
+    {
+      "source": "lingual-vein",
+      "target": "internal-jugular-vein",
+      "type": "drains_to",
+      "direction": "inferior"
+    },
+    {
+      "source": "pterygoid-plexus",
+      "target": "retromandibular-vein",
+      "type": "drains_to",
+      "label": "via maxillary vein"
+    },
+    {
+      "source": "pterygoid-plexus",
+      "target": "cavernous-sinus",
+      "type": "continuous_with",
+      "label": "emissary communication (infection route)",
+      "direction": "superior"
+    },
+    {
+      "source": "cavernous-sinus",
+      "target": "sigmoid-sinus",
+      "type": "drains_to",
+      "label": "via superior/inferior petrosal sinuses",
+      "direction": "posterior"
+    },
+    {
+      "source": "cavernous-sinus",
+      "target": "internal-carotid-artery",
+      "type": "landmark_for",
+      "label": "ICA and CN VI traverse the sinus"
+    },
+    {
+      "source": "sigmoid-sinus",
+      "target": "internal-jugular-vein",
+      "type": "drains_to",
+      "label": "via jugular foramen",
+      "direction": "inferior"
+    },
+    {
+      "source": "thyroid-gland",
+      "target": "superior-thyroid-vein",
+      "type": "drains_to",
+      "label": "superior pole",
+      "direction": "superior"
+    },
+    {
+      "source": "thyroid-gland",
+      "target": "middle-thyroid-vein",
+      "type": "drains_to",
+      "label": "lateral",
+      "direction": "lateral"
+    },
+    {
+      "source": "thyroid-gland",
+      "target": "inferior-thyroid-vein",
+      "type": "drains_to",
+      "label": "inferior pole/isthmus",
+      "direction": "inferior"
     }
   ]
 }

--- a/data/kag-graph.json
+++ b/data/kag-graph.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "updated": "2026-07-02T20:10:42.377Z",
+  "updated": "2026-07-02T20:27:08.319Z",
   "status": "DRAFT expansion — 40-node temporal-bone seed is vetted (review:true); all other nodes are subagent-authored scaffolding (review:false) pending owner stress-test against curated source text.",
   "sources": [
     "Cummings Otolaryngology 7e",
@@ -3677,7 +3677,7 @@
         "costochondral graft"
       ],
       "abbrev": null,
-      "structure": "cartilage",
+      "structure": null,
       "region": null,
       "laterality": null,
       "oksat": {
@@ -3956,7 +3956,7 @@
       ],
       "abbrev": "SMAS",
       "structure": "fascia",
-      "region": null,
+      "region": "facial-skeleton",
       "laterality": "paired",
       "oksat": {
         "modules": [],
@@ -15846,6 +15846,3821 @@
         ]
       },
       "review": false
+    },
+    {
+      "id": "auricular-cartilage",
+      "label": "Auricular Cartilage",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Single elastic-cartilage framework of the auricle whose folds and hollows form the surface subunits (helix, antihelix, tragus, concha); continuous medially with the cartilaginous external auditory canal. The lobule lacks cartilage.",
+      "sources": [
+        "Gray's Anatomy",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "pinna cartilage",
+        "auricular framework"
+      ],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "external-ear",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "helix",
+      "label": "Helix",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Curved outer rim of the auricle, beginning at the crus of the helix within the concha and ending at the lobule. An elastic-cartilage subunit of the auricular framework.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "external-ear",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "antihelix",
+      "label": "Antihelix",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Y-shaped ridge anterior and parallel to the helix; superiorly it divides into superior and inferior crura that bound the triangular fossa. Loss of its fold produces prominent-ear deformity.",
+      "sources": [
+        "Gray's Anatomy",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "anthelix"
+      ],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "external-ear",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "superior-crus",
+      "label": "Superior Crus of Antihelix",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Upper of the two divergent limbs of the antihelix; with the inferior crus it bounds the triangular fossa.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "superior crus"
+      ],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "external-ear",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "inferior-crus",
+      "label": "Inferior Crus of Antihelix",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Lower, more horizontal limb of the antihelix; with the superior crus it bounds the triangular fossa.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "inferior crus"
+      ],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "external-ear",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "tragus",
+      "label": "Tragus",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Cartilaginous projection anterior to the external auditory meatus, overlapping its opening; separated from the antitragus by the intertragic notch.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "external-ear",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "antitragus",
+      "label": "Antitragus",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Small tubercle opposite the tragus, superior to the lobule; separated from the tragus by the intertragic notch and continuous with the inferior antihelix.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "external-ear",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "concha",
+      "label": "Concha",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Deepest hollow of the auricle, divided by the crus of the helix into cymba and cavum; the cavum concha leads medially into the external auditory canal.",
+      "sources": [
+        "Gray's Anatomy",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "concha auriculae",
+        "cymba concha",
+        "cavum concha"
+      ],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "external-ear",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "scaphoid-fossa",
+      "label": "Scaphoid Fossa",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Narrow curved gutter between the helix and the antihelix; a hollow of the auricular cartilage framework.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "scapha"
+      ],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "external-ear",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "triangular-fossa",
+      "label": "Triangular Fossa",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Depression bounded by the superior and inferior crura of the antihelix; a hollow of the auricular cartilage framework.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "fossa triangularis"
+      ],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "external-ear",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "lobule",
+      "label": "Lobule (Earlobe)",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Inferior fibrofatty portion of the auricle; unlike the other subunits it contains NO cartilage, only fibrous tissue, fat, and skin. Continuous superiorly with the antitragus and helix.",
+      "sources": [
+        "Gray's Anatomy",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "earlobe",
+        "lobulus auriculae"
+      ],
+      "abbrev": null,
+      "structure": null,
+      "region": "external-ear",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "temporal-bone",
+      "label": "Temporal Bone",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Paired bone of the skull base composed of squamous, petrous, mastoid, and tympanic parts plus the styloid process; houses the middle and inner ear and transmits the facial and vestibulocochlear nerves.",
+      "sources": [
+        "Gray's Anatomy",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "squamous-part",
+      "label": "Squamous Part of Temporal Bone",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Thin, flat superolateral plate of the temporal bone; bears the mandibular fossa and the zygomatic process, forming the roof and part of the wall of the external auditory canal.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "squama temporalis",
+        "temporal squama"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "petrous-part",
+      "label": "Petrous Part of Temporal Bone",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Dense pyramidal portion of the temporal bone housing the otic capsule (cochlea, vestibule, semicircular canals) and the internal auditory canal; wedged between the sphenoid and occipital bones at the skull base.",
+      "sources": [
+        "Gray's Anatomy",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "petrous pyramid",
+        "petrous temporal bone"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "mastoid-part",
+      "label": "Mastoid Part of Temporal Bone",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Posteroinferior part of the temporal bone bearing the mastoid process and air cells; continuous with the petrous part and the site of the mastoid antrum communicating with the epitympanum.",
+      "sources": [
+        "Gray's Anatomy",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "mastoid portion"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "tympanic-part",
+      "label": "Tympanic Part of Temporal Bone",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Curved plate forming the anterior wall, floor, and lower posterior wall of the bony external auditory canal and the tympanic sulcus for the tympanic annulus; ends medially at the petrotympanic fissure.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "tympanic plate"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "otic-capsule",
+      "label": "Otic Capsule",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Dense endochondral bone of the petrous temporal bone that encloses the membranous labyrinth; contains the cochlea, vestibule, and semicircular canals. Its enchondral layer does not remodel, relevant in otosclerosis and otic-capsule-violating fractures.",
+      "sources": [
+        "Gray's Anatomy",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "bony labyrinth capsule"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "tympanosquamous-fissure",
+      "label": "Tympanosquamous Fissure",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Suture line on the mandibular fossa between the squamous and tympanic parts of the temporal bone; lies anterolateral to the petrotympanic fissure.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "squamotympanic fissure"
+      ],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "petrotympanic-fissure",
+      "label": "Petrotympanic Fissure (Glaserian Fissure)",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Slit between the petrous and tympanic parts at the medial mandibular fossa. Transmits the chorda tympani nerve out of the middle ear and the anterior tympanic artery; also transmits the anterior malleal ligament.",
+      "sources": [
+        "Gray's Anatomy",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Glaserian fissure",
+        "glaserian fissure"
+      ],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "petrosquamous-suture",
+      "label": "Petrosquamous Suture",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Suture between the petrous and squamous parts of the temporal bone; a persistent (Koerner's) septum along this line can complicate mastoid surgery and provide a route for infection spread.",
+      "sources": [
+        "Gray's Anatomy",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Koerner's septum"
+      ],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "maxilla",
+      "label": "Maxilla",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Paired central midface bone forming the upper jaw, anterior maxillary sinus wall, inferior orbital rim/floor, piriform aperture and hard palate; key to Le Fort fracture patterns.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "maxilla-frontal-process",
+      "label": "Frontal Process of Maxilla",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Superomedial maxillary projection meeting the frontal and nasal bones; forms the medial orbital rim and part of the nasomaxillary buttress and lacrimal fossa.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "maxilla-zygomatic-process",
+      "label": "Zygomatic Process of Maxilla",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Lateral maxillary projection articulating with the zygoma at the zygomaticomaxillary suture; component of the lateral (zygomaticomaxillary) vertical buttress.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "maxilla-alveolar-process",
+      "label": "Alveolar Process of Maxilla",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Tooth-bearing inferior ridge of the maxilla; its dental sockets anchor the vertical midface buttresses and are disrupted in Le Fort I fractures.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "maxilla-palatine-process",
+      "label": "Palatine Process of Maxilla",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Horizontal shelf forming the anterior three-quarters of the hard palate, meeting its fellow at the intermaxillary suture and the palatine bone posteriorly.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "mandible-condyle",
+      "label": "Mandibular Condyle",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Rounded superior process of the ramus articulating with the temporal glenoid fossa at the TMJ; common site of subcondylar fracture.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "mandible-coronoid-process",
+      "label": "Coronoid Process",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Anterosuperior ramus process giving insertion to the temporalis muscle; separated from the condyle by the mandibular (sigmoid) notch.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "mandible-ramus",
+      "label": "Mandibular Ramus",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Vertical posterior segment bearing the condyle and coronoid; lateral surface receives masseter, medial surface receives medial pterygoid.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "mandible-angle",
+      "label": "Mandibular Angle",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Junction of ramus and body; a frequent fracture site, weakened by the third molar and the masseter-medial pterygoid muscular sling.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "mandible-body",
+      "label": "Mandibular Body",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Horizontal tooth-bearing segment transmitting the inferior alveolar nerve through its canal to the mental foramen.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "mandible-symphysis",
+      "label": "Mandibular Symphysis",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Midline anterior mandible (fused embryologic symphysis); parasymphyseal fractures often accompany contralateral condylar fractures.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "mandible-alveolar-ridge",
+      "label": "Mandibular Alveolar Ridge",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Tooth-bearing crest of the mandibular body; resorbs after tooth loss and is relevant to dental rehabilitation and osteotomy planning.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "zygoma",
+      "label": "Zygoma",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Malar bone forming cheek prominence and lateral orbital rim/floor; articulates with frontal, temporal, maxillary and sphenoid bones as the ZMC quadripod.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "nasal-bone",
+      "label": "Nasal Bone",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Paired bones forming the bony nasal dorsum; articulate superiorly with frontal bone, medially with each other, laterally with the maxillary frontal process.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "frontal-bone",
+      "label": "Frontal Bone",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Forms the forehead, supraorbital rims and orbital roofs and houses the frontal sinus; its inferior articulations define the frontal-bar horizontal buttress.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "glabella",
+      "label": "Glabella",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Smooth midline prominence of the frontal bone between the supraorbital ridges and above the frontonasal suture; a cephalometric soft-tissue landmark.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "supraorbital-rim",
+      "label": "Supraorbital Rim",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Superior orbital margin of the frontal bone bearing the supraorbital notch/foramen; part of the upper transverse (frontal-bar) midface buttress.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "lacrimal-bone",
+      "label": "Lacrimal Bone",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Small medial orbital wall bone forming, with the maxillary frontal process, the lacrimal fossa lodging the lacrimal sac and nasolacrimal duct.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "palatine-bone",
+      "label": "Palatine Bone",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "L-shaped bone with horizontal and perpendicular plates; forms the posterior hard palate, lateral nasal wall and part of the pterygopalatine fossa.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "palatine-bone-horizontal-plate",
+      "label": "Horizontal Plate of Palatine Bone",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Forms the posterior one-quarter of the hard palate, meeting the palatine process of the maxilla anteriorly and its fellow at the midline.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "palatine-bone-perpendicular-plate",
+      "label": "Perpendicular Plate of Palatine Bone",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Vertical plate forming the posterior lateral nasal wall; its sphenopalatine notch, closed by the sphenoid, becomes the sphenopalatine foramen.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "nasomaxillary-buttress",
+      "label": "Nasomaxillary (Medial) Buttress",
+      "type": "concept",
+      "subspecialty": "fprs",
+      "detail": "Medial vertical midface buttress running along the piriform aperture from the alveolus through the frontal process of the maxilla to the frontal bone.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "zygomaticomaxillary-buttress",
+      "label": "Zygomaticomaxillary (Lateral) Buttress",
+      "type": "concept",
+      "subspecialty": "fprs",
+      "detail": "Lateral vertical buttress from the maxillary alveolus through the zygomaticomaxillary junction and zygoma to the frontal bone; a key ORIF fixation strut.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "pterygomaxillary-buttress",
+      "label": "Pterygomaxillary (Posterior) Buttress",
+      "type": "concept",
+      "subspecialty": "fprs",
+      "detail": "Posterior vertical buttress connecting the maxilla to the sphenoid pterygoid plates; disrupted in Le Fort fractures via the pterygomaxillary junction.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "frontal-bar-buttress",
+      "label": "Frontal Bar (Upper Transverse) Buttress",
+      "type": "concept",
+      "subspecialty": "fprs",
+      "detail": "Thick horizontal bar of the frontal bone across the supraorbital rims and glabella; the superior transverse strut resisting midface disruption.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "infraorbital-buttress",
+      "label": "Infraorbital Rim (Transverse) Buttress",
+      "type": "concept",
+      "subspecialty": "fprs",
+      "detail": "Horizontal buttress along the inferior orbital rim linking the medial and lateral vertical struts; commonly plated in ZMC and orbital fractures.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "palatal-buttress",
+      "label": "Palatoalveolar (Lower Transverse) Buttress",
+      "type": "concept",
+      "subspecialty": "fprs",
+      "detail": "Horizontal palatal-alveolar strut across the hard palate tying the paired vertical buttresses together at the occlusal level.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "zygomaticotemporal-suture",
+      "label": "Zygomaticotemporal Suture",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Articulation of the zygomatic process of the temporal bone with the temporal process of the zygoma forming the zygomatic arch.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "nasomaxillary-suture",
+      "label": "Nasomaxillary Suture",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Suture between the lateral edge of the nasal bone and the frontal process of the maxilla, along the nasomaxillary buttress.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "frontonasal-suture",
+      "label": "Frontonasal Suture",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Midline articulation of the nasal bones with the frontal bone; its midpoint (nasion) is a standard cephalometric landmark.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "facial-skeleton",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "frontomaxillary-suture",
+      "label": "Frontomaxillary Suture",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Suture between the frontal bone and the frontal process of the maxilla, superior to the medial orbital rim.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "intermaxillary-suture",
+      "label": "Intermaxillary Suture",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Midline suture uniting the two maxillae along the palatine processes and anterior nasal spine; site of the median palatal raphe.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "facial-skeleton",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "internasal-suture",
+      "label": "Internasal Suture",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Midline suture joining the paired nasal bones forming the bony dorsum ridge.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "facial-skeleton",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "glenoid-fossa",
+      "label": "Glenoid (Mandibular) Fossa",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Concavity on the temporal bone squama that receives the mandibular condyle and articular disc to form the TMJ; bounded anteriorly by the articular eminence.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "septal-cartilage",
+      "label": "Septal (Quadrangular) Cartilage",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Quadrangular cartilage forming the anterior nasal septum; continuous posterosuperiorly with the ethmoid perpendicular plate and posteroinferiorly with the vomer.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "nasal-sinus",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "upper-lateral-cartilage",
+      "label": "Upper Lateral Cartilage",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Paired middle-vault cartilages fused to the dorsal septum; their caudal scroll overlaps the lower lateral cartilage and the internal nasal valve angle.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "sesamoid-cartilage",
+      "label": "Sesamoid Cartilage",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Small accessory cartilages within the fibrofatty tissue lateral to the lower lateral cartilage along the alar margin.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "keystone-area",
+      "label": "Keystone Area",
+      "type": "concept",
+      "subspecialty": "rhinology",
+      "detail": "Bony-cartilaginous junction where the caudal nasal bones overlap the cephalic upper lateral cartilages and dorsal septum; critical dorsal support in rhinoplasty.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "nasal-sinus",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "perpendicular-plate-of-ethmoid",
+      "label": "Perpendicular Plate of Ethmoid",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Descending midline ethmoid plate forming the superior bony nasal septum, continuous with the septal cartilage and vomer.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "nasal-sinus",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "vomer",
+      "label": "Vomer",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Midline bone forming the posteroinferior bony nasal septum; articulates with the ethmoid perpendicular plate, sphenoid, maxilla and palatine crests.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "nasal-sinus",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "superior-turbinate",
+      "label": "Superior Turbinate",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Smallest ethmoid turbinate; the sphenoethmoidal recess and posterior ethmoid cells drain in relation to it.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "ethmoid-bulla",
+      "label": "Ethmoid Bulla",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Largest, most constant anterior ethmoid air cell bulging into the middle meatus; forms the posterior boundary of the hiatus semilunaris and ostiomeatal complex.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "basal-lamella",
+      "label": "Basal Lamella",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Coronal bony attachment of the middle turbinate to the lamina papyracea; the surgical boundary separating anterior from posterior ethmoid cells.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "agger-nasi",
+      "label": "Agger Nasi Cell",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Most anterior ethmoid air cell anterior to the middle turbinate attachment; a key landmark for the frontal recess and frontal sinus drainage.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "nasal-sinus",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "ethmoid-bone",
+      "label": "Ethmoid Bone",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Central bone contributing the cribriform plate, perpendicular plate, lamina papyracea and ethmoid air cells with the middle and superior turbinates.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "nasal-sinus",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "right-thyroid-lamina",
+      "label": "Right Thyroid Lamina",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Right quadrilateral plate of the thyroid cartilage; fuses anteriorly with the left lamina at the laryngeal prominence.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "left-thyroid-lamina",
+      "label": "Left Thyroid Lamina",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Left quadrilateral plate of the thyroid cartilage; fuses anteriorly with the right lamina at the laryngeal prominence.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "thyroid-superior-cornu",
+      "label": "Superior Cornu of Thyroid Cartilage",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Upper horn of the thyroid lamina; connected to the greater cornu of the hyoid by the lateral thyrohyoid ligament.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "superior thyroid horn"
+      ],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "thyroid-inferior-cornu",
+      "label": "Inferior Cornu of Thyroid Cartilage",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Lower horn of the thyroid lamina; its medial facet articulates with the cricoid to form the cricothyroid joint.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "inferior thyroid horn"
+      ],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "laryngeal-prominence",
+      "label": "Laryngeal Prominence",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Anterior midline fusion of the thyroid laminae ('Adam's apple'); anterior commissure lies on its inner surface.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Adam's apple"
+      ],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "oblique-line",
+      "label": "Oblique Line of Thyroid Cartilage",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Ridge on the outer thyroid lamina giving attachment to the sternothyroid, thyrohyoid, and inferior pharyngeal constrictor muscles.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "cricoid-arch",
+      "label": "Cricoid Arch",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Narrow anterior portion of the signet-ring cricoid cartilage; gives origin to the cricothyroid and lateral cricoarytenoid muscles.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "cricoid-lamina",
+      "label": "Cricoid Lamina",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Broad posterior plate of the cricoid; bears the cricoarytenoid facets superiorly and gives origin to the posterior cricoarytenoid muscle.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "vocal-process",
+      "label": "Vocal Process of Arytenoid",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Anterior projection of the arytenoid that anchors the posterior end of the vocal ligament; a key landmark for medialization and injection.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "vocal-fold-paralysis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "muscular-process",
+      "label": "Muscular Process of Arytenoid",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Lateral projection of the arytenoid; insertion of the posterior and lateral cricoarytenoid muscles that rotate the arytenoid.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "arytenoid-apex",
+      "label": "Apex of Arytenoid",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Superior tip of the arytenoid cartilage; articulates with the corniculate cartilage and lies within the aryepiglottic fold.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "petiole",
+      "label": "Petiole of Epiglottis",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Narrow inferior stalk of the epiglottis attached to the inner thyroid cartilage by the thyroepiglottic ligament.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "corniculate-cartilage",
+      "label": "Corniculate Cartilage",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Small paired elastic cartilage (of Santorini) sitting on the arytenoid apex within the aryepiglottic fold.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "cartilage of Santorini"
+      ],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "cuneiform-cartilage",
+      "label": "Cuneiform Cartilage",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Small paired elastic cartilage (of Wrisberg) within the aryepiglottic fold, anterolateral to the corniculate, providing support.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "cartilage of Wrisberg"
+      ],
+      "abbrev": null,
+      "structure": "cartilage",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "vocalis-muscle",
+      "label": "Vocalis Muscle",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Medial deep fibers of the thyroarytenoid lying against the vocal ligament; fine-tunes vocal fold tension and pitch.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "benign-vocal-fold-lesions"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "thyroepiglottic-muscle",
+      "label": "Thyroepiglottic Muscle",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Superolateral thyroarytenoid fibers running to the epiglottis; widens the laryngeal inlet.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "aryepiglottic-muscle",
+      "label": "Aryepiglottic Muscle",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Oblique interarytenoid fibers continuing into the aryepiglottic fold; acts as a sphincter narrowing the laryngeal inlet during swallowing.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "buccopharyngeal-fascia",
+      "label": "Buccopharyngeal Fascia",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Posterior extension of the pretracheal (visceral) fascia covering the constrictor muscles and buccinator; forms the anterior wall of the retropharyngeal space and the medial wall of the parapharyngeal space.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "buccopharyngeal layer"
+      ],
+      "abbrev": null,
+      "structure": "fascia",
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "visceral-space",
+      "label": "Visceral (Pretracheal) Space",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Midline compartment enclosed by the pretracheal/visceral fascia containing the thyroid gland, trachea, and esophagus; infection can descend to the anterior superior mediastinum.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "pretracheal space",
+        "anterior visceral space"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "carotid-space",
+      "label": "Carotid Space",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Space defined by the carotid sheath (the 'Lincoln's highway' of the neck) spanning skull base to mediastinum; contains the carotid artery, internal jugular vein, and vagus nerve.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "Lincoln's highway"
+      ],
+      "abbrev": null,
+      "structure": "space",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "mylohyoid-muscle",
+      "label": "Mylohyoid Muscle",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Suprahyoid muscle forming the muscular floor of the mouth (oral diaphragm); elevates the hyoid and floor of mouth in swallowing. Its free posterior border separates the sublingual and submandibular spaces.",
+      "sources": [
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "geniohyoid-muscle",
+      "label": "Geniohyoid Muscle",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Suprahyoid muscle from the mental spine of the mandible to the hyoid; elevates and draws the hyoid anteriorly, widening the pharynx during swallowing.",
+      "sources": [
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "stylohyoid-muscle",
+      "label": "Stylohyoid Muscle",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Suprahyoid muscle from the styloid process to the hyoid; elevates and retracts the hyoid. Innervated by the facial nerve.",
+      "sources": [
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "digastric-anterior-belly",
+      "label": "Digastric Muscle (Anterior Belly)",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Suprahyoid; from the digastric fossa of the mandible to the intermediate tendon slung on the hyoid. Elevates the hyoid and depresses the mandible; innervated by the mylohyoid branch of V3.",
+      "sources": [
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "digastric-posterior-belly",
+      "label": "Digastric Muscle (Posterior Belly)",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Suprahyoid; from the mastoid notch to the intermediate tendon on the hyoid. Elevates and retracts the hyoid; key surgical landmark overlying the retromandibular structures. Innervated by the facial nerve.",
+      "sources": [
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "sternohyoid-muscle",
+      "label": "Sternohyoid Muscle",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Infrahyoid strap muscle from the manubrium to the hyoid; depresses the hyoid after swallowing. Innervated by the ansa cervicalis (C1-C3).",
+      "sources": [
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "strap muscle"
+      ],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "sternothyroid-muscle",
+      "label": "Sternothyroid Muscle",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Infrahyoid strap muscle from the manubrium to the oblique line of the thyroid cartilage; depresses the larynx. Innervated by the ansa cervicalis.",
+      "sources": [
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "strap muscle"
+      ],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "thyrohyoid-muscle",
+      "label": "Thyrohyoid Muscle",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Infrahyoid strap from the thyroid cartilage to the hyoid; depresses the hyoid or elevates the larynx when the hyoid is fixed. Innervated by C1 fibers travelling with the hypoglossal nerve.",
+      "sources": [
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "strap muscle"
+      ],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "omohyoid-muscle",
+      "label": "Omohyoid Muscle",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Two-bellied infrahyoid strap from the scapula to the hyoid, tethered by a fascial sling to the clavicle; depresses the hyoid and is a surgical landmark dividing neck level III/IV. Innervated by the ansa cervicalis.",
+      "sources": [
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "strap muscle"
+      ],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "cervical-vertebra",
+      "label": "Cervical Vertebra",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "One of seven cervical vertebrae (C1-C7); characterized by transverse foramina transmitting the vertebral vessels. The vertebral bodies and anterior longitudinal ligament form the posterior floor of the prevertebral space.",
+      "sources": [
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "C-spine vertebra"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "cervical-spine-hyoid",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "atlas-c1",
+      "label": "Atlas (C1)",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "First cervical vertebra; a ring lacking a body or spinous process. Articulates superiorly with the occipital condyles (atlanto-occipital, nodding) and inferiorly/around the dens with C2 (atlanto-axial, rotation).",
+      "sources": [
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "C1"
+      ],
+      "abbrev": "C1",
+      "structure": "bone",
+      "region": "cervical-spine-hyoid",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "axis-c2",
+      "label": "Axis (C2)",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Second cervical vertebra bearing the odontoid process (dens), the pivot around which the atlas and head rotate at the median atlanto-axial joint.",
+      "sources": [
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "C2",
+        "epistropheus"
+      ],
+      "abbrev": "C2",
+      "structure": "bone",
+      "region": "cervical-spine-hyoid",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "transverse-process",
+      "label": "Transverse Process (Cervical)",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Lateral bony process of a cervical vertebra containing the transverse foramen; anterior tubercle of C6 (carotid tubercle of Chassaignac) is a compression landmark for the common carotid artery.",
+      "sources": [
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "cervical-spine-hyoid",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "transverse-foramen",
+      "label": "Transverse Foramen (Foramen Transversarium)",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Foramen in the cervical transverse process transmitting the vertebral artery and vein (artery typically enters at C6 and ascends to C1). A defining feature of cervical vertebrae.",
+      "sources": [
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "foramen transversarium"
+      ],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "cervical-spine-hyoid",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "vertebral-artery",
+      "label": "Vertebral Artery",
+      "type": "vessel",
+      "subspecialty": "fundamentals",
+      "detail": "First branch of the subclavian artery; ascends through the cervical transverse foramina (C6 up to C1), enters the foramen magnum, and joins to form the basilar artery. At risk in prevertebral and lateral neck dissection.",
+      "sources": [
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "cervical-spine-hyoid",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "medial-pterygoid-plate",
+      "label": "Medial Pterygoid Plate",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Thin vertical plate of the sphenoid bone; its inferior tip curves laterally as the pterygoid hamulus, around which tensor veli palatini tendon hooks.",
+      "sources": [
+        "Gray's Anatomy",
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "medial pterygoid lamina"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "pterygoid-hamulus",
+      "label": "Pterygoid Hamulus",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Hook-shaped inferior projection of the medial pterygoid plate; the tensor veli palatini tendon turns around it, and the pterygomandibular raphe attaches superiorly here.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "hamulus"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "lateral-pterygoid-plate",
+      "label": "Lateral Pterygoid Plate",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Broader plate of the sphenoid; its lateral and medial surfaces give origin to the lateral and medial pterygoid muscles respectively.",
+      "sources": [
+        "Gray's Anatomy",
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "lateral pterygoid lamina"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "buccinator",
+      "label": "Buccinator Muscle",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Muscle of the cheek arising in part from the pterygomandibular raphe; compresses the cheek against the teeth during mastication.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "superior-pharyngeal-constrictor",
+      "label": "Superior Pharyngeal Constrictor",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Uppermost constrictor arising from the pterygoid hamulus, pterygomandibular raphe, and mandibular mylohyoid line; forms the lateral and posterior wall of the oropharynx.",
+      "sources": [
+        "Gray's Anatomy",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "middle-pharyngeal-constrictor",
+      "label": "Middle Pharyngeal Constrictor",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Arises from the greater and lesser cornua of the hyoid bone and the stylohyoid ligament; overlaps the superior constrictor externally.",
+      "sources": [
+        "Gray's Anatomy",
+        "Moore Clinically Oriented Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "inferior-pharyngeal-constrictor",
+      "label": "Inferior Pharyngeal Constrictor",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Lowest constrictor with thyropharyngeus (from the thyroid cartilage oblique line) and cricopharyngeus (from the cricoid cartilage) parts; the Killian dehiscence between them is the site of Zenker diverticulum.",
+      "sources": [
+        "Gray's Anatomy",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "cricopharyngeus",
+      "label": "Cricopharyngeus Muscle",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Circular lower part of the inferior constrictor arising from the cricoid cartilage; functions as the upper esophageal sphincter (UES) and is the muscle divided in cricopharyngeal myotomy.",
+      "sources": [
+        "Cummings Otolaryngology",
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "upper esophageal sphincter"
+      ],
+      "abbrev": "UES",
+      "structure": "muscle",
+      "region": "oral-pharynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "palatine-process-of-maxilla",
+      "label": "Palatine Process of Maxilla",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Horizontal shelf of the maxilla forming the anterior three-quarters of the hard palate; meets its fellow at the median palatine suture.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "horizontal-plate-of-palatine",
+      "label": "Horizontal Plate of Palatine Bone",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Forms the posterior quarter of the hard palate; its posterior free border gives attachment to the palatine aponeurosis of the soft palate.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "horizontal plate of palatine"
+      ],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "hard-palate",
+      "label": "Hard Palate",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Bony roof of the mouth formed by the palatine processes of the maxillae and horizontal plates of the palatine bones; separates the oral and nasal cavities.",
+      "sources": [
+        "Gray's Anatomy",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "oral-pharynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "incisive-foramen",
+      "label": "Incisive Foramen",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Midline opening behind the central incisors transmitting the nasopalatine nerve and sphenopalatine vessels to the anterior hard palate.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "incisive canal"
+      ],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "oral-pharynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "greater-palatine-foramen",
+      "label": "Greater Palatine Foramen",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Opening at the posterolateral hard palate transmitting the greater palatine nerve and vessels that supply the mucosa of the hard palate.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "lesser-palatine-foramen",
+      "label": "Lesser Palatine Foramen",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Small opening posterior to the greater palatine foramen transmitting the lesser palatine nerves and vessels to the soft palate and tonsil.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "palatine-aponeurosis",
+      "label": "Palatine Aponeurosis",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Fibrous sheet, the expanded tensor veli palatini tendon, attached to the posterior border of the hard palate; forms the fibrous skeleton of the soft palate into which the other palatal muscles insert.",
+      "sources": [
+        "Gray's Anatomy",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "aponeurosis of soft palate"
+      ],
+      "abbrev": null,
+      "structure": "membrane",
+      "region": "oral-pharynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "palatoglossal-arch",
+      "label": "Palatoglossal Arch (Anterior Tonsillar Pillar)",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Anterior tonsillar pillar overlying the palatoglossus muscle; forms the anterior boundary of the tonsillar fossa and the oropharyngeal isthmus.",
+      "sources": [
+        "Gray's Anatomy",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "anterior tonsillar pillar",
+        "palatoglossus"
+      ],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "palatopharyngeal-arch",
+      "label": "Palatopharyngeal Arch (Posterior Tonsillar Pillar)",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Posterior tonsillar pillar overlying the palatopharyngeus muscle; forms the posterior boundary of the tonsillar fossa.",
+      "sources": [
+        "Gray's Anatomy",
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [
+        "posterior tonsillar pillar",
+        "palatopharyngeus"
+      ],
+      "abbrev": null,
+      "structure": "muscle",
+      "region": "oral-pharynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "sphenoid",
+      "label": "Sphenoid Bone",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Central keystone of the cranial base; articulates with all other cranial bones. Forms much of the middle cranial fossa.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "ethmoid",
+      "label": "Ethmoid Bone",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Midline bone forming part of the anterior cranial base, nasal roof and medial orbital walls.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "occipital-bone",
+      "label": "Occipital Bone",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Forms the posterior cranial fossa and encircles the foramen magnum.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "parietal-bone",
+      "label": "Parietal Bone",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Paired calvarial bones contributing to the lateral skull vault.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "greater-wing",
+      "label": "Greater Wing of Sphenoid",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Forms the anterior middle cranial fossa floor; transmits foramina rotundum, ovale and spinosum.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "lesser-wing",
+      "label": "Lesser Wing of Sphenoid",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Forms the posterior anterior-cranial-fossa margin and the anterior clinoid process; its root bounds the optic canal.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "body-of-sphenoid",
+      "label": "Body of Sphenoid",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Central cube containing the sphenoid sinus and supporting the sella turcica.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "pterygoid-process",
+      "label": "Pterygoid Process",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Descends from the sphenoid body/greater wing junction; contains medial and lateral pterygoid plates.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "clivus",
+      "label": "Clivus",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Sloping midline surface formed by the fused sphenoid body and basiocciput, posterior to the dorsum sellae.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "crista-galli",
+      "label": "Crista Galli",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Midline ethmoid ridge projecting superiorly for attachment of the falx cerebri.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "perpendicular-plate",
+      "label": "Perpendicular Plate of Ethmoid",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Forms the superior bony nasal septum.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "ethmoid-labyrinth",
+      "label": "Ethmoid Labyrinth",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Paired lateral masses containing the ethmoid air cells, bounded superiorly by the fovea ethmoidalis.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "basiocciput",
+      "label": "Basiocciput",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Basilar part of the occipital bone forming the lower clivus and fusing with the sphenoid.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "occipital-condyle",
+      "label": "Occipital Condyle",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Paired condyles flanking the foramen magnum that articulate with the atlas.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "squamous-occipital",
+      "label": "Squamous Occipital",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Expanded plate posterior to the foramen magnum forming the posterior fossa wall.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "planum-sphenoidale",
+      "label": "Planum Sphenoidale",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Flat surface of the sphenoid between the ethmoid and the tuberculum sellae.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "tuberculum-sellae",
+      "label": "Tuberculum Sellae",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Bony ridge marking the anterior boundary of the sella turcica.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "dorsum-sellae",
+      "label": "Dorsum Sellae",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Posterior wall of the sella turcica, continuous inferiorly with the clivus.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "foramen-cecum",
+      "label": "Foramen Cecum",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Small midline pit between the frontal bone and crista galli; may transmit an emissary vein.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "jugular-tubercle",
+      "label": "Jugular Tubercle",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Occipital elevation superomedial to the hypoglossal canal and jugular foramen.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "sphenooccipital-synchondrosis",
+      "label": "Spheno-occipital Synchondrosis",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Cartilaginous junction between the sphenoid body and basiocciput; fuses in late adolescence and drives clival growth.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "sphenoethmoidal-junction",
+      "label": "Sphenoethmoidal Junction",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Articulation between the sphenoid and the posterior ethmoid.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "sphenofrontal-suture",
+      "label": "Sphenofrontal Suture",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Suture between the lesser/greater wing of the sphenoid and the frontal bone.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "sphenopetrosal-fissure",
+      "label": "Sphenopetrosal Fissure",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Fissure between the greater wing of the sphenoid and the petrous temporal bone.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
+    },
+    {
+      "id": "petrooccipital-fissure",
+      "label": "Petro-occipital Fissure",
+      "type": "anatomy",
+      "subspecialty": "rhinology",
+      "detail": "Fissure between the petrous temporal bone and the basiocciput, ending at the jugular foramen.",
+      "sources": [
+        "Gray's Anatomy"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": false
     }
   ],
   "edges": [
@@ -19411,6 +23226,1743 @@
       "target": "vagus-nerve",
       "type": "forms",
       "label": "contents"
+    },
+    {
+      "source": "helix",
+      "target": "auricular-cartilage",
+      "type": "part_of"
+    },
+    {
+      "source": "antihelix",
+      "target": "auricular-cartilage",
+      "type": "part_of"
+    },
+    {
+      "source": "tragus",
+      "target": "auricular-cartilage",
+      "type": "part_of",
+      "direction": "anterior"
+    },
+    {
+      "source": "antitragus",
+      "target": "auricular-cartilage",
+      "type": "part_of"
+    },
+    {
+      "source": "concha",
+      "target": "auricular-cartilage",
+      "type": "part_of"
+    },
+    {
+      "source": "scaphoid-fossa",
+      "target": "auricular-cartilage",
+      "type": "part_of"
+    },
+    {
+      "source": "triangular-fossa",
+      "target": "auricular-cartilage",
+      "type": "part_of"
+    },
+    {
+      "source": "superior-crus",
+      "target": "antihelix",
+      "type": "part_of",
+      "direction": "superior"
+    },
+    {
+      "source": "inferior-crus",
+      "target": "antihelix",
+      "type": "part_of",
+      "direction": "inferior"
+    },
+    {
+      "source": "lobule",
+      "target": "auricular-cartilage",
+      "type": "continuous_with",
+      "label": "fibrofatty, no cartilage",
+      "direction": "inferior"
+    },
+    {
+      "source": "helix",
+      "target": "scaphoid-fossa",
+      "type": "continuous_with"
+    },
+    {
+      "source": "scaphoid-fossa",
+      "target": "antihelix",
+      "type": "continuous_with"
+    },
+    {
+      "source": "superior-crus",
+      "target": "triangular-fossa",
+      "type": "continuous_with"
+    },
+    {
+      "source": "inferior-crus",
+      "target": "triangular-fossa",
+      "type": "continuous_with"
+    },
+    {
+      "source": "antihelix",
+      "target": "antitragus",
+      "type": "continuous_with",
+      "direction": "inferior"
+    },
+    {
+      "source": "antitragus",
+      "target": "tragus",
+      "type": "continuous_with",
+      "label": "intertragic notch"
+    },
+    {
+      "source": "helix",
+      "target": "lobule",
+      "type": "continuous_with",
+      "direction": "inferior"
+    },
+    {
+      "source": "lobule",
+      "target": "antitragus",
+      "type": "continuous_with",
+      "direction": "superior"
+    },
+    {
+      "source": "concha",
+      "target": "external-auditory-canal",
+      "type": "continuous_with",
+      "direction": "medial"
+    },
+    {
+      "source": "squamous-part",
+      "target": "temporal-bone",
+      "type": "part_of"
+    },
+    {
+      "source": "petrous-part",
+      "target": "temporal-bone",
+      "type": "part_of"
+    },
+    {
+      "source": "mastoid-part",
+      "target": "temporal-bone",
+      "type": "part_of",
+      "direction": "posterior"
+    },
+    {
+      "source": "tympanic-part",
+      "target": "temporal-bone",
+      "type": "part_of"
+    },
+    {
+      "source": "styloid-process",
+      "target": "temporal-bone",
+      "type": "part_of",
+      "direction": "inferior"
+    },
+    {
+      "source": "mastoid",
+      "target": "mastoid-part",
+      "type": "part_of"
+    },
+    {
+      "source": "tympanic-part",
+      "target": "external-auditory-canal",
+      "type": "forms",
+      "label": "anterior wall and floor"
+    },
+    {
+      "source": "squamous-part",
+      "target": "external-auditory-canal",
+      "type": "forms",
+      "label": "roof",
+      "direction": "superior"
+    },
+    {
+      "source": "otic-capsule",
+      "target": "petrous-part",
+      "type": "part_of"
+    },
+    {
+      "source": "cochlea",
+      "target": "otic-capsule",
+      "type": "contained_in"
+    },
+    {
+      "source": "vestibule",
+      "target": "otic-capsule",
+      "type": "contained_in"
+    },
+    {
+      "source": "semicircular-canals",
+      "target": "otic-capsule",
+      "type": "contained_in"
+    },
+    {
+      "source": "internal-auditory-canal",
+      "target": "petrous-part",
+      "type": "contained_in"
+    },
+    {
+      "source": "tympanosquamous-fissure",
+      "target": "squamous-part",
+      "type": "articulates_with"
+    },
+    {
+      "source": "tympanosquamous-fissure",
+      "target": "tympanic-part",
+      "type": "articulates_with"
+    },
+    {
+      "source": "petrotympanic-fissure",
+      "target": "petrous-part",
+      "type": "articulates_with"
+    },
+    {
+      "source": "petrotympanic-fissure",
+      "target": "tympanic-part",
+      "type": "articulates_with"
+    },
+    {
+      "source": "petrotympanic-fissure",
+      "target": "chorda-tympani",
+      "type": "transmits",
+      "label": "exit from middle ear",
+      "direction": "anterior"
+    },
+    {
+      "source": "petrotympanic-fissure",
+      "target": "anterior-malleal-ligament",
+      "type": "transmits"
+    },
+    {
+      "source": "petrosquamous-suture",
+      "target": "petrous-part",
+      "type": "articulates_with"
+    },
+    {
+      "source": "petrosquamous-suture",
+      "target": "squamous-part",
+      "type": "articulates_with"
+    },
+    {
+      "source": "tensor-tympani",
+      "target": "malleus",
+      "type": "attaches_to",
+      "label": "neck of malleus",
+      "direction": "medial"
+    },
+    {
+      "source": "stapedius-muscle",
+      "target": "stapes",
+      "type": "attaches_to",
+      "label": "neck of stapes",
+      "direction": "posterior"
+    },
+    {
+      "source": "maxilla-frontal-process",
+      "target": "maxilla",
+      "type": "part_of",
+      "direction": "superior"
+    },
+    {
+      "source": "maxilla-zygomatic-process",
+      "target": "maxilla",
+      "type": "part_of",
+      "direction": "lateral"
+    },
+    {
+      "source": "maxilla-alveolar-process",
+      "target": "maxilla",
+      "type": "part_of",
+      "direction": "inferior"
+    },
+    {
+      "source": "maxilla-palatine-process",
+      "target": "maxilla",
+      "type": "part_of",
+      "direction": "medial"
+    },
+    {
+      "source": "mandible-condyle",
+      "target": "mandible",
+      "type": "part_of",
+      "direction": "superior"
+    },
+    {
+      "source": "mandible-coronoid-process",
+      "target": "mandible",
+      "type": "part_of",
+      "direction": "superior"
+    },
+    {
+      "source": "mandible-ramus",
+      "target": "mandible",
+      "type": "part_of",
+      "direction": "posterior"
+    },
+    {
+      "source": "mandible-angle",
+      "target": "mandible",
+      "type": "part_of"
+    },
+    {
+      "source": "mandible-body",
+      "target": "mandible",
+      "type": "part_of",
+      "direction": "anterior"
+    },
+    {
+      "source": "mandible-symphysis",
+      "target": "mandible",
+      "type": "part_of",
+      "direction": "anterior"
+    },
+    {
+      "source": "mandible-alveolar-ridge",
+      "target": "mandible",
+      "type": "part_of",
+      "direction": "superior"
+    },
+    {
+      "source": "glabella",
+      "target": "frontal-bone",
+      "type": "part_of",
+      "direction": "anterior"
+    },
+    {
+      "source": "supraorbital-rim",
+      "target": "frontal-bone",
+      "type": "part_of",
+      "direction": "superior"
+    },
+    {
+      "source": "palatine-bone-horizontal-plate",
+      "target": "palatine-bone",
+      "type": "part_of"
+    },
+    {
+      "source": "palatine-bone-perpendicular-plate",
+      "target": "palatine-bone",
+      "type": "part_of"
+    },
+    {
+      "source": "zygoma",
+      "target": "zygomaticomaxillary-complex",
+      "type": "part_of"
+    },
+    {
+      "source": "maxilla",
+      "target": "zygomaticomaxillary-complex",
+      "type": "part_of"
+    },
+    {
+      "source": "maxilla",
+      "target": "orbital-floor",
+      "type": "forms",
+      "direction": "medial"
+    },
+    {
+      "source": "zygoma",
+      "target": "orbital-floor",
+      "type": "forms",
+      "direction": "lateral"
+    },
+    {
+      "source": "palatine-bone-horizontal-plate",
+      "target": "maxilla-palatine-process",
+      "type": "continuous_with",
+      "direction": "anterior"
+    },
+    {
+      "source": "frontozygomatic-suture",
+      "target": "frontal-bone",
+      "type": "articulates_with",
+      "direction": "superior"
+    },
+    {
+      "source": "frontozygomatic-suture",
+      "target": "zygoma",
+      "type": "articulates_with",
+      "direction": "inferior"
+    },
+    {
+      "source": "zygomaticomaxillary-suture",
+      "target": "zygoma",
+      "type": "articulates_with",
+      "direction": "superior"
+    },
+    {
+      "source": "zygomaticomaxillary-suture",
+      "target": "maxilla",
+      "type": "articulates_with",
+      "direction": "inferior"
+    },
+    {
+      "source": "zygomaticotemporal-suture",
+      "target": "zygoma",
+      "type": "articulates_with",
+      "direction": "anterior"
+    },
+    {
+      "source": "zygomaticotemporal-suture",
+      "target": "temporal-bone",
+      "type": "articulates_with",
+      "direction": "posterior"
+    },
+    {
+      "source": "nasomaxillary-suture",
+      "target": "nasal-bone",
+      "type": "articulates_with",
+      "direction": "medial"
+    },
+    {
+      "source": "nasomaxillary-suture",
+      "target": "maxilla-frontal-process",
+      "type": "articulates_with",
+      "direction": "lateral"
+    },
+    {
+      "source": "frontonasal-suture",
+      "target": "frontal-bone",
+      "type": "articulates_with",
+      "direction": "superior"
+    },
+    {
+      "source": "frontonasal-suture",
+      "target": "nasal-bone",
+      "type": "articulates_with",
+      "direction": "inferior"
+    },
+    {
+      "source": "frontomaxillary-suture",
+      "target": "frontal-bone",
+      "type": "articulates_with",
+      "direction": "superior"
+    },
+    {
+      "source": "frontomaxillary-suture",
+      "target": "maxilla-frontal-process",
+      "type": "articulates_with",
+      "direction": "inferior"
+    },
+    {
+      "source": "intermaxillary-suture",
+      "target": "maxilla",
+      "type": "articulates_with"
+    },
+    {
+      "source": "internasal-suture",
+      "target": "nasal-bone",
+      "type": "articulates_with"
+    },
+    {
+      "source": "pterygomaxillary-fissure",
+      "target": "maxilla",
+      "type": "articulates_with",
+      "direction": "anterior"
+    },
+    {
+      "source": "pterygomaxillary-fissure",
+      "target": "sphenoid",
+      "type": "articulates_with",
+      "direction": "posterior"
+    },
+    {
+      "source": "nasomaxillary-buttress",
+      "target": "facial-buttresses",
+      "type": "part_of"
+    },
+    {
+      "source": "nasomaxillary-buttress",
+      "target": "maxilla-frontal-process",
+      "type": "forms"
+    },
+    {
+      "source": "nasomaxillary-buttress",
+      "target": "frontal-bone",
+      "type": "attaches_to",
+      "direction": "superior"
+    },
+    {
+      "source": "zygomaticomaxillary-buttress",
+      "target": "facial-buttresses",
+      "type": "part_of"
+    },
+    {
+      "source": "zygomaticomaxillary-buttress",
+      "target": "maxilla-zygomatic-process",
+      "type": "forms"
+    },
+    {
+      "source": "zygomaticomaxillary-buttress",
+      "target": "zygoma",
+      "type": "forms",
+      "direction": "superior"
+    },
+    {
+      "source": "pterygomaxillary-buttress",
+      "target": "facial-buttresses",
+      "type": "part_of"
+    },
+    {
+      "source": "pterygomaxillary-buttress",
+      "target": "pterygomaxillary-fissure",
+      "type": "attaches_to",
+      "direction": "posterior"
+    },
+    {
+      "source": "frontal-bar-buttress",
+      "target": "facial-buttresses",
+      "type": "part_of"
+    },
+    {
+      "source": "frontal-bar-buttress",
+      "target": "frontal-bone",
+      "type": "forms"
+    },
+    {
+      "source": "frontal-bar-buttress",
+      "target": "supraorbital-rim",
+      "type": "forms"
+    },
+    {
+      "source": "infraorbital-buttress",
+      "target": "facial-buttresses",
+      "type": "part_of"
+    },
+    {
+      "source": "infraorbital-buttress",
+      "target": "orbital-floor",
+      "type": "attaches_to",
+      "direction": "inferior"
+    },
+    {
+      "source": "palatal-buttress",
+      "target": "facial-buttresses",
+      "type": "part_of"
+    },
+    {
+      "source": "palatal-buttress",
+      "target": "maxilla-palatine-process",
+      "type": "forms"
+    },
+    {
+      "source": "palatal-buttress",
+      "target": "palatine-bone-horizontal-plate",
+      "type": "forms",
+      "direction": "posterior"
+    },
+    {
+      "source": "temporomandibular-joint",
+      "target": "mandible-condyle",
+      "type": "articulates_with",
+      "direction": "inferior"
+    },
+    {
+      "source": "temporomandibular-joint",
+      "target": "glenoid-fossa",
+      "type": "articulates_with",
+      "direction": "superior"
+    },
+    {
+      "source": "mandible-condyle",
+      "target": "glenoid-fossa",
+      "type": "articulates_with",
+      "direction": "superior"
+    },
+    {
+      "source": "glenoid-fossa",
+      "target": "temporal-bone",
+      "type": "part_of"
+    },
+    {
+      "source": "articular-disc",
+      "target": "mandible-condyle",
+      "type": "attaches_to",
+      "direction": "superior"
+    },
+    {
+      "source": "nasal-bone",
+      "target": "frontal-bone",
+      "type": "articulates_with",
+      "direction": "superior"
+    },
+    {
+      "source": "nasal-bone",
+      "target": "maxilla-frontal-process",
+      "type": "articulates_with",
+      "direction": "lateral"
+    },
+    {
+      "source": "lacrimal-bone",
+      "target": "maxilla-frontal-process",
+      "type": "articulates_with",
+      "direction": "anterior"
+    },
+    {
+      "source": "lacrimal-bone",
+      "target": "nasolacrimal-duct",
+      "type": "forms",
+      "direction": "lateral"
+    },
+    {
+      "source": "inferior-turbinate",
+      "target": "maxilla",
+      "type": "attaches_to",
+      "direction": "lateral"
+    },
+    {
+      "source": "septal-cartilage",
+      "target": "perpendicular-plate-of-ethmoid",
+      "type": "continuous_with",
+      "direction": "posterior"
+    },
+    {
+      "source": "septal-cartilage",
+      "target": "vomer",
+      "type": "continuous_with",
+      "direction": "posterior"
+    },
+    {
+      "source": "perpendicular-plate-of-ethmoid",
+      "target": "vomer",
+      "type": "continuous_with",
+      "direction": "inferior"
+    },
+    {
+      "source": "septal-cartilage",
+      "target": "nasal-septum",
+      "type": "part_of"
+    },
+    {
+      "source": "perpendicular-plate-of-ethmoid",
+      "target": "nasal-septum",
+      "type": "part_of"
+    },
+    {
+      "source": "vomer",
+      "target": "nasal-septum",
+      "type": "part_of"
+    },
+    {
+      "source": "perpendicular-plate-of-ethmoid",
+      "target": "ethmoid-bone",
+      "type": "part_of"
+    },
+    {
+      "source": "upper-lateral-cartilage",
+      "target": "septal-cartilage",
+      "type": "continuous_with",
+      "direction": "medial"
+    },
+    {
+      "source": "upper-lateral-cartilage",
+      "target": "nasal-bone",
+      "type": "continuous_with",
+      "direction": "superior"
+    },
+    {
+      "source": "keystone-area",
+      "target": "nasal-bone",
+      "type": "bounded_by",
+      "direction": "superior"
+    },
+    {
+      "source": "keystone-area",
+      "target": "upper-lateral-cartilage",
+      "type": "bounded_by",
+      "direction": "inferior"
+    },
+    {
+      "source": "keystone-area",
+      "target": "septal-cartilage",
+      "type": "bounded_by",
+      "direction": "deep"
+    },
+    {
+      "source": "upper-lateral-cartilage",
+      "target": "lower-lateral-cartilage",
+      "type": "continuous_with",
+      "direction": "inferior"
+    },
+    {
+      "source": "sesamoid-cartilage",
+      "target": "lower-lateral-cartilage",
+      "type": "continuous_with",
+      "direction": "lateral"
+    },
+    {
+      "source": "ethmoid-bone",
+      "target": "ethmoid-sinus",
+      "type": "forms"
+    },
+    {
+      "source": "middle-turbinate",
+      "target": "ethmoid-bone",
+      "type": "part_of"
+    },
+    {
+      "source": "superior-turbinate",
+      "target": "ethmoid-bone",
+      "type": "part_of"
+    },
+    {
+      "source": "uncinate-process",
+      "target": "ethmoid-bone",
+      "type": "part_of"
+    },
+    {
+      "source": "ethmoid-bulla",
+      "target": "ethmoid-bone",
+      "type": "part_of"
+    },
+    {
+      "source": "agger-nasi",
+      "target": "ethmoid-bone",
+      "type": "part_of",
+      "direction": "anterior"
+    },
+    {
+      "source": "basal-lamella",
+      "target": "middle-turbinate",
+      "type": "part_of"
+    },
+    {
+      "source": "basal-lamella",
+      "target": "lamina-papyracea",
+      "type": "attaches_to",
+      "direction": "lateral"
+    },
+    {
+      "source": "ostiomeatal-complex",
+      "target": "uncinate-process",
+      "type": "bounded_by",
+      "direction": "anterior"
+    },
+    {
+      "source": "ostiomeatal-complex",
+      "target": "ethmoid-bulla",
+      "type": "bounded_by",
+      "direction": "posterior"
+    },
+    {
+      "source": "ostiomeatal-complex",
+      "target": "middle-turbinate",
+      "type": "bounded_by",
+      "direction": "medial"
+    },
+    {
+      "source": "agger-nasi",
+      "target": "frontal-sinus",
+      "type": "landmark_for",
+      "direction": "anterior"
+    },
+    {
+      "source": "superior-turbinate",
+      "target": "sphenopalatine-foramen",
+      "type": "landmark_for",
+      "direction": "posterior"
+    },
+    {
+      "source": "sphenopalatine-foramen",
+      "target": "palatine-bone-perpendicular-plate",
+      "type": "bounded_by"
+    },
+    {
+      "source": "smas",
+      "target": "zygoma",
+      "type": "attaches_to",
+      "direction": "superficial"
+    },
+    {
+      "source": "right-thyroid-lamina",
+      "target": "thyroid-cartilage",
+      "type": "part_of",
+      "direction": "lateral"
+    },
+    {
+      "source": "left-thyroid-lamina",
+      "target": "thyroid-cartilage",
+      "type": "part_of",
+      "direction": "lateral"
+    },
+    {
+      "source": "thyroid-superior-cornu",
+      "target": "thyroid-cartilage",
+      "type": "part_of",
+      "direction": "superior"
+    },
+    {
+      "source": "thyroid-inferior-cornu",
+      "target": "thyroid-cartilage",
+      "type": "part_of",
+      "direction": "inferior"
+    },
+    {
+      "source": "laryngeal-prominence",
+      "target": "thyroid-cartilage",
+      "type": "part_of",
+      "direction": "anterior"
+    },
+    {
+      "source": "oblique-line",
+      "target": "thyroid-cartilage",
+      "type": "part_of",
+      "direction": "lateral"
+    },
+    {
+      "source": "right-thyroid-lamina",
+      "target": "left-thyroid-lamina",
+      "type": "continuous_with",
+      "label": "fuse at prominence",
+      "direction": "anterior"
+    },
+    {
+      "source": "cricoid-arch",
+      "target": "cricoid-cartilage",
+      "type": "part_of",
+      "direction": "anterior"
+    },
+    {
+      "source": "cricoid-lamina",
+      "target": "cricoid-cartilage",
+      "type": "part_of",
+      "direction": "posterior"
+    },
+    {
+      "source": "vocal-process",
+      "target": "arytenoid-cartilage",
+      "type": "part_of",
+      "direction": "anterior"
+    },
+    {
+      "source": "muscular-process",
+      "target": "arytenoid-cartilage",
+      "type": "part_of",
+      "direction": "lateral"
+    },
+    {
+      "source": "arytenoid-apex",
+      "target": "arytenoid-cartilage",
+      "type": "part_of",
+      "direction": "superior"
+    },
+    {
+      "source": "petiole",
+      "target": "epiglottis",
+      "type": "part_of",
+      "direction": "inferior"
+    },
+    {
+      "source": "corniculate-cartilage",
+      "target": "arytenoid-apex",
+      "type": "articulates_with",
+      "direction": "superior"
+    },
+    {
+      "source": "cuneiform-cartilage",
+      "target": "quadrangular-membrane",
+      "type": "contained_in",
+      "label": "aryepiglottic fold"
+    },
+    {
+      "source": "cuneiform-cartilage",
+      "target": "corniculate-cartilage",
+      "type": "continuous_with",
+      "direction": "anterior"
+    },
+    {
+      "source": "cricothyroid-joint",
+      "target": "thyroid-inferior-cornu",
+      "type": "articulates_with",
+      "direction": "inferior"
+    },
+    {
+      "source": "cricothyroid-joint",
+      "target": "cricoid-arch",
+      "type": "articulates_with",
+      "direction": "lateral"
+    },
+    {
+      "source": "cricoarytenoid-joint",
+      "target": "cricoid-lamina",
+      "type": "articulates_with",
+      "direction": "superior"
+    },
+    {
+      "source": "cricoarytenoid-joint",
+      "target": "muscular-process",
+      "type": "articulates_with",
+      "label": "arytenoid base"
+    },
+    {
+      "source": "thyroarytenoid-muscle",
+      "target": "vocal-process",
+      "type": "attaches_to",
+      "direction": "posterior"
+    },
+    {
+      "source": "vocalis-muscle",
+      "target": "vocal-process",
+      "type": "attaches_to",
+      "direction": "posterior"
+    },
+    {
+      "source": "vocalis-muscle",
+      "target": "thyroid-cartilage",
+      "type": "attaches_to",
+      "direction": "anterior"
+    },
+    {
+      "source": "vocalis-muscle",
+      "target": "thyroarytenoid-muscle",
+      "type": "part_of",
+      "direction": "medial"
+    },
+    {
+      "source": "vocalis-muscle",
+      "target": "vocal-ligament",
+      "type": "attaches_to",
+      "label": "tenses vocal fold"
+    },
+    {
+      "source": "lateral-cricoarytenoid-muscle",
+      "target": "muscular-process",
+      "type": "attaches_to",
+      "label": "adductor"
+    },
+    {
+      "source": "lateral-cricoarytenoid-muscle",
+      "target": "cricoid-arch",
+      "type": "attaches_to",
+      "direction": "anterior"
+    },
+    {
+      "source": "posterior-cricoarytenoid-muscle",
+      "target": "muscular-process",
+      "type": "attaches_to",
+      "label": "sole abductor"
+    },
+    {
+      "source": "posterior-cricoarytenoid-muscle",
+      "target": "cricoid-lamina",
+      "type": "attaches_to",
+      "direction": "posterior"
+    },
+    {
+      "source": "cricothyroid-muscle",
+      "target": "cricoid-arch",
+      "type": "attaches_to",
+      "direction": "anterior"
+    },
+    {
+      "source": "cricothyroid-muscle",
+      "target": "thyroid-inferior-cornu",
+      "type": "attaches_to",
+      "direction": "inferior"
+    },
+    {
+      "source": "interarytenoid-muscle",
+      "target": "arytenoid-apex",
+      "type": "attaches_to",
+      "label": "adductor"
+    },
+    {
+      "source": "thyroepiglottic-muscle",
+      "target": "thyroid-cartilage",
+      "type": "attaches_to",
+      "direction": "anterior"
+    },
+    {
+      "source": "thyroepiglottic-muscle",
+      "target": "epiglottis",
+      "type": "attaches_to",
+      "direction": "superior"
+    },
+    {
+      "source": "aryepiglottic-muscle",
+      "target": "arytenoid-apex",
+      "type": "attaches_to",
+      "direction": "posterior"
+    },
+    {
+      "source": "aryepiglottic-muscle",
+      "target": "epiglottis",
+      "type": "attaches_to",
+      "direction": "anterior"
+    },
+    {
+      "source": "vocal-ligament",
+      "target": "vocal-process",
+      "type": "attaches_to",
+      "direction": "posterior"
+    },
+    {
+      "source": "conus-elasticus",
+      "target": "cricothyroid-membrane",
+      "type": "part_of",
+      "label": "cricothyroid ligament"
+    },
+    {
+      "source": "cricothyroid-membrane",
+      "target": "vocal-ligament",
+      "type": "continuous_with",
+      "direction": "superior"
+    },
+    {
+      "source": "quadrangular-membrane",
+      "target": "aryepiglottic-muscle",
+      "type": "continuous_with",
+      "label": "aryepiglottic fold",
+      "direction": "superior"
+    },
+    {
+      "source": "quadrangular-membrane",
+      "target": "vestibular-ligament",
+      "type": "continuous_with",
+      "direction": "inferior"
+    },
+    {
+      "source": "thyrohyoid-membrane",
+      "target": "thyroid-superior-cornu",
+      "type": "attaches_to",
+      "direction": "superior"
+    },
+    {
+      "source": "thyrohyoid-membrane",
+      "target": "hyoid-bone",
+      "type": "suspends",
+      "label": "suspends larynx",
+      "direction": "superior"
+    },
+    {
+      "source": "buccopharyngeal-fascia",
+      "target": "pretracheal-visceral-fascia",
+      "type": "part_of",
+      "label": "posterior part of visceral fascia",
+      "direction": "posterior"
+    },
+    {
+      "source": "buccopharyngeal-fascia",
+      "target": "pretracheal-visceral-fascia",
+      "type": "continuous_with"
+    },
+    {
+      "source": "parapharyngeal-space",
+      "target": "buccopharyngeal-fascia",
+      "type": "bounded_by",
+      "label": "medial wall",
+      "direction": "medial"
+    },
+    {
+      "source": "parapharyngeal-space",
+      "target": "prevertebral-fascia",
+      "type": "bounded_by",
+      "label": "posterior wall",
+      "direction": "posterior"
+    },
+    {
+      "source": "parapharyngeal-space",
+      "target": "carotid-sheath",
+      "type": "bounded_by",
+      "label": "posterolateral",
+      "direction": "posterior"
+    },
+    {
+      "source": "retropharyngeal-space",
+      "target": "buccopharyngeal-fascia",
+      "type": "bounded_by",
+      "label": "anterior wall",
+      "direction": "anterior"
+    },
+    {
+      "source": "retropharyngeal-space",
+      "target": "carotid-sheath",
+      "type": "bounded_by",
+      "label": "lateral wall",
+      "direction": "lateral"
+    },
+    {
+      "source": "prevertebral-space",
+      "target": "cervical-vertebra",
+      "type": "bounded_by",
+      "label": "posterior floor",
+      "direction": "posterior"
+    },
+    {
+      "source": "submandibular-space",
+      "target": "mylohyoid-muscle",
+      "type": "bounded_by",
+      "label": "roof (divides sublingual/submaxillary)",
+      "direction": "superior"
+    },
+    {
+      "source": "visceral-space",
+      "target": "pretracheal-visceral-fascia",
+      "type": "bounded_by",
+      "label": "anterior wall",
+      "direction": "anterior"
+    },
+    {
+      "source": "visceral-space",
+      "target": "buccopharyngeal-fascia",
+      "type": "bounded_by",
+      "label": "posterior wall",
+      "direction": "posterior"
+    },
+    {
+      "source": "thyroid-gland",
+      "target": "visceral-space",
+      "type": "contained_in"
+    },
+    {
+      "source": "carotid-space",
+      "target": "carotid-sheath",
+      "type": "bounded_by",
+      "label": "enclosed by sheath"
+    },
+    {
+      "source": "carotid-space",
+      "target": "internal-jugular-vein",
+      "type": "transmits"
+    },
+    {
+      "source": "carotid-space",
+      "target": "vagus-nerve",
+      "type": "transmits"
+    },
+    {
+      "source": "carotid-sheath",
+      "target": "internal-jugular-vein",
+      "type": "transmits"
+    },
+    {
+      "source": "carotid-sheath",
+      "target": "vagus-nerve",
+      "type": "transmits"
+    },
+    {
+      "source": "mylohyoid-muscle",
+      "target": "hyoid-bone",
+      "type": "attaches_to",
+      "label": "elevates hyoid",
+      "direction": "superior"
+    },
+    {
+      "source": "geniohyoid-muscle",
+      "target": "hyoid-bone",
+      "type": "attaches_to",
+      "label": "elevates hyoid",
+      "direction": "superior"
+    },
+    {
+      "source": "stylohyoid-muscle",
+      "target": "hyoid-bone",
+      "type": "attaches_to",
+      "label": "elevates hyoid",
+      "direction": "superior"
+    },
+    {
+      "source": "digastric-anterior-belly",
+      "target": "hyoid-bone",
+      "type": "attaches_to",
+      "label": "elevates hyoid",
+      "direction": "superior"
+    },
+    {
+      "source": "digastric-posterior-belly",
+      "target": "hyoid-bone",
+      "type": "attaches_to",
+      "label": "elevates hyoid",
+      "direction": "superior"
+    },
+    {
+      "source": "sternohyoid-muscle",
+      "target": "hyoid-bone",
+      "type": "attaches_to",
+      "label": "depresses hyoid",
+      "direction": "inferior"
+    },
+    {
+      "source": "thyrohyoid-muscle",
+      "target": "hyoid-bone",
+      "type": "attaches_to",
+      "label": "depresses hyoid",
+      "direction": "inferior"
+    },
+    {
+      "source": "omohyoid-muscle",
+      "target": "hyoid-bone",
+      "type": "attaches_to",
+      "label": "depresses hyoid",
+      "direction": "inferior"
+    },
+    {
+      "source": "sternothyroid-muscle",
+      "target": "thyroid-cartilage",
+      "type": "attaches_to",
+      "label": "depresses larynx",
+      "direction": "inferior"
+    },
+    {
+      "source": "mylohyoid-muscle",
+      "target": "mandible",
+      "type": "attaches_to",
+      "label": "mylohyoid line",
+      "direction": "superior"
+    },
+    {
+      "source": "geniohyoid-muscle",
+      "target": "mandible",
+      "type": "attaches_to",
+      "label": "mental spine",
+      "direction": "anterior"
+    },
+    {
+      "source": "digastric-anterior-belly",
+      "target": "mandible",
+      "type": "attaches_to",
+      "label": "digastric fossa",
+      "direction": "anterior"
+    },
+    {
+      "source": "digastric-posterior-belly",
+      "target": "digastric-anterior-belly",
+      "type": "continuous_with",
+      "label": "via intermediate tendon"
+    },
+    {
+      "source": "stylohyoid-muscle",
+      "target": "styloid-process",
+      "type": "attaches_to",
+      "direction": "superior"
+    },
+    {
+      "source": "thyrohyoid-muscle",
+      "target": "thyroid-cartilage",
+      "type": "attaches_to",
+      "label": "oblique line",
+      "direction": "inferior"
+    },
+    {
+      "source": "atlas-c1",
+      "target": "axis-c2",
+      "type": "articulates_with",
+      "label": "atlanto-axial joint",
+      "direction": "inferior"
+    },
+    {
+      "source": "atlas-c1",
+      "target": "cervical-vertebra",
+      "type": "part_of",
+      "label": "C1"
+    },
+    {
+      "source": "axis-c2",
+      "target": "cervical-vertebra",
+      "type": "part_of",
+      "label": "C2"
+    },
+    {
+      "source": "transverse-process",
+      "target": "cervical-vertebra",
+      "type": "part_of",
+      "direction": "lateral"
+    },
+    {
+      "source": "transverse-foramen",
+      "target": "transverse-process",
+      "type": "part_of"
+    },
+    {
+      "source": "transverse-foramen",
+      "target": "vertebral-artery",
+      "type": "transmits",
+      "label": "C6 to C1",
+      "direction": "superior"
+    },
+    {
+      "source": "vertebral-artery",
+      "target": "transverse-foramen",
+      "type": "passes_through",
+      "direction": "superior"
+    },
+    {
+      "source": "medial-pterygoid-plate",
+      "target": "sphenoid",
+      "type": "part_of",
+      "label": "process of sphenoid",
+      "direction": "medial"
+    },
+    {
+      "source": "lateral-pterygoid-plate",
+      "target": "sphenoid",
+      "type": "part_of",
+      "label": "process of sphenoid",
+      "direction": "lateral"
+    },
+    {
+      "source": "pterygoid-hamulus",
+      "target": "medial-pterygoid-plate",
+      "type": "part_of",
+      "label": "inferior tip",
+      "direction": "inferior"
+    },
+    {
+      "source": "pterygomandibular-raphe",
+      "target": "pterygoid-hamulus",
+      "type": "attaches_to",
+      "label": "superior attachment",
+      "direction": "superior"
+    },
+    {
+      "source": "buccinator",
+      "target": "pterygomandibular-raphe",
+      "type": "attaches_to",
+      "label": "posterior origin",
+      "direction": "anterior"
+    },
+    {
+      "source": "superior-pharyngeal-constrictor",
+      "target": "pterygomandibular-raphe",
+      "type": "attaches_to",
+      "label": "origin",
+      "direction": "posterior"
+    },
+    {
+      "source": "superior-pharyngeal-constrictor",
+      "target": "mandible",
+      "type": "attaches_to",
+      "label": "mylohyoid line origin",
+      "direction": "anterior"
+    },
+    {
+      "source": "superior-pharyngeal-constrictor",
+      "target": "pterygoid-hamulus",
+      "type": "attaches_to",
+      "label": "origin",
+      "direction": "superior"
+    },
+    {
+      "source": "middle-pharyngeal-constrictor",
+      "target": "hyoid-bone",
+      "type": "attaches_to",
+      "label": "greater & lesser cornua",
+      "direction": "inferior"
+    },
+    {
+      "source": "middle-pharyngeal-constrictor",
+      "target": "stylohyoid-ligament",
+      "type": "attaches_to",
+      "label": "origin",
+      "direction": "superior"
+    },
+    {
+      "source": "inferior-pharyngeal-constrictor",
+      "target": "thyroid-cartilage",
+      "type": "attaches_to",
+      "label": "thyropharyngeus origin",
+      "direction": "superior"
+    },
+    {
+      "source": "inferior-pharyngeal-constrictor",
+      "target": "cricoid-cartilage",
+      "type": "attaches_to",
+      "label": "cricopharyngeus origin",
+      "direction": "inferior"
+    },
+    {
+      "source": "cricopharyngeus",
+      "target": "inferior-pharyngeal-constrictor",
+      "type": "part_of",
+      "label": "lower fibers",
+      "direction": "inferior"
+    },
+    {
+      "source": "cricopharyngeus",
+      "target": "cricoid-cartilage",
+      "type": "attaches_to",
+      "label": "origin"
+    },
+    {
+      "source": "sphenomandibular-ligament",
+      "target": "sphenoid",
+      "type": "attaches_to",
+      "label": "spine of sphenoid",
+      "direction": "superior"
+    },
+    {
+      "source": "sphenomandibular-ligament",
+      "target": "mandible",
+      "type": "suspends",
+      "label": "TMJ suspensory ligament"
+    },
+    {
+      "source": "palatine-process-of-maxilla",
+      "target": "hard-palate",
+      "type": "forms",
+      "label": "anterior 3/4",
+      "direction": "anterior"
+    },
+    {
+      "source": "horizontal-plate-of-palatine",
+      "target": "hard-palate",
+      "type": "forms",
+      "label": "posterior 1/4",
+      "direction": "posterior"
+    },
+    {
+      "source": "palatine-process-of-maxilla",
+      "target": "horizontal-plate-of-palatine",
+      "type": "continuous_with",
+      "label": "transverse palatine suture",
+      "direction": "posterior"
+    },
+    {
+      "source": "incisive-foramen",
+      "target": "hard-palate",
+      "type": "part_of",
+      "label": "anterior midline",
+      "direction": "anterior"
+    },
+    {
+      "source": "greater-palatine-foramen",
+      "target": "hard-palate",
+      "type": "part_of",
+      "label": "posterolateral",
+      "direction": "posterior"
+    },
+    {
+      "source": "lesser-palatine-foramen",
+      "target": "hard-palate",
+      "type": "part_of",
+      "label": "posterolateral",
+      "direction": "posterior"
+    },
+    {
+      "source": "palatine-aponeurosis",
+      "target": "hard-palate",
+      "type": "attaches_to",
+      "label": "posterior border",
+      "direction": "anterior"
+    },
+    {
+      "source": "palatine-aponeurosis",
+      "target": "horizontal-plate-of-palatine",
+      "type": "attaches_to",
+      "label": "posterior free border",
+      "direction": "anterior"
+    },
+    {
+      "source": "palatine-aponeurosis",
+      "target": "soft-palate",
+      "type": "forms",
+      "label": "fibrous skeleton of soft palate",
+      "direction": "posterior"
+    },
+    {
+      "source": "soft-palate",
+      "target": "palatine-aponeurosis",
+      "type": "continuous_with",
+      "label": "aponeurotic core",
+      "direction": "anterior"
+    },
+    {
+      "source": "palatine-tonsil",
+      "target": "palatoglossal-arch",
+      "type": "bounded_by",
+      "label": "anterior pillar",
+      "direction": "anterior"
+    },
+    {
+      "source": "palatine-tonsil",
+      "target": "palatopharyngeal-arch",
+      "type": "bounded_by",
+      "label": "posterior pillar",
+      "direction": "posterior"
+    },
+    {
+      "source": "palatoglossal-arch",
+      "target": "soft-palate",
+      "type": "attaches_to",
+      "label": "superior attachment",
+      "direction": "superior"
+    },
+    {
+      "source": "palatoglossal-arch",
+      "target": "oral-tongue",
+      "type": "attaches_to",
+      "label": "into tongue",
+      "direction": "inferior"
+    },
+    {
+      "source": "palatopharyngeal-arch",
+      "target": "soft-palate",
+      "type": "attaches_to",
+      "label": "superior attachment",
+      "direction": "superior"
+    },
+    {
+      "source": "greater-wing",
+      "target": "sphenoid",
+      "type": "part_of"
+    },
+    {
+      "source": "lesser-wing",
+      "target": "sphenoid",
+      "type": "part_of"
+    },
+    {
+      "source": "body-of-sphenoid",
+      "target": "sphenoid",
+      "type": "part_of"
+    },
+    {
+      "source": "pterygoid-process",
+      "target": "sphenoid",
+      "type": "part_of"
+    },
+    {
+      "source": "sella-turcica",
+      "target": "body-of-sphenoid",
+      "type": "part_of",
+      "direction": "superior"
+    },
+    {
+      "source": "clivus",
+      "target": "body-of-sphenoid",
+      "type": "part_of",
+      "direction": "posterior"
+    },
+    {
+      "source": "clivus",
+      "target": "occipital-bone",
+      "type": "part_of",
+      "direction": "posterior"
+    },
+    {
+      "source": "sphenoid-sinus",
+      "target": "body-of-sphenoid",
+      "type": "contained_in"
+    },
+    {
+      "source": "crista-galli",
+      "target": "ethmoid",
+      "type": "part_of"
+    },
+    {
+      "source": "perpendicular-plate",
+      "target": "ethmoid",
+      "type": "part_of"
+    },
+    {
+      "source": "ethmoid-labyrinth",
+      "target": "ethmoid",
+      "type": "part_of"
+    },
+    {
+      "source": "cribriform-plate",
+      "target": "ethmoid",
+      "type": "part_of"
+    },
+    {
+      "source": "fovea-ethmoidalis",
+      "target": "ethmoid-labyrinth",
+      "type": "part_of",
+      "direction": "superior"
+    },
+    {
+      "source": "basiocciput",
+      "target": "occipital-bone",
+      "type": "part_of"
+    },
+    {
+      "source": "occipital-condyle",
+      "target": "occipital-bone",
+      "type": "part_of"
+    },
+    {
+      "source": "squamous-occipital",
+      "target": "occipital-bone",
+      "type": "part_of"
+    },
+    {
+      "source": "jugular-tubercle",
+      "target": "occipital-bone",
+      "type": "part_of"
+    },
+    {
+      "source": "planum-sphenoidale",
+      "target": "body-of-sphenoid",
+      "type": "part_of"
+    },
+    {
+      "source": "tuberculum-sellae",
+      "target": "body-of-sphenoid",
+      "type": "part_of"
+    },
+    {
+      "source": "dorsum-sellae",
+      "target": "body-of-sphenoid",
+      "type": "part_of",
+      "direction": "posterior"
+    },
+    {
+      "source": "sella-turcica",
+      "target": "tuberculum-sellae",
+      "type": "bounded_by",
+      "direction": "anterior"
+    },
+    {
+      "source": "sella-turcica",
+      "target": "dorsum-sellae",
+      "type": "bounded_by",
+      "direction": "posterior"
+    },
+    {
+      "source": "dorsum-sellae",
+      "target": "clivus",
+      "type": "continuous_with",
+      "direction": "inferior"
+    },
+    {
+      "source": "planum-sphenoidale",
+      "target": "tuberculum-sellae",
+      "type": "continuous_with",
+      "direction": "posterior"
+    },
+    {
+      "source": "crista-galli",
+      "target": "cribriform-plate",
+      "type": "continuous_with",
+      "direction": "superior"
+    },
+    {
+      "source": "foramen-cecum",
+      "target": "frontal-bone",
+      "type": "bounded_by",
+      "direction": "anterior"
+    },
+    {
+      "source": "foramen-cecum",
+      "target": "crista-galli",
+      "type": "bounded_by",
+      "direction": "posterior"
+    },
+    {
+      "source": "sphenooccipital-synchondrosis",
+      "target": "sphenoid",
+      "type": "articulates_with"
+    },
+    {
+      "source": "sphenooccipital-synchondrosis",
+      "target": "occipital-bone",
+      "type": "articulates_with"
+    },
+    {
+      "source": "sphenoethmoidal-junction",
+      "target": "sphenoid",
+      "type": "articulates_with"
+    },
+    {
+      "source": "sphenoethmoidal-junction",
+      "target": "ethmoid",
+      "type": "articulates_with"
+    },
+    {
+      "source": "sphenofrontal-suture",
+      "target": "sphenoid",
+      "type": "articulates_with"
+    },
+    {
+      "source": "sphenofrontal-suture",
+      "target": "frontal-bone",
+      "type": "articulates_with"
+    },
+    {
+      "source": "sphenopetrosal-fissure",
+      "target": "sphenoid",
+      "type": "articulates_with"
+    },
+    {
+      "source": "sphenopetrosal-fissure",
+      "target": "temporal-bone",
+      "type": "articulates_with"
+    },
+    {
+      "source": "petrooccipital-fissure",
+      "target": "temporal-bone",
+      "type": "articulates_with"
+    },
+    {
+      "source": "petrooccipital-fissure",
+      "target": "occipital-bone",
+      "type": "articulates_with"
+    },
+    {
+      "source": "foramen-ovale",
+      "target": "greater-wing",
+      "type": "contained_in"
+    },
+    {
+      "source": "foramen-rotundum",
+      "target": "greater-wing",
+      "type": "contained_in"
+    },
+    {
+      "source": "foramen-spinosum",
+      "target": "greater-wing",
+      "type": "contained_in"
+    },
+    {
+      "source": "optic-canal",
+      "target": "lesser-wing",
+      "type": "contained_in"
+    },
+    {
+      "source": "superior-orbital-fissure",
+      "target": "greater-wing",
+      "type": "bounded_by",
+      "direction": "inferior"
+    },
+    {
+      "source": "superior-orbital-fissure",
+      "target": "lesser-wing",
+      "type": "bounded_by",
+      "direction": "superior"
+    },
+    {
+      "source": "jugular-foramen",
+      "target": "temporal-bone",
+      "type": "bounded_by",
+      "direction": "anterior"
+    },
+    {
+      "source": "jugular-foramen",
+      "target": "occipital-bone",
+      "type": "bounded_by",
+      "direction": "posterior"
+    },
+    {
+      "source": "hypoglossal-canal",
+      "target": "occipital-bone",
+      "type": "contained_in"
+    },
+    {
+      "source": "foramen-magnum",
+      "target": "occipital-bone",
+      "type": "contained_in"
+    },
+    {
+      "source": "carotid-canal",
+      "target": "temporal-bone",
+      "type": "contained_in"
+    },
+    {
+      "source": "foramen-magnum",
+      "target": "occipital-condyle",
+      "type": "bounded_by",
+      "direction": "lateral"
     }
   ]
 }

--- a/data/kag-graph.json
+++ b/data/kag-graph.json
@@ -1,0 +1,1346 @@
+{
+  "version": 2,
+  "updated": "2026-07-02T19:25:43.159Z",
+  "status": "SEED — vetted temporal-bone otology core. Authored expansion nodes (later phases) carry review:false until owner review.",
+  "sources": [
+    "Cummings Otolaryngology 7e"
+  ],
+  "nodes": [
+    {
+      "id": "external-auditory-canal",
+      "label": "External Auditory Canal",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "S-shaped canal ~2.5cm. Lateral 1/3 cartilaginous, medial 2/3 bony. Isthmus is the narrowest point at bone-cartilage junction.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "tympanic-membrane",
+      "label": "Tympanic Membrane",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Three layers: squamous epithelium, fibrous middle, mucosal lining. Pars tensa (inferior) and pars flaccida (superior, Shrapnell membrane).",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "malleus",
+      "label": "Malleus",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Largest ossicle. Manubrium attached to TM. Head articulates with incus in epitympanum. Lateral process creates malleolar fold.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "incus",
+      "label": "Incus",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Articulates with malleus (body) and stapes (lenticular process). Long process is most vulnerable to necrosis in chronic otitis media.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "stapes",
+      "label": "Stapes",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Smallest bone in body. Footplate sits in oval window. Stapedius muscle attaches to neck/head, dampening ossicular chain vibration.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "oval-window",
+      "label": "Oval Window",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Niche between middle and inner ear, sealed by stapes footplate and annular ligament. Transmits sound to scala vestibuli.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "round-window",
+      "label": "Round Window",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Membrane-covered opening of scala tympani. Serves as pressure release for fluid displaced by stapes footplate movement. Important CI electrode entry.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "cochlea",
+      "label": "Cochlea",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "2.5 turns spiral. Contains scala vestibuli, scala media (cochlear duct), and scala tympani. Organ of Corti sits on basilar membrane in scala media. Tonotopic: base=high freq, apex=low freq.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "vestibule",
+      "label": "Vestibule",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Central chamber of bony labyrinth. Contains utricle and saccule (otolith organs for linear acceleration). Oval window opens into vestibule.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "semicircular-canals",
+      "label": "Semicircular Canals",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Three canals (superior, posterior, lateral) detect angular acceleration. Each has ampulla with crista ampullaris. Lateral canal 30° from horizontal.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "facial-nerve",
+      "label": "Facial Nerve (CN VII)",
+      "type": "nerve",
+      "subspecialty": "otology",
+      "detail": "Complex course: IAC → labyrinthine → geniculate ganglion → tympanic → second genu → mastoid → stylomastoid foramen. Labyrinthine segment is narrowest and most susceptible to injury.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "chorda-tympani",
+      "label": "Chorda Tympani",
+      "type": "nerve",
+      "subspecialty": "otology",
+      "detail": "Branch of CN VII. Carries taste from anterior 2/3 tongue and parasympathetic fibers to submandibular/sublingual glands. Crosses middle ear between malleus and incus.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "greater-superficial-petrosal",
+      "label": "Greater Superficial Petrosal Nerve",
+      "type": "nerve",
+      "subspecialty": "otology",
+      "detail": "Branch of CN VII at geniculate ganglion. Carries parasympathetic fibers for lacrimal gland secretion. Exits via hiatus of facial canal.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "vestibulocochlear-nerve",
+      "label": "Vestibulocochlear Nerve (CN VIII)",
+      "type": "nerve",
+      "subspecialty": "otology",
+      "detail": "Travels through IAC with CN VII. Superior and inferior vestibular divisions plus cochlear division. Vulnerable to vestibular schwannoma.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "internal-auditory-canal",
+      "label": "Internal Auditory Canal",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Contains CN VII, CN VIII (superior/inferior vestibular, cochlear), and labyrinthine artery. Transverse and vertical crests divide IAC into four quadrants.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "tegmen-tympani",
+      "label": "Tegmen Tympani",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Thin bone forming roof of middle ear and mastoid. Separates middle ear from middle cranial fossa. Erosion risks meningitis and CSF leak.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "mastoid",
+      "label": "Mastoid",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Pneumatized portion of temporal bone. Contains mastoid antrum connecting to epitympanum via aditus ad antrum. Degree of pneumatization varies.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "epitympanum",
+      "label": "Epitympanum",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Superior portion of middle ear (attic). Contains head of malleus and body of incus. Cholesteatoma commonly originates from pars flaccida retraction into epitympanum.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "facial-recess",
+      "label": "Facial Recess",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Triangular space bounded by: fossa incudis superiorly, facial nerve medially, chorda tympani laterally. Key surgical landmark for cochlear implant electrode insertion.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "sinus-tympani",
+      "label": "Sinus Tympani",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Deep recess posteromedial to round window niche, medial to facial nerve. Difficult to visualize directly — common site for residual cholesteatoma.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "promontory",
+      "label": "Promontory",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Rounded elevation on medial wall of middle ear formed by basal turn of cochlea. Jacobson nerve (CN IX tympanic branch) courses over it.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "stapedius-muscle",
+      "label": "Stapedius Muscle",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Smallest skeletal muscle. Innervated by CN VII. Contracts reflexively to loud sound (acoustic reflex), dampening ossicular chain movement.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "tensor-tympani",
+      "label": "Tensor Tympani",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Innervated by CN V3. Inserts on manubrium of malleus. Tenses TM and dampens sound. Located in semicanal above eustachian tube.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "eustachian-tube",
+      "label": "Eustachian Tube",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Connects middle ear to nasopharynx. Adults: 36mm, 45° angle. Children shorter, more horizontal. Equalizes middle ear pressure. Lined by respiratory epithelium.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "labyrinthine-artery",
+      "label": "Labyrinthine Artery",
+      "type": "vessel",
+      "subspecialty": "otology",
+      "detail": "Usually branch of AICA (85%). End artery — occlusion causes sudden SNHL and vestibular loss. Travels through IAC.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "sigmoid-sinus",
+      "label": "Sigmoid Sinus",
+      "type": "vessel",
+      "subspecialty": "otology",
+      "detail": "S-shaped venous sinus in posterior fossa. Lateral boundary of mastoid surgery. Thrombosis is complication of coalescent mastoiditis.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "cholesteatoma",
+      "label": "Cholesteatoma",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Keratinizing squamous epithelium in middle ear/mastoid. Acquired (pars flaccida retraction) more common than congenital. Erodes bone via enzymatic activity and pressure.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "otosclerosis",
+      "label": "Otosclerosis",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Abnormal bone remodeling at oval window causing stapes fixation. Autosomal dominant with incomplete penetrance. Presents as progressive conductive hearing loss.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "chronic-otitis-media",
+      "label": "Chronic Otitis Media",
+      "type": "pathology",
+      "subspecialty": "otology",
+      "detail": "Permanent TM perforation with chronic middle ear drainage >6 weeks. May be with or without cholesteatoma. Often causes conductive hearing loss.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "vestibular-schwannoma",
+      "label": "Vestibular Schwannoma",
+      "type": "pathology",
+      "subspecialty": "skull-base",
+      "detail": "Benign tumor of Schwann cells on CN VIII (usually superior vestibular division). Most common CPA tumor. Bilateral = NF2. Presents with asymmetric SNHL.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "tympanoplasty",
+      "label": "Tympanoplasty",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Surgical repair of TM perforation ± ossicular chain reconstruction. Grafts: temporalis fascia, tragal perichondrium, cartilage. Underlay vs overlay technique.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "mastoidectomy",
+      "label": "Mastoidectomy",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Canal wall up (CWU) vs canal wall down (CWD). Landmarks: tegmen, sigmoid, lateral SCC, facial nerve. CWD creates mastoid bowl requiring lifelong care.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "stapedectomy",
+      "label": "Stapedectomy",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Removal of stapes and placement of prosthesis for otosclerosis. Stapedotomy (small fenestra) preferred. Risk: SNHL, vertigo, facial nerve injury, perilymph fistula.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "cochlear-implant",
+      "label": "Cochlear Implant",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Electrode array inserted via round window or cochleostomy into scala tympani. Posterior tympanotomy (facial recess) approach. For severe-profound SNHL.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "ossiculoplasty",
+      "label": "Ossiculoplasty",
+      "type": "procedure",
+      "subspecialty": "otology",
+      "detail": "Reconstruction of ossicular chain. PORP (partial) replaces incus, TORP (total) replaces all. Materials: titanium, hydroxyapatite, autograft.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "lateral-semicircular-canal",
+      "label": "Lateral Semicircular Canal",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Key landmark in mastoid surgery — lies medial to antrum. Oriented 30° above horizontal. Most commonly involved in BPPV is posterior canal, not lateral.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "geniculate-ganglion",
+      "label": "Geniculate Ganglion",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Sensory ganglion of CN VII at first genu. Gives off greater superficial petrosal nerve. Site of herpes zoster reactivation in Ramsay Hunt syndrome.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "organ-of-corti",
+      "label": "Organ of Corti",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Sensory epithelium in scala media. Inner hair cells (single row, ~3500) are primary transducers. Outer hair cells (3 rows, ~12000) provide cochlear amplification.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "jacobson-nerve",
+      "label": "Jacobson Nerve (Tympanic Branch CN IX)",
+      "type": "nerve",
+      "subspecialty": "otology",
+      "detail": "Branch of CN IX. Courses over promontory forming tympanic plexus. Provides sensation to middle ear mucosa and parasympathetic fibers to parotid (via lesser petrosal nerve).",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    },
+    {
+      "id": "stylomastoid-foramen",
+      "label": "Stylomastoid Foramen",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Exit point of CN VII from temporal bone. Landmark for facial nerve identification in parotid surgery. Located between styloid and mastoid processes.",
+      "sources": [
+        "Cummings 7e"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": null,
+      "laterality": null,
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": []
+      },
+      "review": true
+    }
+  ],
+  "edges": [
+    {
+      "source": "external-auditory-canal",
+      "target": "tympanic-membrane",
+      "type": "contained_in",
+      "label": "terminates at"
+    },
+    {
+      "source": "tympanic-membrane",
+      "target": "malleus",
+      "type": "contained_in",
+      "label": "manubrium attached"
+    },
+    {
+      "source": "malleus",
+      "target": "incus",
+      "type": "contained_in",
+      "label": "articulates in epitympanum"
+    },
+    {
+      "source": "incus",
+      "target": "stapes",
+      "type": "contained_in",
+      "label": "lenticular process to head"
+    },
+    {
+      "source": "stapes",
+      "target": "oval-window",
+      "type": "contained_in",
+      "label": "footplate in"
+    },
+    {
+      "source": "oval-window",
+      "target": "vestibule",
+      "type": "contained_in",
+      "label": "opens into"
+    },
+    {
+      "source": "round-window",
+      "target": "cochlea",
+      "type": "contained_in",
+      "label": "opens from scala tympani"
+    },
+    {
+      "source": "cochlea",
+      "target": "organ-of-corti",
+      "type": "contained_in",
+      "label": "contains"
+    },
+    {
+      "source": "cochlea",
+      "target": "vestibule",
+      "type": "contained_in",
+      "label": "connects to"
+    },
+    {
+      "source": "vestibule",
+      "target": "semicircular-canals",
+      "type": "contained_in",
+      "label": "connects to"
+    },
+    {
+      "source": "semicircular-canals",
+      "target": "lateral-semicircular-canal",
+      "type": "contained_in"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "chorda-tympani",
+      "type": "branches_from"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "greater-superficial-petrosal",
+      "type": "branches_from"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "geniculate-ganglion",
+      "type": "contained_in",
+      "label": "first genu"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "internal-auditory-canal",
+      "type": "contained_in"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "stylomastoid-foramen",
+      "type": "contained_in",
+      "label": "exits at"
+    },
+    {
+      "source": "facial-nerve",
+      "target": "stapedius-muscle",
+      "type": "innervates"
+    },
+    {
+      "source": "vestibulocochlear-nerve",
+      "target": "internal-auditory-canal",
+      "type": "contained_in"
+    },
+    {
+      "source": "vestibulocochlear-nerve",
+      "target": "cochlea",
+      "type": "innervates",
+      "label": "cochlear division"
+    },
+    {
+      "source": "vestibulocochlear-nerve",
+      "target": "vestibule",
+      "type": "innervates",
+      "label": "vestibular division"
+    },
+    {
+      "source": "labyrinthine-artery",
+      "target": "cochlea",
+      "type": "supplies"
+    },
+    {
+      "source": "labyrinthine-artery",
+      "target": "internal-auditory-canal",
+      "type": "contained_in"
+    },
+    {
+      "source": "sigmoid-sinus",
+      "target": "mastoid",
+      "type": "landmark_for",
+      "label": "lateral boundary"
+    },
+    {
+      "source": "tegmen-tympani",
+      "target": "epitympanum",
+      "type": "contained_in",
+      "label": "roof of"
+    },
+    {
+      "source": "epitympanum",
+      "target": "malleus",
+      "type": "contained_in"
+    },
+    {
+      "source": "epitympanum",
+      "target": "incus",
+      "type": "contained_in"
+    },
+    {
+      "source": "facial-recess",
+      "target": "facial-nerve",
+      "type": "landmark_for",
+      "label": "medial boundary"
+    },
+    {
+      "source": "facial-recess",
+      "target": "chorda-tympani",
+      "type": "landmark_for",
+      "label": "lateral boundary"
+    },
+    {
+      "source": "sinus-tympani",
+      "target": "round-window",
+      "type": "landmark_for",
+      "label": "posteromed to RW"
+    },
+    {
+      "source": "sinus-tympani",
+      "target": "facial-nerve",
+      "type": "landmark_for",
+      "label": "lateral boundary"
+    },
+    {
+      "source": "promontory",
+      "target": "cochlea",
+      "type": "arises_from",
+      "label": "basal turn forms"
+    },
+    {
+      "source": "jacobson-nerve",
+      "target": "promontory",
+      "type": "landmark_for",
+      "label": "courses over"
+    },
+    {
+      "source": "tensor-tympani",
+      "target": "malleus",
+      "type": "landmark_for",
+      "label": "inserts on manubrium"
+    },
+    {
+      "source": "eustachian-tube",
+      "target": "epitympanum",
+      "type": "contained_in",
+      "label": "communicates with"
+    },
+    {
+      "source": "cholesteatoma",
+      "target": "epitympanum",
+      "type": "arises_from",
+      "label": "pars flaccida retraction"
+    },
+    {
+      "source": "cholesteatoma",
+      "target": "incus",
+      "type": "complication_of",
+      "label": "erodes long process"
+    },
+    {
+      "source": "cholesteatoma",
+      "target": "lateral-semicircular-canal",
+      "type": "complication_of",
+      "label": "may erode"
+    },
+    {
+      "source": "cholesteatoma",
+      "target": "facial-nerve",
+      "type": "complication_of",
+      "label": "may erode"
+    },
+    {
+      "source": "cholesteatoma",
+      "target": "tegmen-tympani",
+      "type": "complication_of",
+      "label": "may erode"
+    },
+    {
+      "source": "otosclerosis",
+      "target": "stapes",
+      "type": "complication_of",
+      "label": "fixes footplate"
+    },
+    {
+      "source": "chronic-otitis-media",
+      "target": "tympanic-membrane",
+      "type": "complication_of",
+      "label": "perforates"
+    },
+    {
+      "source": "vestibular-schwannoma",
+      "target": "vestibulocochlear-nerve",
+      "type": "arises_from"
+    },
+    {
+      "source": "vestibular-schwannoma",
+      "target": "internal-auditory-canal",
+      "type": "contained_in"
+    },
+    {
+      "source": "tympanoplasty",
+      "target": "tympanic-membrane",
+      "type": "treats"
+    },
+    {
+      "source": "tympanoplasty",
+      "target": "chronic-otitis-media",
+      "type": "treats"
+    },
+    {
+      "source": "mastoidectomy",
+      "target": "cholesteatoma",
+      "type": "treats"
+    },
+    {
+      "source": "mastoidectomy",
+      "target": "mastoid",
+      "type": "landmark_for"
+    },
+    {
+      "source": "stapedectomy",
+      "target": "otosclerosis",
+      "type": "treats"
+    },
+    {
+      "source": "stapedectomy",
+      "target": "stapes",
+      "type": "landmark_for"
+    },
+    {
+      "source": "cochlear-implant",
+      "target": "round-window",
+      "type": "landmark_for",
+      "label": "insertion site"
+    },
+    {
+      "source": "cochlear-implant",
+      "target": "facial-recess",
+      "type": "landmark_for",
+      "label": "approach via"
+    },
+    {
+      "source": "ossiculoplasty",
+      "target": "incus",
+      "type": "treats",
+      "label": "replaces eroded"
+    }
+  ]
+}

--- a/data/kag-graph.json
+++ b/data/kag-graph.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "updated": "2026-07-02T20:27:08.319Z",
+  "updated": "2026-07-02T20:28:23.725Z",
   "status": "DRAFT expansion — 40-node temporal-bone seed is vetted (review:true); all other nodes are subagent-authored scaffolding (review:false) pending owner stress-test against curated source text.",
   "sources": [
     "Cummings Otolaryngology 7e",
@@ -24963,6 +24963,47 @@
       "target": "occipital-condyle",
       "type": "bounded_by",
       "direction": "lateral"
+    },
+    {
+      "source": "parietal-bone",
+      "target": "frontal-bone",
+      "type": "articulates_with",
+      "label": "cranial suture"
+    },
+    {
+      "source": "parietal-bone",
+      "target": "occipital-bone",
+      "type": "articulates_with",
+      "label": "cranial suture"
+    },
+    {
+      "source": "parietal-bone",
+      "target": "temporal-bone",
+      "type": "articulates_with",
+      "label": "cranial suture"
+    },
+    {
+      "source": "parietal-bone",
+      "target": "sphenoid",
+      "type": "articulates_with",
+      "label": "cranial suture"
+    },
+    {
+      "source": "level-vi-neck",
+      "target": "level-vii-neck",
+      "type": "continuous_with",
+      "direction": "inferior"
+    },
+    {
+      "source": "level-vi-neck",
+      "target": "thyroid-gland",
+      "type": "bounded_by"
+    },
+    {
+      "source": "level-vi-neck",
+      "target": "level-iv-neck",
+      "type": "continuous_with",
+      "direction": "superior"
     }
   ]
 }

--- a/data/kag-graph.json
+++ b/data/kag-graph.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "updated": "2026-07-02T20:01:14.367Z",
+  "updated": "2026-07-02T20:10:42.377Z",
   "status": "DRAFT expansion — 40-node temporal-bone seed is vetted (review:true); all other nodes are subagent-authored scaffolding (review:false) pending owner stress-test against curated source text.",
   "sources": [
     "Cummings Otolaryngology 7e",
@@ -14558,6 +14558,1294 @@
         ]
       },
       "review": false
+    },
+    {
+      "id": "annular-ligament",
+      "label": "Annular Ligament (Stapediovestibular)",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Ring of elastic fibrous tissue anchoring the stapes footplate within the oval window; its ossification/fixation is the hallmark of otosclerosis.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "ligament",
+      "region": "temporal-bone",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "otosclerosis-stapes"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "anterior-malleal-ligament",
+      "label": "Anterior Malleal Ligament",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Suspensory ligament running from the malleus neck (anterior process) to the petrotympanic (Glaserian) fissure; contributes to the ossicular rotational axis.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "ligament",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "tympanoplasty-ossiculoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "lateral-malleal-ligament",
+      "label": "Lateral Malleal Ligament",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Fan-shaped ligament from the malleus neck to the tympanic notch (of Rivinus), forming the roof of Prussak's space.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "ligament",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "tympanoplasty-ossiculoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "superior-malleal-ligament",
+      "label": "Superior Malleal Ligament",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Suspends the malleus head from the epitympanic roof (tegmen); helps define the axis of ossicular rotation.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "ligament",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "tympanoplasty-ossiculoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "posterior-incudal-ligament",
+      "label": "Posterior Incudal Ligament",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Suspends the short process of the incus in the incudal fossa; a key fulcrum, relevant when disarticulating the incudostapedial joint.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "ligament",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "tympanoplasty-ossiculoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "incudomallear-joint",
+      "label": "Incudomallear Joint",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Saddle-shaped synovial joint between the malleus head and incus body; the two move as a unit about the anteroposterior ligamentous axis.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "tympanoplasty-ossiculoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "incudostapedial-joint",
+      "label": "Incudostapedial Joint",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Ball-and-socket synovial joint between the long process (lenticular) of the incus and the stapes head; commonly disarticulated in ossiculoplasty and most eroded ossicular link in chronic OM.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "tympanoplasty-ossiculoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "tympanic-annulus",
+      "label": "Tympanic Annulus (Annulus Fibrosus)",
+      "type": "anatomy",
+      "subspecialty": "otology",
+      "detail": "Fibrocartilaginous ring seating the pars tensa in the tympanic sulcus; deficient superiorly at the notch of Rivinus where the pars flaccida attaches.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "ligament",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "tympanoplasty-ossiculoplasty"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "thyrohyoid-membrane",
+      "label": "Thyrohyoid Membrane",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Fibroelastic sheet suspending the thyroid cartilage from the hyoid; pierced by the internal branch of the superior laryngeal nerve and superior laryngeal vessels.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "membrane",
+      "region": "larynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "laryngotracheal-stenosis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "quadrangular-membrane",
+      "label": "Quadrangular Membrane",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Upper fibroelastic membrane of the endolarynx; its free lower edge forms the vestibular (false vocal) ligament and its upper edge the aryepiglottic fold.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "membrane",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "benign-vocal-fold-lesions"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "vestibular-ligament",
+      "label": "Vestibular Ligament (False Cord)",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Thickened inferior free margin of the quadrangular membrane forming the framework of the false vocal fold above the laryngeal ventricle.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "ligament",
+      "region": "larynx",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "benign-vocal-fold-lesions"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "hyoepiglottic-ligament",
+      "label": "Hyoepiglottic Ligament",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Connects the anterior epiglottis to the hyoid body, forming the floor of the pre-epiglottic (Boyer) space; tenting it opens the vallecula during suspension laryngoscopy.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "ligament",
+      "region": "larynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "laryngeal-scc"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "thyroepiglottic-ligament",
+      "label": "Thyroepiglottic Ligament",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Tethers the epiglottic petiole to the inner thyroid lamina just above the anterior commissure; a route of anterior tumor spread into the pre-epiglottic space.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "ligament",
+      "region": "larynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "laryngeal-scc"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "cricotracheal-ligament",
+      "label": "Cricotracheal Ligament",
+      "type": "anatomy",
+      "subspecialty": "laryngology",
+      "detail": "Connects the lower cricoid border to the first tracheal ring; divided and reapproximated in cricotracheal resection for subglottic stenosis.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "ligament",
+      "region": "larynx",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "laryngotracheal-stenosis"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "trigeminal-nerve",
+      "label": "Trigeminal Nerve (CN V)",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Largest cranial nerve; divides into V1 (ophthalmic), V2 (maxillary) and V3 (mandibular), each exiting the skull base through a separate foramen.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "maxillary-nerve",
+      "label": "Maxillary Nerve (V2)",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Second trigeminal division; purely sensory, exits the middle cranial fossa via foramen rotundum into the pterygopalatine fossa.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "mandibular-nerve",
+      "label": "Mandibular Nerve (V3)",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Third trigeminal division carrying sensory and motor (muscles of mastication) fibers; exits through foramen ovale into the masticator space.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "middle-meningeal-artery",
+      "label": "Middle Meningeal Artery",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Branch of the maxillary artery entering the cranium through foramen spinosum; classic source of epidural hematoma.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "optic-nerve",
+      "label": "Optic Nerve (CN II)",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "CN II passes with the ophthalmic artery through the optic canal in the lesser wing of sphenoid; at risk in endoscopic sphenoethmoid surgery.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "olfactory-nerve",
+      "label": "Olfactory Nerve (CN I)",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "CN I fila traverse the cribriform plate; a common site of anterior skull base CSF leak and esthesioneuroblastoma origin.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "glossopharyngeal-nerve",
+      "label": "Glossopharyngeal Nerve (CN IX)",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "CN IX exits the jugular foramen (pars nervosa) with CN X and XI; injury causes loss of gag and posterior-tongue taste.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "vagus-nerve",
+      "label": "Vagus Nerve (CN X)",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "CN X leaves the skull through the jugular foramen and descends in the carotid sheath; supplies laryngeal and pharyngeal function.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "accessory-nerve",
+      "label": "Accessory Nerve (CN XI)",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "CN XI exits the jugular foramen to innervate SCM and trapezius; landmark in level IIb/V neck dissection.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "hypoglossal-nerve",
+      "label": "Hypoglossal Nerve (CN XII)",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "CN XII exits the hypoglossal canal to supply all intrinsic and most extrinsic tongue muscles.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "internal-jugular-vein",
+      "label": "Internal Jugular Vein",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Begins at the jugular foramen (pars vascularis) as the sigmoid sinus continuation; travels in the carotid sheath.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "internal-carotid-artery",
+      "label": "Internal Carotid Artery",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Enters the skull through the carotid canal of the petrous temporal bone; passes the cavernous sinus adjacent to the sphenoid sinus.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "foramen-ovale",
+      "label": "Foramen Ovale",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Sphenoid greater-wing foramen transmitting V3, the accessory meningeal artery and lesser petrosal nerve; ('MALE' mnemonic: mandibular n., accessory meningeal a., lesser petrosal n., emissary veins).",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "foramen-rotundum",
+      "label": "Foramen Rotundum",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Sphenoid foramen connecting the middle cranial fossa to the pterygopalatine fossa; transmits the maxillary nerve (V2).",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "foramen-spinosum",
+      "label": "Foramen Spinosum",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Small sphenoid foramen posterolateral to foramen ovale transmitting the middle meningeal artery and meningeal branch of V3.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "jugular-foramen",
+      "label": "Jugular Foramen",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Foramen between temporal and occipital bones; pars nervosa carries CN IX, pars vascularis carries CN X, XI and the internal jugular vein. Site of glomus jugulare.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "hypoglossal-canal",
+      "label": "Hypoglossal Canal",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Canal in the occipital condyle transmitting CN XII; anterior to the condyle relative to the jugular foramen.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "foramen-magnum",
+      "label": "Foramen Magnum",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Largest skull-base foramen transmitting the medulla-spinal cord junction, vertebral arteries and the spinal roots of CN XI.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "skull-base",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "carotid-canal",
+      "label": "Carotid Canal",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "S-shaped canal in the petrous temporal bone transmitting the internal carotid artery and its sympathetic/venous plexus.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "superior-orbital-fissure",
+      "label": "Superior Orbital Fissure",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Cleft between sphenoid wings transmitting CN III, IV, VI, V1 (ophthalmic) and the superior ophthalmic vein; involved in superior orbital fissure syndrome.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "optic-canal",
+      "label": "Optic Canal",
+      "type": "anatomy",
+      "subspecialty": "fundamentals",
+      "detail": "Canal in the lesser wing of sphenoid transmitting the optic nerve (CN II) and ophthalmic artery.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "skull-base",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "anterior-skull-base-pituitary"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pterygomaxillary-fissure",
+      "label": "Pterygomaxillary Fissure",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Cleft between the maxilla and the pterygoid process leading into the pterygopalatine fossa; transmits the terminal maxillary artery and posterior superior alveolar branches; landmark in maxillary (Le Fort) osteotomy and JNA resection.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "foramen",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "temporomandibular-joint",
+      "label": "Temporomandibular Joint (TMJ)",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Bilateral synovial ginglymoarthrodial joint between the mandibular condyle and the glenoid fossa of the temporal bone; the only joint with a fibrocartilaginous articular disc dividing it into upper (translation) and lower (rotation) compartments.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "articular-disc",
+      "label": "TMJ Articular Disc (Meniscus)",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Biconcave fibrocartilage separating the TMJ into superior and inferior compartments; anterior displacement produces internal derangement and clicking.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": null,
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "frontozygomatic-suture",
+      "label": "Frontozygomatic Suture",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Articulation of the zygomatic frontal process with the frontal bone; a key reduction/fixation point and vertical buttress landmark in ZMC fracture repair.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "zygomaticomaxillary-suture",
+      "label": "Zygomaticomaxillary Suture",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Junction of the zygoma and maxilla along the inferior orbital rim/zygomaticomaxillary buttress; step-off here signals ZMC fracture.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "joint",
+      "region": "facial-skeleton",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "styloid-process",
+      "label": "Styloid Process",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Slender temporal bone projection anchoring the stylohyoid, stylomandibular and stylopharyngeus/styloglossus/stylohyoid muscles (Riolan's bouquet); elongation causes Eagle syndrome.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "temporal-bone",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "hyoid-bone",
+      "label": "Hyoid Bone",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "U-shaped midline bone suspended by muscles and ligaments, anchoring the larynx and tongue base; the only bone with no direct articulation. Resected with the tract in Sistrunk procedure.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "bone",
+      "region": "cervical-spine-hyoid",
+      "laterality": "midline",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "stylohyoid-ligament",
+      "label": "Stylohyoid Ligament",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Fibrous band from the styloid tip to the lesser cornu of the hyoid (2nd branchial arch derivative); may ossify in Eagle syndrome.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "ligament",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "stylomandibular-ligament",
+      "label": "Stylomandibular Ligament",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Thickened deep cervical fascia from the styloid process to the mandibular angle; accessory TMJ ligament and the boundary separating the parotid from the submandibular space.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "ligament",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "sphenomandibular-ligament",
+      "label": "Sphenomandibular Ligament",
+      "type": "anatomy",
+      "subspecialty": "fprs",
+      "detail": "Accessory TMJ ligament from the sphenoid spine to the mandibular lingula (Meckel's cartilage remnant); primary passive support of the mandible and a landmark shielding the inferior alveolar nerve at the mandibular foramen.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "ligament",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "facial-trauma-mandible-midface"
+        ]
+      },
+      "review": false
+    },
+    {
+      "id": "pterygomandibular-raphe",
+      "label": "Pterygomandibular Raphe",
+      "type": "anatomy",
+      "subspecialty": "hn_onc",
+      "detail": "Tendinous band from the pterygoid hamulus to the posterior mylohyoid line where the buccinator meets the superior pharyngeal constrictor; landmark for inferior alveolar nerve block.",
+      "sources": [
+        "Cummings Otolaryngology"
+      ],
+      "corrections": [],
+      "leitner": {
+        "box": 1,
+        "nextReview": "2026-07-02"
+      },
+      "aliases": [],
+      "abbrev": null,
+      "structure": "ligament",
+      "region": "neck",
+      "laterality": "paired",
+      "oksat": {
+        "modules": [],
+        "concepts": [],
+        "topics": [
+          "head-neck-spaces-deep-neck-infections"
+        ]
+      },
+      "review": false
     }
   ],
   "edges": [
@@ -17680,6 +18968,449 @@
       "source": "pediatric-polysomnography-criteria",
       "target": "pediatric-osa",
       "type": "staged_with"
+    },
+    {
+      "source": "annular-ligament",
+      "target": "stapes",
+      "type": "attaches_to",
+      "label": "footplate"
+    },
+    {
+      "source": "annular-ligament",
+      "target": "oval-window",
+      "type": "attaches_to"
+    },
+    {
+      "source": "annular-ligament",
+      "target": "stapes",
+      "type": "suspends"
+    },
+    {
+      "source": "stapes",
+      "target": "oval-window",
+      "type": "articulates_with",
+      "label": "via annular ligament"
+    },
+    {
+      "source": "anterior-malleal-ligament",
+      "target": "malleus",
+      "type": "attaches_to",
+      "direction": "anterior"
+    },
+    {
+      "source": "lateral-malleal-ligament",
+      "target": "malleus",
+      "type": "attaches_to",
+      "direction": "lateral"
+    },
+    {
+      "source": "superior-malleal-ligament",
+      "target": "malleus",
+      "type": "suspends",
+      "direction": "superior"
+    },
+    {
+      "source": "superior-malleal-ligament",
+      "target": "tegmen-tympani",
+      "type": "attaches_to",
+      "direction": "superior"
+    },
+    {
+      "source": "superior-malleal-ligament",
+      "target": "epitympanum",
+      "type": "contained_in"
+    },
+    {
+      "source": "posterior-incudal-ligament",
+      "target": "incus",
+      "type": "suspends",
+      "label": "short process",
+      "direction": "posterior"
+    },
+    {
+      "source": "incudomallear-joint",
+      "target": "malleus",
+      "type": "articulates_with"
+    },
+    {
+      "source": "incudomallear-joint",
+      "target": "incus",
+      "type": "articulates_with"
+    },
+    {
+      "source": "incudostapedial-joint",
+      "target": "incus",
+      "type": "articulates_with",
+      "label": "lenticular process"
+    },
+    {
+      "source": "incudostapedial-joint",
+      "target": "stapes",
+      "type": "articulates_with"
+    },
+    {
+      "source": "tympanic-annulus",
+      "target": "tympanic-membrane",
+      "type": "attaches_to"
+    },
+    {
+      "source": "thyrohyoid-membrane",
+      "target": "thyroid-cartilage",
+      "type": "attaches_to",
+      "direction": "inferior"
+    },
+    {
+      "source": "thyrohyoid-membrane",
+      "target": "hyoid-bone",
+      "type": "attaches_to",
+      "direction": "superior"
+    },
+    {
+      "source": "thyrohyoid-membrane",
+      "target": "thyroid-cartilage",
+      "type": "suspends",
+      "direction": "inferior"
+    },
+    {
+      "source": "quadrangular-membrane",
+      "target": "epiglottis",
+      "type": "attaches_to",
+      "direction": "anterior"
+    },
+    {
+      "source": "quadrangular-membrane",
+      "target": "arytenoid-cartilage",
+      "type": "attaches_to",
+      "direction": "posterior"
+    },
+    {
+      "source": "vestibular-ligament",
+      "target": "quadrangular-membrane",
+      "type": "part_of",
+      "label": "free inferior edge",
+      "direction": "inferior"
+    },
+    {
+      "source": "vestibular-ligament",
+      "target": "thyroid-cartilage",
+      "type": "attaches_to",
+      "direction": "anterior"
+    },
+    {
+      "source": "vestibular-ligament",
+      "target": "arytenoid-cartilage",
+      "type": "attaches_to",
+      "direction": "posterior"
+    },
+    {
+      "source": "hyoepiglottic-ligament",
+      "target": "epiglottis",
+      "type": "attaches_to"
+    },
+    {
+      "source": "hyoepiglottic-ligament",
+      "target": "hyoid-bone",
+      "type": "attaches_to",
+      "direction": "anterior"
+    },
+    {
+      "source": "thyroepiglottic-ligament",
+      "target": "epiglottis",
+      "type": "attaches_to",
+      "label": "petiole"
+    },
+    {
+      "source": "thyroepiglottic-ligament",
+      "target": "thyroid-cartilage",
+      "type": "attaches_to",
+      "direction": "anterior"
+    },
+    {
+      "source": "cricotracheal-ligament",
+      "target": "cricoid-cartilage",
+      "type": "attaches_to",
+      "direction": "inferior"
+    },
+    {
+      "source": "vocal-ligament",
+      "target": "conus-elasticus",
+      "type": "part_of",
+      "label": "free superior edge",
+      "direction": "superior"
+    },
+    {
+      "source": "maxillary-nerve",
+      "target": "trigeminal-nerve",
+      "type": "part_of"
+    },
+    {
+      "source": "mandibular-nerve",
+      "target": "trigeminal-nerve",
+      "type": "part_of"
+    },
+    {
+      "source": "foramen-ovale",
+      "target": "mandibular-nerve",
+      "type": "transmits",
+      "label": "V3"
+    },
+    {
+      "source": "foramen-rotundum",
+      "target": "maxillary-nerve",
+      "type": "transmits",
+      "label": "V2"
+    },
+    {
+      "source": "foramen-spinosum",
+      "target": "middle-meningeal-artery",
+      "type": "transmits"
+    },
+    {
+      "source": "jugular-foramen",
+      "target": "glossopharyngeal-nerve",
+      "type": "transmits",
+      "label": "CN IX"
+    },
+    {
+      "source": "jugular-foramen",
+      "target": "vagus-nerve",
+      "type": "transmits",
+      "label": "CN X"
+    },
+    {
+      "source": "jugular-foramen",
+      "target": "accessory-nerve",
+      "type": "transmits",
+      "label": "CN XI"
+    },
+    {
+      "source": "jugular-foramen",
+      "target": "internal-jugular-vein",
+      "type": "transmits"
+    },
+    {
+      "source": "hypoglossal-canal",
+      "target": "hypoglossal-nerve",
+      "type": "transmits",
+      "label": "CN XII"
+    },
+    {
+      "source": "foramen-magnum",
+      "target": "accessory-nerve",
+      "type": "transmits",
+      "label": "spinal root"
+    },
+    {
+      "source": "carotid-canal",
+      "target": "internal-carotid-artery",
+      "type": "transmits"
+    },
+    {
+      "source": "superior-orbital-fissure",
+      "target": "trigeminal-nerve",
+      "type": "transmits",
+      "label": "V1 division"
+    },
+    {
+      "source": "optic-canal",
+      "target": "optic-nerve",
+      "type": "transmits",
+      "label": "CN II"
+    },
+    {
+      "source": "cribriform-plate",
+      "target": "olfactory-nerve",
+      "type": "transmits",
+      "label": "CN I"
+    },
+    {
+      "source": "stylomastoid-foramen",
+      "target": "facial-nerve",
+      "type": "transmits",
+      "label": "CN VII"
+    },
+    {
+      "source": "pterygomaxillary-fissure",
+      "target": "maxillary-nerve",
+      "type": "transmits",
+      "label": "terminal branches"
+    },
+    {
+      "source": "optic-canal",
+      "target": "anterior-skull-base",
+      "type": "part_of",
+      "direction": "posterior"
+    },
+    {
+      "source": "cribriform-plate",
+      "target": "olfactory-nerve",
+      "type": "landmark_for"
+    },
+    {
+      "source": "carotid-canal",
+      "target": "internal-carotid-artery",
+      "type": "landmark_for",
+      "label": "petrous ICA"
+    },
+    {
+      "source": "temporomandibular-joint",
+      "target": "mandible",
+      "type": "articulates_with",
+      "label": "condyle",
+      "direction": "superior"
+    },
+    {
+      "source": "articular-disc",
+      "target": "temporomandibular-joint",
+      "type": "part_of"
+    },
+    {
+      "source": "articular-disc",
+      "target": "temporomandibular-joint",
+      "type": "contained_in"
+    },
+    {
+      "source": "frontozygomatic-suture",
+      "target": "zygomaticomaxillary-complex",
+      "type": "articulates_with",
+      "direction": "superior"
+    },
+    {
+      "source": "frontozygomatic-suture",
+      "target": "facial-buttresses",
+      "type": "landmark_for",
+      "label": "vertical buttress"
+    },
+    {
+      "source": "zygomaticomaxillary-suture",
+      "target": "zygomaticomaxillary-complex",
+      "type": "articulates_with",
+      "direction": "inferior"
+    },
+    {
+      "source": "zygomaticomaxillary-suture",
+      "target": "facial-buttresses",
+      "type": "part_of",
+      "label": "ZM buttress"
+    },
+    {
+      "source": "styloid-process",
+      "target": "stylomastoid-foramen",
+      "type": "landmark_for",
+      "direction": "anterior"
+    },
+    {
+      "source": "stylohyoid-ligament",
+      "target": "styloid-process",
+      "type": "attaches_to",
+      "direction": "superior"
+    },
+    {
+      "source": "stylohyoid-ligament",
+      "target": "hyoid-bone",
+      "type": "attaches_to",
+      "label": "lesser cornu",
+      "direction": "inferior"
+    },
+    {
+      "source": "stylohyoid-ligament",
+      "target": "hyoid-bone",
+      "type": "suspends",
+      "direction": "inferior"
+    },
+    {
+      "source": "stylomandibular-ligament",
+      "target": "styloid-process",
+      "type": "attaches_to",
+      "direction": "superior"
+    },
+    {
+      "source": "stylomandibular-ligament",
+      "target": "mandible",
+      "type": "attaches_to",
+      "label": "angle",
+      "direction": "inferior"
+    },
+    {
+      "source": "stylomandibular-ligament",
+      "target": "temporomandibular-joint",
+      "type": "part_of",
+      "label": "accessory ligament"
+    },
+    {
+      "source": "stylomandibular-ligament",
+      "target": "parotid-space",
+      "type": "landmark_for",
+      "label": "separates from submandibular"
+    },
+    {
+      "source": "stylomandibular-ligament",
+      "target": "submandibular-space",
+      "type": "landmark_for"
+    },
+    {
+      "source": "sphenomandibular-ligament",
+      "target": "mandible",
+      "type": "attaches_to",
+      "label": "lingula",
+      "direction": "inferior"
+    },
+    {
+      "source": "sphenomandibular-ligament",
+      "target": "temporomandibular-joint",
+      "type": "part_of",
+      "label": "accessory ligament"
+    },
+    {
+      "source": "pterygomandibular-raphe",
+      "target": "mandible",
+      "type": "attaches_to",
+      "label": "mylohyoid line",
+      "direction": "inferior"
+    },
+    {
+      "source": "hyoid-bone",
+      "target": "thyrohyoid-membrane",
+      "type": "landmark_for",
+      "direction": "superior"
+    },
+    {
+      "source": "alar-fascia",
+      "target": "deep-cervical-fascia",
+      "type": "part_of"
+    },
+    {
+      "source": "carotid-sheath",
+      "target": "investing-layer-deep-cervical-fascia",
+      "type": "continuous_with"
+    },
+    {
+      "source": "carotid-sheath",
+      "target": "pretracheal-visceral-fascia",
+      "type": "continuous_with"
+    },
+    {
+      "source": "carotid-sheath",
+      "target": "prevertebral-fascia",
+      "type": "continuous_with"
+    },
+    {
+      "source": "parapharyngeal-space",
+      "target": "investing-layer-deep-cervical-fascia",
+      "type": "bounded_by",
+      "direction": "lateral"
+    },
+    {
+      "source": "carotid-sheath",
+      "target": "internal-jugular-vein",
+      "type": "forms",
+      "label": "contents"
+    },
+    {
+      "source": "carotid-sheath",
+      "target": "vagus-nerve",
+      "type": "forms",
+      "label": "contents"
     }
   ]
 }

--- a/docs/authoring-kag.md
+++ b/docs/authoring-kag.md
@@ -1,0 +1,108 @@
+# Authoring the KAG (nodes, edges, enrichment)
+
+This is the committed version of the process used to build the term web and the
+structural atlas. You never edit `data/kag-graph.json` by hand. Instead you
+write **shards** — small `{nodes, edges}` files — and let
+`tools/kag-validate.mjs` validate and merge them. The schema every shard obeys
+is `docs/kag-schema.md`; read it first.
+
+## A shard
+
+A shard is a single JSON object with two arrays and **no file wrapper**:
+
+```jsonc
+{
+  "nodes": [ Node, ... ],   // Node schema per docs/kag-schema.md
+  "edges": [ Edge, ... ]    // Edge schema per docs/kag-schema.md
+}
+```
+
+Drop one or more shard files into a shard directory (e.g.
+`scratchpad_p2/shards/<batch>.json`). One shard per authoring scope
+(subspecialty or anatomical region) keeps them small and reviewable.
+
+## The authoring contract
+
+1. **Kebab-case ids** (`[a-z0-9]+(-[a-z0-9]+)*`), globally unique. The validator
+   warns on non-kebab ids.
+2. **Reuse existing ids.** Do not re-author `facial-nerve`, `cochlea`, etc. —
+   add edges *to* them. On an id collision the seed / earlier shard wins and
+   your duplicate node is skipped.
+3. **Cite every node:** ≥1 entry in `sources`. Authored nodes are written with
+   `review:false` (the validator forces this on shard nodes regardless of what
+   you put). A node graduates to `review:true` only when the owner (a resident)
+   vets it.
+4. **No fabrication.** If something is uncertain, say so in `detail` and leave
+   `review:false`. Prefer owner-supplied source text; otherwise cite researched
+   sources.
+5. **Structural fields only for physical structures.** Set `structure`,
+   `region`, `laterality`, and edge `direction` only on real anatomical
+   structures. Non-structural nodes (pathology, procedure, nerve, vessel,
+   concept) leave `structure`/`region` null and never appear in the atlas.
+6. **Give every node an `oksat.topics` entry** where possible — it is how
+   coverage is traced. The validator warns when a node has no topics.
+7. **Every edge endpoint must resolve** to a node id in the final merged graph.
+   Edges with a missing endpoint are silently dropped (no dangling edges ever
+   land).
+
+### OKSAT concept links must be real
+
+`node.oksat.concepts` entries are `{ module: "<slug>", concept: "<cKey>" }`.
+The `concept` must be a **real CONCEPTS key** of that module — the validator
+loads the actual module files (`js/mcq-modules/*.js`) and checks each pair
+against the module's `CONCEPTS` object. Any pair that does not resolve is
+**dropped** with a warning (it does not fail the shard). Likewise
+`oksat.modules` entries must be known module slugs, or they are filtered out.
+Copy concept keys exactly — they are load-bearing (see the appendix in
+`docs/oto-kag-atlas-plan.md`).
+
+## Validate + merge
+
+```bash
+node tools/kag-validate.mjs --dir <shardDir> [--graph data/kag-graph.json] [--dry]
+```
+
+Defaults: `--dir scratchpad_p2/shards`, `--graph data/kag-graph.json`. Use
+`--dry` to validate and print the report **without writing** the graph. The
+script never throws on bad data — it coerces, drops, and reports.
+
+**What it coerces:**
+
+- `type` not in the node enum → `concept`.
+- legacy `subspecialty` → canonical via the map; anything else → `fundamentals`.
+- `structure` / `region` / `laterality` not in their enums → `null`.
+- edge `type` not in the enum → `contained_in`.
+- v2 fields defaulted (`aliases:[]`, `abbrev:null`, `leitner:{box:1,…}`, etc.);
+  shard nodes forced to `review:false`.
+
+**What it drops:**
+
+- shard nodes whose `id` collides with an existing node (seed / earlier shard
+  wins).
+- `oksat.concepts` / `oksat.modules` entries that don't resolve to a real
+  module key.
+- edges whose `source` or `target` is missing from the final node set, and
+  duplicate edges (`source|target|type` already present).
+
+**Coverage report.** After merging it prints seed-vs-added node/edge counts,
+collisions and dropped/dangling edge totals, structural-node and oksat-linked
+counts, dropped-link count, per-shard additions, per-subspecialty node counts,
+taxonomy topic coverage (with any UNCOVERED topics listed), and a final audit
+of dangling edges and duplicate ids. Without `--dry` (and if no shard-parse
+errors occurred) it writes the merged graph back to `--graph`.
+
+## Fan-out pattern (how the graph was built)
+
+Bulk authoring is fanned out: **one authoring agent per subspecialty (term web)
+or per anatomical region (structural atlas)**. Each agent gets the schema, the
+enums, its scope, and the relevant concept keys, and returns one shard. Each
+shard is validated (fix loop: send the validator's error/warning list back to
+the same agent, don't respawn cold), then merged serially so the id space stays
+consistent. All authored content stays `review:false` until the owner's
+clinical review pass. The full playbook is in `docs/oto-kag-atlas-plan.md` §9.
+
+## Related
+
+- `docs/kag-schema.md` — the v2 data model and all enums.
+- `docs/oto-kag-atlas-plan.md` — master plan, architectural decisions, and the
+  load-bearing OKSAT concept-key appendix.

--- a/docs/kag-schema.md
+++ b/docs/kag-schema.md
@@ -1,0 +1,188 @@
+# KAG schema (v2)
+
+The Knowledge Atlas Graph is the site's canonical OHNS knowledge graph. It lives
+in one committed file, `data/kag-graph.json`, and every surface that shows graph
+data (`kag.html`, `atlas.html`, the OKSAT crossover links) reads it through
+`js/kag-store.js`. GitHub Pages is static, so **the JSON file *is* the
+database** — there is no server and no build step. This document is the exact
+contract every reader and every authored shard obeys. It is authoritative:
+enums below are copied verbatim from `tools/kag-validate.mjs`.
+
+Current graph: ~656 nodes / ~929 edges, 265 of them structural; the 40-node
+temporal-bone seed is vetted (`review:true`), every other authored node is
+`review:false` pending owner clinical review.
+
+## File wrapper
+
+```jsonc
+{
+  "version": 2,
+  "updated": "<ISO timestamp>",
+  "status": "DRAFT — pending clinical review.",   // free text; DRAFT until owner sign-off
+  "sources": ["Cummings Otolaryngology 7e", "AAO-HNSF Core Curriculum"],
+  "nodes": [ Node, ... ],
+  "edges": [ Edge, ... ]
+}
+```
+
+`version` is `2`. Schema v2 is **additive and backward-compatible**: every v2
+field is optional, v1 nodes/edges load unchanged, and every reader guards each
+new field.
+
+## Node
+
+```jsonc
+{
+  // --- v1 (unchanged) ---
+  "id": "cricoid-cartilage",            // kebab-case slug, globally unique
+  "label": "Cricoid Cartilage",
+  "type": "anatomy",                    // NODE_TYPES enum
+  "subspecialty": "laryngology",        // one of the 9 canonical keys
+  "detail": "Only complete cartilaginous ring of the airway…",
+  "sources": ["Cummings 7e"],           // >=1 required for authored nodes
+  "corrections": [],                    // [{ text, source, date, resolved }]
+  "leitner": { "box": 1, "nextReview": "<TODAY>" },
+
+  // --- v2 additive ---
+  "aliases": ["signet-ring cartilage"], // synonyms; feed search + term DB
+  "abbrev": null,                       // short form string, or null
+  "structure": "cartilage",             // STRUCTURES enum, or null (non-structural)
+  "region": "larynx",                   // REGIONS enum, or null
+  "laterality": "midline",              // midline | paired | null
+  "oksat": {                            // links INTO OKSAT (may be empty)
+    "modules": [],                      // manifest slugs
+    "concepts": [],                     // [{ module: "<slug>", concept: "<cKey>" }]
+    "topics": []                        // OKSAT_TAXONOMY topic ids
+  },
+  "review": false                       // true once a human vets the node
+}
+```
+
+A node is **structural** (appears in `atlas.html`) iff `structure` is set to a
+valid enum value. `structure` and `region` are orthogonal to `subspecialty`:
+a bone can be `subspecialty:'fundamentals'` yet `region:'larynx'`. Clinical
+subspecialty and anatomical region are separate axes.
+
+## Edge
+
+```jsonc
+{
+  "source": "cricothyroid-joint",       // must resolve to a node id
+  "target": "cricoid-cartilage",        // must resolve to a node id
+  "type": "part_of",                    // EDGE_TYPES enum
+  "label": "articulates at facet",      // optional human phrase
+  "direction": "inferior"               // optional spatial seed for a future 3D layer
+}
+```
+
+Edges have no id and no weight. Edge identity for dedup is
+`source|target|type`. `label` and `direction` are optional and only emitted
+when present.
+
+## Enums (verbatim from `tools/kag-validate.mjs`)
+
+### Node `type`
+
+| Value |
+|---|
+| `anatomy` |
+| `pathology` |
+| `procedure` |
+| `nerve` |
+| `vessel` |
+| `drug` |
+| `concept` |
+
+Bad/absent `type` is coerced to `concept`.
+
+### `subspecialty` — 9 canonical keys
+
+`otology`, `rhinology`, `laryngology`, `hn_onc`, `fprs`, `pediatrics`,
+`sleep`, `endocrine`, `fundamentals`.
+
+Unknown value → coerced to `fundamentals`.
+
+**Legacy → canonical map** (applied on read by `KAGStore.normSub` and by the
+validator):
+
+| Legacy KAG value | Canonical |
+|---|---|
+| `head-neck-onc` | `hn_onc` |
+| `peds-ent` | `pediatrics` |
+| `facial-plastics` | `fprs` |
+| `skull-base` | `otology` (its clinical home; use `region:'skull-base'` for grouping) |
+
+### `structure` (atlas membership; or `null`)
+
+`bone`, `cartilage`, `ligament`, `fascia`, `joint`, `foramen`, `space`,
+`membrane`, `muscle`.
+
+`atlas.html` defaults to showing `bone`/`cartilage`/`ligament`/`fascia`/`joint`
+and lets the user toggle the rest. `structure:null` = non-structural → not in
+the atlas view.
+
+### `region` (atlas grouping; or `null`)
+
+`temporal-bone`, `skull-base`, `facial-skeleton`, `nasal-sinus`, `larynx`,
+`neck`, `oral-pharynx`, `cervical-spine-hyoid`, `external-ear`.
+
+### `laterality`
+
+`midline`, `paired`, or `null`.
+
+### Edge `type`
+
+**v1 relational (11):** `innervates`, `supplies`, `drains_to`, `landmark_for`,
+`complication_of`, `differentiates_from`, `treats`, `staged_with`,
+`arises_from`, `contained_in`, `branches_from`.
+
+**v2 structural (9):** `articulates_with`, `attaches_to`, `part_of`,
+`bounded_by`, `continuous_with`, `passes_through`, `transmits`, `suspends`,
+`forms`.
+
+Unknown edge `type` is coerced to `contained_in`.
+
+### Edge `direction` (optional spatial seed)
+
+`superior`, `inferior`, `medial`, `lateral`, `anterior`, `posterior`, `deep`,
+`superficial`, or `null`. Surfaced by the atlas now; reserved for a future 3D
+layer.
+
+## Storage & merge model
+
+The committed file is the shared, canonical copy. Each browser also keeps its
+own progress in `localStorage['kag-graph']` (Leitner boxes, corrections). On
+load, readers fetch the file and merge the two — **local wins**:
+
+- `KAGStore.fetch()` — GET `data/kag-graph.json?ts=…` with `cache:'no-store'`;
+  cached after the first call; returns `null` on any failure (never throws).
+- `KAGStore.merge(fileGraph)` — union of local and file. For every node the
+  local copy already has (by `id`), the local node is kept; the file only
+  **adds** nodes/edges the local copy is missing. Edges dedup by
+  `source|target|type`. This preserves the user's progress while still pulling
+  in new authored content.
+- `KAGStore.save(graph)` — writes `localStorage['kag-graph']` (guarded).
+
+### Two write paths (both require an explicit owner action)
+
+1. **Download to commit** — `KAGStore.download(graph)` writes the merged graph
+   to a `kag-graph.json` file the owner commits to the repo.
+2. **Contents-API push** — `KAGStore.push(graph, token)` PUTs
+   `data/kag-graph.json` via the GitHub Contents API. The fine-grained token is
+   pasted at sync time, used for that request only, and **never persisted**
+   (not localStorage, not the file, not the repo).
+
+Nothing writes to the repo automatically.
+
+### Deep links
+
+Both `kag.html` and `atlas.html` accept `?node=<id>`: on boot they center and
+isolate that node's neighborhood and open its detail panel. Unknown id → no-op
+(kag) or a toast (atlas). This is the target of every "Open in KAG" /
+"Practice" crossover link.
+
+## Related
+
+- `docs/authoring-kag.md` — how to author/enrich nodes and edges and run the
+  validator.
+- `docs/oto-kag-atlas-plan.md` — the master plan and architectural decisions.

--- a/docs/oto-kag-atlas-plan.md
+++ b/docs/oto-kag-atlas-plan.md
@@ -282,13 +282,21 @@ staged_with, arises_from, contained_in, branches_from`.)
 ## 5. Phase map (dependencies)
 
 ```
-Phase 0  Externalize KAG + kag-store + deep links        (foundation)
-Phase 1  Schema v2 fields + module↔KAG links + extractor upgrade
-Phase 2  Term-web expansion  (subagent fan-out, per subspecialty)   ── needs 1
-Phase 3  Usage analytics (hybrid; owner provisions endpoint)        ── independent, needs 0
-Phase 4  Structural anatomy atlas (subagent fan-out, per region)    ── needs 1 (+2 helps)
+Phase 0  Externalize KAG + kag-store + deep links        (foundation)   [DONE]
+Phase 1  Schema v2 fields + module↔KAG links + extractor upgrade        [DONE]
+Phase 2  Term-web expansion  (subagent fan-out, per subspecialty)       [DONE]
+Phase 4  Structural anatomy atlas (subagent fan-out, per region)        [DONE]
+Phase 4b Atlas relationship augmentation (subagent fan-out, per region) [IN PROGRESS]
+Phase 3  Usage analytics (hybrid; owner provisions endpoint)            [DEFERRED — owner call 2026-07, not needed for now]
 Phase 5  Navigation, docs, versioning, hygiene, regression          ── needs all
 ```
+
+**Plan amendment (2026-07, owner):** Phase 3 (usage analytics) is deferred —
+not necessary for now. Inserted **Phase 4b** before Phase 5: augment the
+structural atlas with additional anatomic features and, especially,
+relationships (articulations, attachments, boundaries, part-of hierarchies),
+fanned out per anatomical region. All authored content stays `review:false`
+for the owner's later curated-source stress test.
 Each phase ends with a runnable site (`python3 -m http.server 8000`) and its
 checklist passing. One commit per phase on
 `claude/oto-kag-anatomy-atlas-x19jfa`.

--- a/docs/oto-kag-atlas-plan.md
+++ b/docs/oto-kag-atlas-plan.md
@@ -286,9 +286,9 @@ Phase 0  Externalize KAG + kag-store + deep links        (foundation)   [DONE]
 Phase 1  Schema v2 fields + module↔KAG links + extractor upgrade        [DONE]
 Phase 2  Term-web expansion  (subagent fan-out, per subspecialty)       [DONE]
 Phase 4  Structural anatomy atlas (subagent fan-out, per region)        [DONE]
-Phase 4b Atlas relationship augmentation (subagent fan-out, per region) [IN PROGRESS]
+Phase 4b Atlas relationship augmentation (subagent fan-out, per region) [DONE]
 Phase 3  Usage analytics (hybrid; owner provisions endpoint)            [DEFERRED — owner call 2026-07, not needed for now]
-Phase 5  Navigation, docs, versioning, hygiene, regression          ── needs all
+Phase 5  Navigation, docs, versioning, hygiene                          [DONE — nav in P4, docs/hygiene here; analytics parts N/A (P3 deferred)]
 ```
 
 **Plan amendment (2026-07, owner):** Phase 3 (usage analytics) is deferred —

--- a/docs/oto-kag-atlas-plan.md
+++ b/docs/oto-kag-atlas-plan.md
@@ -1,0 +1,779 @@
+# OHNS Term Web, Usage Analytics & Structural Anatomy Atlas — Master Plan
+
+*Plan only. Granular, contingency-covered, written so a less-capable executor
+model (or a fleet of subagents) can build it phase by phase without holes.
+Grounded on the REAL repo as it exists on branch
+`claude/oto-kag-anatomy-atlas-x19jfa` — every file path, storage key, id
+format, and deep-link string below was verified against the current code.*
+
+---
+
+## 0. What we are building (three pillars, one graph)
+
+The site already has two knowledge surfaces that must now be fused and grown:
+
+- **KAG** — `kag.html` + `kag-extract.html`: a Cytoscape knowledge graph of OHNS
+  entities (`{nodes, edges}`) with a Leitner self-test. Today it lives **only**
+  in `localStorage['kag-graph']`; the 40-node seed is hard-coded inside
+  `kag.html` (all temporal-bone otology). There is **no committed KAG data
+  file** — unlike OKSAT.
+- **OKSAT** — `oksat.html` + 5 question modules + `js/oksat-*.js`: a study
+  platform with a hub Atlas graph, a draft 62-topic taxonomy
+  (`js/oksat-taxonomy.js`), a cross-module concept graph
+  (`js/oksat-concept-graph.js`), and a shared **committed** database
+  `data/oksat-db.json` synced via the GitHub Contents API.
+
+The three deliverables the owner asked for:
+
+1. **Otolaryngology term database (KAG expansion).** Turn the KAG into a
+   *massive interconnected web* mirroring the OHNS core content, and wire it
+   **bidirectionally** to OKSAT questions/modules/topics so a learner can
+   traverse term → question → module → topic and back.
+2. **Usage analytics.** Log visitors, number of uses, and question statistics —
+   **cumulative** and **auto-saved to the site**.
+3. **Structural anatomy atlas.** Bones, cartilage, ligaments, fascia only.
+   3D deferred — for now **encode every relationship and name every structure**.
+   The atlas is **not a new dataset**; it is a *structural view of the KAG*, so
+   `module → KAG (detailed relationships) → anatomy atlas` is one pipeline with
+   the KAG as the single source of truth (this is how we "reduce redundancy").
+
+**The unifying architectural decision (D0):** the KAG becomes the site's
+canonical knowledge graph, externalized into a committed, growing data file.
+The term web, the module links, and the anatomy atlas are all layers/views on
+that one file. Nothing is authored twice.
+
+---
+
+## 1. Verified inventory (do not re-derive — this is ground truth)
+
+### 1.1 KAG (`kag.html`)
+- **Storage:** single key `localStorage['kag-graph']` = `{nodes, edges}`.
+  `loadGraph()` returns it or deep-copies `SEED_GRAPH`; `saveGraph(g)` writes it.
+- **Node schema:** `{ id (kebab slug), label, type, subspecialty, detail,
+  sources[], corrections[], leitner:{box,nextReview} }`.
+- **Edge schema:** `{ source, target, type, label? }` (no id, no weight).
+- **Node `type` enum:** `anatomy | pathology | procedure | nerve | vessel |
+  drug | concept`. `NODE_COLORS` (bright, saturated) keys off `type`.
+- **Seed:** 40 nodes (24 anatomy, 5 nerve, 2 vessel, 4 pathology, 5 procedure),
+  52 edges. All `subspecialty: otology` except `vestibular-schwannoma`
+  (`skull-base`). Edge types used: `contained_in`×21, `landmark_for`×11,
+  `complication_of`×6, `treats`×5, `innervates`×3, `arises_from`×3,
+  `branches_from`×2, `supplies`×1.
+- **Leitner:** `LEITNER_INTERVALS={1:1,2:3,3:7,4:14,5:30}` days;
+  due = `leitner.nextReview <= today`; grade buttons `data-conf` =
+  `again|hard|good|easy`.
+- **Corrections:** `node.corrections[] = {text, source, date, resolved}`;
+  inbox in Settings modal; `hasCorrections` drives a yellow border.
+- **Filter pills:** built from KAG's OWN subspecialty list
+  `['rhinology','otology','head-neck-onc','laryngology','peds-ent',
+  'skull-base','facial-plastics']` and filter on the node `subspecialty` field.
+  **This vocabulary DIFFERS from OKSAT's — see §3 reconciliation.**
+- **Search:** matches `label` OR `detail`.
+- **Import/Export/Reset:** import requires `{nodes, edges}`, dedups nodes by
+  `id`, edges by `source|target|type`; export downloads
+  `kag-graph-<TODAY>.json`; reset restores `SEED_GRAPH`.
+
+### 1.2 Extractor (`kag-extract.html`)
+- Model `claude-sonnet-4-20250514`, endpoint
+  `https://api.anthropic.com/v1/messages`, streaming, browser-direct.
+- Node types + edge types = the enums above. Node requires `id`+`label`;
+  fills defaults (`type`→`concept`, `subspecialty`→`rhinology`, empty
+  `sources/corrections`, `leitner{box:1,nextReview:today}`).
+- **Merge → `localStorage['kag-graph']`**, dedup nodes by `id`, edges by
+  `source|target|type`. API key in `localStorage['kag-api-key']`.
+
+### 1.3 OKSAT modules (exact slugs, counts, keys)
+| Slug | Items | DOMAINS (keys) | # CONCEPT keys |
+|---|---|---|---|
+| `pediatrics` | 40 mcq | foundations, CHL, SNHL, syndromic, workup, management, cases | ~53 |
+| `ta-tubes` | 54 mcq | foundations, bmt, tonsillectomy, neck, complications, cases | ~44 |
+| `vestibular-schwannoma` | 46 mcq | anatomy, pathophysiology, epidemiology, diagnosis, treatment, complications, NF2, cases | ~36 |
+| `facial-reanimation` | 42 mcq | anatomy, physiology, evaluation, workup, treatment, complications, cases | ~27 |
+| `dtc-risk-stratification` | 25 recall | staging, operative, completion, pathology, riskStrat, controversy | ~25 |
+
+**Total 207 items, ~180 concept keys.** The full key→label→domain lists for all
+five modules were extracted and are attached in **Appendix A** (executors copy
+verbatim — the keys are load-bearing). **Known data-hygiene bug:** `pediatrics`
+CONCEPTS defines `CHL` twice (the second wins); flag during Phase 1.
+
+### 1.4 OKSAT wiring (deep links + ids)
+- Viewer: `oksat-study.html?m=<slug>` (reads `m`; `c` is passed through to the
+  engine). Script load order ends: manifest → store → reviewer → prefs →
+  taxonomy → concept-graph → engine.
+- Adaptive: `oksat-adaptive.html?t=<topicId>`.
+- Atlas node ids: sub `s:<subspecialty>`, module `m:<slug>`,
+  domain `d:<slug>:<dKey>`, concept `c:<slug>:<cKey>`, gap `g:<topicId>`,
+  crossover literal `kag`. Tap: module→`oksat-study.html?m=`, concept→
+  `oksat-study.html?m=&c=`, gap→`oksat-adaptive.html?t=`, kag→`kag.html`.
+- `window.OKSATAtlas.loadModules()` → Promise of `{slug:{meta,DOMAINS,CONCEPTS,
+  ITEMS}}` (fetch + `new Function` sandbox). **Reuse this everywhere** modules
+  must be read outside the study page.
+- Shared DB `data/oksat-db.json` v2 via `js/oksat-db.js`
+  (`fetch`/`buildMerged`/`download`/`push`). Contents-API `push()` uses a
+  runtime-only token. **Both write paths need the owner to act — nothing writes
+  automatically.** (Load-bearing for Pillar 2.)
+
+### 1.5 Design system (obey it)
+- Tokens only (`css/oksat.css --ok-*`), warm cream canvas, sage/rust feedback,
+  one hue per subspecialty (`OKSAT_SUBSPECIALTIES`), keyboard-first, no build
+  step, degrade gracefully. `js/main.css` styles the older tool pages
+  (kag.html uses its own dark theme + bright `NODE_COLORS`). New surfaces should
+  match OKSAT tokens; KAG/atlas may keep the dark "graph" aesthetic but must be
+  internally consistent and themeable.
+
+---
+
+## 2. Architectural decisions (made once — do not revisit mid-build)
+
+- **D0 — One canonical graph file.** Externalize the KAG into committed
+  **`data/kag-graph.json`** (schema v2, §4). `kag.html`, the new `atlas.html`,
+  and all cross-links read it through **one new module `js/kag-store.js`**
+  (mirrors `js/oksat-db.js`). The in-HTML `SEED_GRAPH` stays only as an offline
+  fallback. **Reason:** a term web that grows and feeds an atlas cannot live in
+  one browser's localStorage or be trapped inside an HTML file.
+- **D1 — The anatomy atlas is a VIEW, never a copy.** `atlas.html` renders the
+  subset of `data/kag-graph.json` where `node.structure` is set (bone /
+  cartilage / ligament / fascia / joint / foramen / space), grouped by
+  `node.region`. Adding a structural node to the KAG makes it appear in the
+  atlas with **zero atlas-code changes**. This is the "reduce redundancy /
+  modules feed the atlas" mechanism.
+- **D2 — Schema v2 is additive and backward-compatible.** Every new field is
+  optional; v1 nodes/edges load unchanged; readers guard every new field. Bump
+  `version` to 2 but never require v2 fields.
+- **D3 — Subspecialty vocab is canonicalized on OKSAT's 9 keys**
+  (`OKSAT_SUBSPECIALTIES`). KAG's legacy values are mapped (§3). Anatomical
+  grouping moves to a **separate `region` field** (a bone can belong to
+  `fundamentals`/anatomy yet a `larynx` region). Clinical subspecialty and
+  anatomical region are orthogonal.
+- **D4 — Cumulative cross-visitor analytics REQUIRE an external write
+  endpoint.** A static Pages site cannot write to itself. Pillar 2 is therefore
+  a **hybrid** (§7): a cookieless hosted analytics script for visitor/pageview
+  counts + one tiny owner-hosted serverless KV endpoint for custom counters.
+  The site degrades to localStorage-only counters when neither is provisioned,
+  and NEVER breaks. Standing up the endpoint/account is an explicit **owner
+  step** the plan flags; do not fake it with an embedded write token (a public
+  site would leak it, and per-visitor commits race + spam history).
+- **D5 — Medical accuracy gate.** Authored nodes are **DRAFT until owner
+  review**. Authoring agents must cite a source per node, must NOT fabricate,
+  and must mark anything uncertain. `status:'DRAFT'` on the file + a
+  `review:false` flag per authored node; a node is not "vetted" until a resident
+  clears it. Prefer owner-supplied source text; else web research with
+  citations.
+- **D6 — No build step, ever.** New JS files are IIFEs exposing `window.*`,
+  loaded as plain `<script>` in a fixed order, every consumer guarded with
+  `window.X && …`. Dev-only tooling (validators) may use Node but is never
+  shipped to Pages.
+- **D7 — Subagent-first construction.** The bulk content work (term web +
+  structural atlas) is fanned out to parallel authoring subagents against a
+  strict JSON contract, each shard validated then merged (§9). One human/owner
+  review pass gates clinical accuracy.
+
+---
+
+## 3. Subspecialty & type reconciliation (do this before authoring anything)
+
+**Canonical subspecialty keys** = the 9 in `OKSAT_SUBSPECIALTIES`:
+`otology, rhinology, laryngology, hn_onc, fprs, pediatrics, sleep, endocrine,
+fundamentals`.
+
+**Legacy KAG → canonical map** (executor adds this table to `js/kag-store.js`
+and to `kag-extract.html`'s prompt):
+
+| KAG legacy | Canonical |
+|---|---|
+| `head-neck-onc` | `hn_onc` |
+| `peds-ent` | `pediatrics` |
+| `facial-plastics` | `fprs` |
+| `skull-base` | `otology` (clinical home) + `region:'skull-base'` |
+| `otology`,`rhinology`,`laryngology` | unchanged |
+
+**`region` enum (new, atlas grouping):** `temporal-bone, skull-base,
+facial-skeleton, nasal-sinus, larynx, neck, oral-pharynx, cervical-spine-hyoid,
+external-ear`. Extendable; keep kebab-case.
+
+**`structure` enum (new, atlas membership):** `bone, cartilage, ligament,
+fascia, joint, foramen, space, membrane, muscle` (muscle/space/foramen included
+as connective context; the atlas defaults to showing bone/cartilage/ligament/
+fascia and lets the user toggle the rest). `structure:null` = non-structural
+(pathology, procedure, nerve, vessel, concept) → not in the atlas view.
+
+**Node `type` enum stays as-is** (backward compat). Structural classification
+rides on the new `structure` field, not on `type` (a `type:'anatomy'` node gets
+`structure:'bone'`). The KAG's `NODE_COLORS` remains valid; the atlas colors by
+`structure` instead.
+
+---
+
+## 4. Schema v2 — exact shapes (the contract every subagent obeys)
+
+### 4.1 `data/kag-graph.json`
+```jsonc
+{
+  "version": 2,
+  "updated": "<ISO>",
+  "status": "DRAFT — pending clinical review by owner (OHNS resident).",
+  "sources": ["AAO-HNSF Core Curriculum", "Cummings 7e", "..."],
+  "nodes": [ Node, ... ],
+  "edges": [ Edge, ... ]
+}
+```
+
+### 4.2 Node (v2) — new fields all optional
+```jsonc
+{
+  // --- v1 (unchanged) ---
+  "id": "cricoid-cartilage",            // kebab slug, globally unique
+  "label": "Cricoid Cartilage",
+  "type": "anatomy",                    // v1 enum, unchanged
+  "subspecialty": "laryngology",        // one of the 9 canonical keys
+  "detail": "Only complete cartilaginous ring of the airway...",
+  "sources": ["Cummings 7e"],           // >=1 required for authored nodes (D5)
+  "corrections": [],
+  "leitner": { "box": 1, "nextReview": "<TODAY>" },
+
+  // --- v2 additive ---
+  "aliases": ["signet ring cartilage"], // synonyms → search + term DB
+  "abbrev": null,
+  "structure": "cartilage",             // §3 enum, or null (non-structural)
+  "region": "larynx",                   // §3 enum, or null
+  "laterality": "midline",              // midline | paired | null
+  "oksat": {                            // links INTO OKSAT (may be empty)
+    "modules": [],                      // manifest slugs
+    "concepts": [],                     // [{ "module": "<slug>", "concept": "<cKey>" }]
+    "topics": []                        // OKSAT_TAXONOMY topic ids
+  },
+  "review": false                       // true once a human vets it
+}
+```
+
+### 4.3 Edge (v2) — new relation types + spatial seed
+```jsonc
+{
+  "source": "cricothyroid-joint",
+  "target": "cricoid-cartilage",
+  "type": "part_of",                    // enum below
+  "label": "articulates at facet",      // optional human phrase
+  "direction": "inferior",              // OPTIONAL spatial seed for 3D-later:
+                                        // superior|inferior|medial|lateral|
+                                        // anterior|posterior|deep|superficial|null
+  "sources": []                         // optional
+}
+```
+**Edge `type` enum v2** = v1 eleven values **plus** structural relations:
+`articulates_with, attaches_to, part_of, bounded_by, continuous_with,
+passes_through, transmits, suspends, forms`. (v1: `innervates, supplies,
+drains_to, landmark_for, complication_of, differentiates_from, treats,
+staged_with, arises_from, contained_in, branches_from`.)
+
+**Validation rules (every shard, every phase):**
+1. `id` unique across the whole graph; kebab-case; `[a-z0-9-]+`.
+2. Every edge `source`/`target` resolves to a node `id` in the merged graph
+   (no dangling). Edge `type` ∈ enum. Node `type` ∈ enum. `subspecialty` ∈ 9
+   canonical. `structure`/`region` ∈ enum or null.
+3. Authored node has ≥1 `sources` entry and `review:false` (D5).
+4. `oksat.concepts[].module`/`.concept` resolve to a real module/CONCEPT key
+   (validated against Appendix A / `loadModules()`), else dropped with a warning
+   (lazy, never throw — mirror `OKSATGraph.audit()`).
+5. Dedup: nodes by `id` (first-write-wins on merge unless the newer has
+   `review:true`), edges by `source|target|type`.
+
+---
+
+## 5. Phase map (dependencies)
+
+```
+Phase 0  Externalize KAG + kag-store + deep links        (foundation)
+Phase 1  Schema v2 fields + module↔KAG links + extractor upgrade
+Phase 2  Term-web expansion  (subagent fan-out, per subspecialty)   ── needs 1
+Phase 3  Usage analytics (hybrid; owner provisions endpoint)        ── independent, needs 0
+Phase 4  Structural anatomy atlas (subagent fan-out, per region)    ── needs 1 (+2 helps)
+Phase 5  Navigation, docs, versioning, hygiene, regression          ── needs all
+```
+Each phase ends with a runnable site (`python3 -m http.server 8000`) and its
+checklist passing. One commit per phase on
+`claude/oto-kag-anatomy-atlas-x19jfa`.
+
+---
+
+## 6. Phase 0 — Externalize the KAG (foundation, near-zero visible change)
+
+**Goal:** move the graph out of the HTML into a committed file read through a
+store, without changing what the user sees.
+
+**Steps**
+1. **Extract the seed → `data/kag-graph.json`.** Copy the current `SEED_GRAPH`
+   (kag.html ~988–1084) into the v2 wrapper (§4.1); for each node add the v2
+   fields as empty/null (`aliases:[]`, `structure:null`, `region:null`,
+   `laterality:null`, `oksat:{modules:[],concepts:[],topics:[]}`, `review:true`
+   — the seed is already vetted). Normalize the one `skull-base` node to
+   `subspecialty:'otology'` + `region:'skull-base'`. Do NOT change ids/labels/
+   details (progress keys off ids). Keep `version:2`.
+2. **New `js/kag-store.js`** (IIFE → `window.KAGStore`), mirroring
+   `js/oksat-db.js`:
+   ```
+   fetch()            // GET data/kag-graph.json?ts=... no-store; fallback SEED
+   merge(fileGraph)   // fileGraph ∪ localStorage['kag-graph']; dedup rules §4.5
+   load()             // merged graph (what kag.html should render)
+   save(graph)        // write localStorage['kag-graph'] (unchanged key)
+   download(graph)    // Blob → kag-graph.json (commit-to-persist path)
+   push(graph, token) // GitHub Contents API PUT data/kag-graph.json (owner path)
+   reverseConcept()   // {"<module>:<cKey>": [nodeId,...]}  built from node.oksat
+   normSub(x)         // legacy→canonical map (§3)
+   audit()            // dangling edges, bad enums, id dupes (console helper)
+   ```
+   Reuse `oksat-db.js`'s `REPO`, token-never-persisted discipline, and merge
+   idioms verbatim where possible.
+3. **Refactor `kag.html`** to boot from the store: on load
+   `KAGStore.fetch().then(f => render(KAGStore.merge(f)))`; keep `SEED_GRAPH`
+   only inside the `fetch` catch. Self-test, corrections, filters, search,
+   import/export **unchanged** (they still read/write `localStorage['kag-graph']`
+   through `saveGraph`). Add `<script src="js/kag-store.js">` before the inline
+   script.
+4. **Deep link `?node=<id>`** in `kag.html`: on boot, if present, center +
+   isolate that node's neighborhood (reuse the existing double-click isolate
+   path). Unknown id → no-op + toast. This is the anchor every "open in KAG"
+   link (Phase 1) will target.
+5. **Sync panel** in the KAG Settings modal (copy OKSAT's): "Download merged
+   graph" + "Push via token" using `KAGStore.download/push`. This is how the
+   term web persists to the repo.
+
+**Verify:** kag.html renders the identical 40-node graph, now sourced from
+`data/kag-graph.json` (confirm via Network tab). Self-test due counts, grading,
+corrections inbox, import/export, filter pills, search all behave as before.
+`kag.html?node=cochlea` opens focused on the cochlea. `KAGStore.audit()` returns
+`[]`. Delete `data/kag-graph.json` locally → falls back to seed, no crash.
+
+---
+
+## 7. Phase 1 — Schema v2 + module↔KAG links + extractor upgrade
+
+**Goal:** make the graph richer and *bidirectionally* connected to OKSAT.
+
+**Steps**
+1. **Apply v2 fields to the seed** (already present as empty from Phase 0) and
+   **populate `oksat` links for the 40 seed nodes** where obvious (e.g. node
+   `cochlea` → concepts in `pediatrics`/`vestibular-schwannoma`; `facial-nerve`
+   → facial-reanimation/VS `facial-nerve`; `stapes`/`oval-window` → otology
+   concepts). Use Appendix A to pick exact `{module,concept}` pairs. Also set
+   `structure`/`region` for the 40 seed nodes (they are all temporal-bone; most
+   are `structure:'bone'|'space'|'membrane'`, ossicles `bone`, TM `membrane`,
+   annular ligament etc. — see Phase 4 for the exhaustive ear list).
+2. **Extractor (`kag-extract.html`) upgrade:** extend the SYSTEM_PROMPT + schema
+   to emit v2 fields — `aliases`, `structure` (from the enum or null), `region`,
+   `laterality`, and `oksat.concepts` when the text names a concept that maps to
+   a module (give the model Appendix A as a lookup, or instruct it to leave
+   `oksat` empty for a human/Phase-1 mapping pass). Normalize `subspecialty` to
+   the 9 canonical keys via the §3 map. Keep the merge target
+   `localStorage['kag-graph']` **and** add a "Download shard" button so
+   extractor output can be committed to `data/kag-graph.json` through the store.
+3. **Module→KAG reverse index** at runtime: `KAGStore.reverseConcept()` builds
+   `"<module>:<concept>" → [nodeId]` from every node's `oksat.concepts`. No new
+   data file needed — the links live on the nodes (single source of truth).
+4. **Traversal UI — KAG side (`kag.html` node panel):** when a node has
+   `oksat.concepts`, render **"Practice"** chips linking
+   `oksat-study.html?m=<module>&c=<concept>`; when it has `oksat.topics`, a
+   **"Adaptive drill"** chip → `oksat-adaptive.html?t=<topicId>`; when
+   `oksat.modules`, a **"Open module"** chip. Chips use OKSAT subspecialty hues.
+5. **Traversal UI — OKSAT side:**
+   - `js/oksat-atlas.js`: on **concept** tap, if `KAGStore.reverseConcept()` has
+     a node for `<slug>:<concept>`, offer/deep-link `kag.html?node=<id>` (make
+     the crossover node-level & bidirectional, not just the single `kag` hub
+     node). Guard on `window.KAGStore`.
+   - Add `<script src="js/kag-store.js">` to `oksat.html` (and later
+     `oksat-study.html`) so the reverse index is available. Guard everything.
+6. **Data-hygiene fix:** resolve the duplicate `CHL` key in
+   `js/mcq-modules/pediatrics.js` (rename the concept-level one, e.g.
+   `CHL-overview`, and update any items referencing it) — do this carefully,
+   re-run the module, keep item count at 40. If risky, leave it and note it in
+   Appendix A as a known collision the mapping must treat as one node.
+
+**Verify:** a seed node with links shows Practice/Adaptive chips that open the
+right question set; an OKSAT concept node with a KAG match round-trips to
+`kag.html?node=…` and back; extractor emits v2 fields and normalized
+subspecialties; `KAGStore.reverseConcept()` has no entries pointing at
+nonexistent module/concept pairs; all 5 modules still load and answer.
+
+---
+
+## 8. Phase 2 — The term web (massive KAG expansion via subagent fan-out)
+
+**Goal:** grow the KAG from 40 otology nodes to a web covering the whole OHNS
+core content, every node linked to the OKSAT concepts/topics it supports.
+
+**Coverage target:** every one of the 62 `OKSAT_TAXONOMY` topics gets a cluster
+of nodes (entities: key anatomy, pathologies, procedures, drugs, staging/
+classification concepts) and their edges; **every OKSAT concept key (Appendix A)
+resolves to ≥1 KAG node** via `node.oksat.concepts`. Prioritize P1 topics first.
+
+**Fan-out design (see §9 for the reusable playbook):**
+- **Batching:** group the 62 topics into ~10 batches by subspecialty (otology,
+  rhinology, laryngology, hn_onc, fprs, pediatrics, sleep, endocrine,
+  fundamentals) — one **authoring subagent per batch**. Big subspecialties
+  (hn_onc, otology) may split into two batches. Each batch is capped (~30–60
+  nodes) so shards stay reviewable.
+- **Each authoring subagent** receives: the schema v2 contract (§4), the §3
+  enums + subspecialty map, its batch's taxonomy topics (with keywords), the
+  relevant slice of Appendix A (so it can fill `oksat.concepts`), any
+  owner-supplied source text, and the no-fabrication + cite-every-node rule
+  (D5). It returns **one JSON shard** `{nodes:[...], edges:[...]}` (no wrapper),
+  `review:false`, ≥1 `sources` per node.
+- **Each shard is validated** by a validator pass (§9 rules + dev script
+  `tools/kag-validate.mjs`) before merge: enums, dangling edges, id collisions
+  against the current graph, oksat-link resolution.
+- **Merge** via `KAGStore.merge` semantics into `data/kag-graph.json`; then run
+  `KAGStore.audit()` and a coverage report (every taxonomy topic touched? every
+  concept key resolved?).
+
+**Content guidance for authors (bake into the agent prompt):** prefer entities
+and relationships that mirror how OHNS is tested — anatomy landmarks, staging
+systems (AJCC/TNM, Koos, House-Brackmann, ATA tiers, Cotton-Myer, Brodsky),
+syndromes/genes, drugs, complications, and the `treats`/`complication_of`/
+`differentiates_from` edges that make the web *traversable for reasoning*, not
+just a glossary. Reuse existing node ids (do not duplicate `facial-nerve`,
+`cochlea`, etc.); add edges to them instead.
+
+**Verify:** node count grows to the low hundreds; `KAGStore.audit()` = `[]`;
+coverage report shows 0 taxonomy topics with no nodes and 0 unresolved P1
+concept keys; kag.html filter pills now light up across all 9 subspecialties;
+spot-check 5 random authored nodes against their cited source; `status` stays
+`DRAFT`, `review:false` on all authored nodes (owner-review gate not yet passed).
+
+---
+
+## 9. Subagent orchestration playbook (used by Phases 2 & 4)
+
+A reusable, deterministic loop the executor runs for each content batch:
+
+1. **Author.** Spawn one authoring subagent per batch with: the §4 schema, §3
+   enums/map, the batch scope (taxonomy topics *or* anatomical region), the
+   Appendix-A slice, owner source text if any, and the hard rules (cite every
+   node; never fabricate; mark uncertainty in `detail` + keep `review:false`;
+   reuse existing ids; kebab-case). **Output contract:** a single fenced JSON
+   object `{nodes, edges}` and nothing else. Run authoring agents **in
+   parallel** (they touch disjoint shard files, no collisions).
+2. **Land the shard** to `scratch/shards/<batch>.json` (not the live file yet).
+3. **Validate.** Run `tools/kag-validate.mjs <shard> data/kag-graph.json`
+   (dev-only Node script implementing §4.5 exactly): reports id collisions,
+   dangling edges, bad enums, unresolved oksat links, missing sources. A shard
+   with errors goes back to its authoring agent via `SendMessage` with the
+   error list (resume the SAME agent — it keeps context — don't respawn cold).
+4. **Merge.** Only clean shards merge into `data/kag-graph.json` via the store's
+   dedup rules. Merge is serial (one shard at a time) to keep the id space
+   consistent.
+5. **Audit + coverage.** After each merge, `KAGStore.audit()` must be `[]`; a
+   coverage script prints remaining gaps; iterate.
+6. **Gate.** All authored nodes stay `review:false` until the owner (resident)
+   signs off. Provide a lightweight "review queue" (Phase 5) listing
+   `review:false` nodes for the owner to accept (`review:true`) or flag
+   (existing corrections mechanism).
+
+**Rules for the orchestrator model:** reuse a running subagent (SendMessage)
+for fixes rather than spawning a fresh cold one; keep shards small enough to
+validate; never merge an unvalidated shard; never let an authoring agent write
+directly to `data/kag-graph.json`.
+
+---
+
+## 10. Phase 3 — Usage analytics (visitors, uses, question stats)
+
+**Honest constraint (D4):** cumulative cross-visitor stats need an external
+write endpoint. This phase is a hybrid; it degrades gracefully and never blocks
+the rest of the build.
+
+**3a — Visitor / pageview counts (automatic, zero maintenance).**
+Add **GoatCounter** (free for a personal medical-ed site, cookieless, no consent
+banner) as one `<script>` include on every page (`index.html`, `oksat*.html`,
+`kag.html`, `atlas.html`, tools). Owner creates the account (**owner step** —
+flagged; until then the include is a commented stub). Alternative:
+Cloudflare Web Analytics (also free/cookieless) — pick one; GoatCounter exposes
+a JSON API for surfacing counts on-site, so prefer it.
+
+**3b — Custom cumulative counters (owner-hosted serverless KV).**
+Stand up **one tiny endpoint** the site owns. Recommended: **Cloudflare Worker +
+KV** (closest to the existing `fetch`-read / `PUT`-write model) or **Deno Deploy
++ Deno KV / Upstash Redis** if atomic increments are wanted (Workers KV has no
+atomic increment and a ~1k writes/day cap — use Durable Objects / Deno KV
+`sum` / Redis `INCR` if concurrency is real). API:
+```
+POST /inc   { metric: "questions_answered" | "module_completed" |
+              "kag_reviewed" | "adaptive_generated", by?: 1, ctx?: "<slug>" }
+              -> atomic add; 204
+GET  /stats -> { questions_answered: N, module_completed: N, ...,
+                 per_module: { "<slug>": N }, updated: ISO }
+```
+CORS allow-origin = the Pages origin. **Commit the Worker source** to
+`serverless/usage-worker.js` (documented, deployed off-Pages by the owner —
+**owner step**, needs their Cloudflare/Deno account + secret). No token ships in
+the site; the endpoint is write-open only for `/inc` with a fixed small
+allowlist of metric names and simple rate limiting.
+
+**3c — Client `js/usage.js`** (IIFE → `window.Usage`, guarded, fail-safe):
+```
+inc(metric, ctx)   // fire-and-forget POST /inc; also bump a localStorage
+                   // mirror ('usage:local:<metric>') so per-browser numbers
+                   // exist even with no endpoint
+stats()            // GET /stats (cache 60s); resolves to {} if no endpoint
+endpoint()         // reads a config const; '' disables network entirely
+```
+If `endpoint()` is empty, `inc` only writes localStorage and `stats` returns the
+localStorage mirror — the site is fully functional, just per-browser (state this
+limitation in the UI).
+
+**3d — Instrument the hooks (all guarded on `window.Usage`):**
+- `js/oksat-engine.js` `recordAnswer` → `Usage.inc('questions_answered', slug)`;
+  on module completion → `Usage.inc('module_completed', slug)`.
+- adaptive controller (`js/oksat-adaptive.js`) → `Usage.inc('adaptive_generated',
+  topicId)` and `questions_answered`.
+- `kag.html` `scoreCard` → `Usage.inc('kag_reviewed')`.
+- Add `<script src="js/usage.js">` to every page (after other stores).
+
+**3e — Usage surface.** A read-only **"Usage" panel** (a new hub tab in
+`oksat.html`, lazy-loaded like Progress/Atlas, and a small footer line on
+`index.html`) that shows cumulative totals from `Usage.stats()` (+ GoatCounter
+JSON for visitors/pageviews if configured). Tokens only, empty-states
+everywhere, no charts library (hand-rolled numbers/bars per OKSAT convention).
+
+**3f — Durable history (optional, reuses repo-as-DB).** A nightly **GitHub
+Action** (`.github/workflows/usage-snapshot.yml`) fetches `/stats` and commits
+it into `data/usage-stats.json` so the repo keeps an auditable cumulative
+record. Keeps live counting off the critical path; the site can also read this
+committed file as a fallback for `stats()`.
+
+**Privacy note (owner-facing + a one-line site notice):** hosted analytics send
+requests to a third party (cookieless, no banner legally needed but disclose it);
+the owned endpoint keeps custom counters on infrastructure the owner controls.
+
+**Verify:** with the endpoint live, answering questions in two different
+browsers increments the SAME `/stats` totals (cumulative, cross-visitor); the
+Usage panel shows growing numbers; with the endpoint disabled
+(`endpoint()===''`), the whole site works and shows per-browser localStorage
+counts labeled as such; GoatCounter records pageviews; the nightly Action writes
+`data/usage-stats.json`.
+
+---
+
+## 11. Phase 4 — Structural anatomy atlas (view of the KAG, fan-out authored)
+
+**Goal:** name every structural entity (bone, cartilage, ligament, fascia — plus
+joints/foramina/spaces as connective tissue context) and encode every structural
+relationship, as a *view* of the KAG. 3D deferred; capture the spatial seed now.
+
+**4a — `atlas.html` (new page, structural view).**
+- Boots from `KAGStore.load()`; **filters** to `node.structure ∈
+  {bone,cartilage,ligament,fascia,joint,foramen,space,membrane}` and edges whose
+  `type` is structural (`articulates_with, attaches_to, part_of, bounded_by,
+  continuous_with, passes_through, transmits, suspends, forms`) OR whose both
+  endpoints are structural.
+- **Groups by `region`** (§3 enum): a region navigator (temporal bone, skull
+  base, facial skeleton, nasal/sinus, larynx, neck, oral-pharynx, hyoid,
+  external ear). Reuse the Cytoscape + dark-graph aesthetic of `kag.html` (or a
+  cleaner region-panel list). Color by `structure` (bone/cartilage/ligament/
+  fascia each a hue; muscle/space/foramen togged).
+- **Structure detail panel:** name, aliases, region, laterality, and grouped
+  relationship lists — *Articulates with* / *Attaches to* / *Part of* /
+  *Bounded by* / *Transmits* — each a link to the related structure (and, via
+  `node.oksat`, a "Practice" chip into OKSAT).
+- **Redundancy reduction is automatic:** the atlas holds no data of its own; a
+  structure exists once in the KAG and is referenced everywhere.
+- **3D-later hooks:** the atlas reads `edge.direction` and `node.laterality`;
+  encode them now so a future 3D layer has spatial seed data. No 3D rendering in
+  this phase (explicitly deferred by the owner).
+
+**4b — Structural content fan-out (playbook §9), one authoring agent per
+region.** Each agent exhaustively names structures + relationships for its
+region, reusing existing KAG ids and adding missing ones, setting `structure`,
+`region`, `laterality`, spatial `direction` on edges, and `oksat` links where a
+module tests it. Regions and their must-cover scope:
+
+- **Temporal bone / external & middle ear** (extends the seed): squamous /
+  petrous / mastoid / tympanic parts; ossicles (bone) + their **ligaments**
+  (annular, anterior/lateral/superior malleal, posterior incudal, stapedial);
+  tympanic membrane (membrane); otic capsule; auricular **cartilage**;
+  tympanomastoid/tympanosquamous sutures.
+- **Skull base & cranial foramina:** sphenoid, ethmoid, frontal, occipital,
+  temporal, parietal bones; foramina (ovale, rotundum, spinosum, lacerum,
+  magnum, jugular, carotid canal, IAC, stylomastoid, hypoglossal, cribriform,
+  optic canal, SOF, IOF) with `transmits` edges to the nerves/vessels already in
+  the KAG.
+- **Facial skeleton:** maxilla, mandible (+ landmarks), zygoma, nasal bones,
+  frontal, lacrimal, palatine, vomer, inferior turbinate; facial buttresses;
+  **TMJ** (joint) + articular disc; sutures.
+- **Nasal / sinus:** septal (quadrangular) cartilage, upper/lower lateral
+  cartilages, sesamoid cartilages; bony septum (perpendicular plate of ethmoid +
+  vomer); turbinates; sinus walls; keystone area (`continuous_with`).
+- **Larynx:** cartilages (thyroid, cricoid, arytenoid, corniculate, cuneiform,
+  epiglottis); **joints** (cricothyroid, cricoarytenoid); **ligaments/membranes**
+  (thyrohyoid membrane, cricothyroid ligament / conus elasticus, quadrangular
+  membrane, vocal ligament, vestibular ligament, hyoepiglottic, thyroepiglottic,
+  cricotracheal); hyoid bone.
+- **Neck fascia & spaces:** superficial cervical fascia (+ platysma); deep
+  cervical fascia — superficial/investing, middle (pretracheal/visceral +
+  buccopharyngeal), deep (prevertebral + alar); carotid sheath; **spaces**
+  (parapharyngeal, retropharyngeal, danger, prevertebral, submandibular,
+  masticator, parotid, visceral) with `bounded_by` edges to their fascial walls.
+- **Oral cavity / pharynx / hyoid suspension:** pterygomandibular raphe;
+  stylohyoid / stylomandibular / sphenomandibular **ligaments**; constrictor
+  skeletal attachments; hyoid `suspends`/`attaches_to` relations.
+
+**4c — Validate + merge** per §9, with extra **structural-completeness checks:**
+every `bone` has ≥1 `articulates_with`; every `cartilage` in the larynx has its
+joints/ligaments; every `fascia` has ≥1 `bounded_by`/`continuous_with`; no
+orphan structural node (structure set but no structural edge).
+
+**Verify:** `atlas.html` renders each region with every structure named; clicking
+a bone lists its articulations and the foramina it contains; a new structural
+KAG node (add one by hand) appears in the atlas with **no atlas code change**
+(proves D1); `oksat` "Practice" chips deep-link correctly; `edge.direction`
+present on a sample so a future 3D layer has data; `KAGStore.audit()` = `[]`.
+
+---
+
+## 12. Phase 5 — Navigation, docs, versioning, hygiene, regression
+
+- **Navigation (`index.html` tools section, ~lines 139–164):** add an **Anatomy
+  Atlas** card (`atlas.html`); keep KAG/OKSAT/Extractor cards; ensure the KAG
+  and Atlas describe their relationship. Verify all tool links.
+- **Owner review queue:** a small view (in `kag.html` Settings or a
+  `kag-review.html`) listing `review:false` nodes grouped by subspecialty, with
+  Accept (`review:true`) / Flag (existing corrections) buttons, writing through
+  `KAGStore`. This is how DRAFT content graduates (D5).
+- **Docs:** new `docs/kag-schema.md` (v2 node/edge, enums, §3 map),
+  `docs/authoring-kag.md` (the subagent/human authoring contract + §9 playbook),
+  `docs/usage-analytics.md` (endpoint spec, deployment steps, privacy). Update
+  `README.md` file tree (add `data/kag-graph.json`, `js/kag-store.js`,
+  `js/usage.js`, `atlas.html`, `serverless/usage-worker.js`), `WIP.md`, and note
+  in `docs/oksat-plan.md` §8 that the KAG is now externalized + OKSAT-linked.
+- **Versioning / merge:** `data/kag-graph.json` `version:2`, monotone additive
+  merge (never delete unknown fields; `review:true` wins on dedup). Extend any
+  reset scanner to leave `kag-graph`/`kag-api-key` intact and clear only
+  `usage:local:*` mirrors when the user resets usage counts.
+- **Full regression:** re-walk Phase 0–4 checklists; confirm the 5 OKSAT modules,
+  hub Atlas, adaptive page, Forge, font themes, day/night, and the KAG self-test
+  are all unbroken; Network tab shows only expected files + the (optional)
+  analytics/endpoint calls.
+
+---
+
+## 13. Cross-cutting risk register
+
+| Risk | Phase | Mitigation |
+|---|---|---|
+| Externalizing KAG breaks self-test/progress (ids change) | 0 | Keep ids/labels byte-identical; only wrap + add optional fields |
+| Subspecialty vocab mismatch corrupts filters/links | 1 | `normSub` map applied on read + in extractor; test both pill sets |
+| Fabricated / wrong medical facts at scale | 2,4 | D5: cite every node, `review:false`, owner gate, DRAFT status; prefer owner source text |
+| Dangling edges / id collisions from parallel shards | 2,4 | `tools/kag-validate.mjs` before every merge; serial merges; `audit()` must be `[]` |
+| Analytics can't be truly automatic on static host | 3 | D4 hybrid; graceful localStorage fallback; owner-provisioned endpoint clearly flagged |
+| Embedded write token leak / commit-spam race | 3 | Never ship a token; use owned KV endpoint with atomic inc; keep Contents-API push owner-only |
+| Atlas duplicating anatomy already in KAG | 4 | D1: atlas is a filtered view, holds no data; reuse ids, add edges |
+| Script load-order errors (no bundler) | all | Fixed order, every consumer `window.X &&`-guarded, degrades to prior behavior |
+| Subagent cold-restart waste | 2,4 | Reuse running agents via SendMessage for fixes; small shards |
+
+---
+
+## 14. Execution order, ownership, and the human-in-the-loop steps
+
+**Order:** 0 → 1 → 2 → 3 → 4 → 5. Phase 3 can run in parallel with 2/4 (it
+touches different files) but needs Phase 0's page structure.
+
+**Owner (human) steps — flag these explicitly, do not fake them:**
+1. Provision the analytics account (GoatCounter/Cloudflare) — Phase 3a.
+2. Deploy the serverless counter endpoint + set its origin allowlist — Phase 3b.
+3. Supply source text where available, and run the **clinical review** pass over
+   `review:false` nodes — Phases 2/4/5 (accuracy gate D5).
+Everything else is executable by the model fleet without secrets. Until owner
+steps land, the site ships with analytics stubbed/degraded and content in DRAFT
+— fully functional, honestly labeled.
+
+---
+
+## 15. Critical files
+
+| File | Role |
+|---|---|
+| **New** `data/kag-graph.json` | Canonical graph (term web + atlas source) |
+| **New** `js/kag-store.js` | fetch/merge/save/download/push/reverseConcept/normSub/audit |
+| **New** `js/usage.js` | client counters (POST /inc, GET /stats, localStorage fallback) |
+| **New** `atlas.html` | structural view of the KAG (Phase 4) |
+| **New** `serverless/usage-worker.js` | owner-deployed KV counter endpoint (off-Pages) |
+| **New** `tools/kag-validate.mjs` | dev-only shard validator (§4.5) |
+| **New** `docs/kag-schema.md`, `docs/authoring-kag.md`, `docs/usage-analytics.md` | contracts + ops |
+| `kag.html` | boot from store, `?node=`, v2 fields, Practice/Adaptive chips, Sync panel |
+| `kag-extract.html` | emit v2 fields, normalize subspecialty, download-shard |
+| `js/oksat-atlas.js` | node-level bidirectional KAG crossover |
+| `js/oksat-engine.js`, `js/oksat-adaptive.js` | `Usage.inc` hooks |
+| `oksat.html` | Usage tab; kag-store include |
+| `index.html` | Anatomy Atlas nav card; footer usage line |
+| `js/mcq-modules/pediatrics.js` | duplicate `CHL` key fix |
+
+---
+
+## 16. End-to-end acceptance (final walk, `python3 -m http.server 8000`)
+
+1. KAG loads from `data/kag-graph.json`; self-test, corrections, import/export,
+   filters, search unchanged; `?node=<id>` focuses.
+2. A KAG node deep-links into the right OKSAT questions; an OKSAT concept node
+   deep-links back to `kag.html?node=…`.
+3. Term web spans all 9 subspecialties; every P1 taxonomy topic and every OKSAT
+   concept key resolves to KAG nodes; `audit()` clean; authored nodes DRAFT.
+4. `atlas.html` names every structure by region with articulation/attachment/
+   boundary lists; adding a structural node needs no atlas code change; spatial
+   `direction` present for the future 3D layer.
+5. Usage: with endpoint, two browsers grow the SAME cumulative `/stats`; Usage
+   panel shows totals + visitors; with endpoint off, site works, per-browser
+   counts labeled honestly; nightly Action snapshots `data/usage-stats.json`.
+6. Regression: 5 OKSAT modules, hub Atlas, adaptive, Forge, font themes,
+   day/night, KAG self-test all intact.
+
+---
+
+## Appendix A — OKSAT module concept keys (verbatim; load-bearing)
+
+*Executors copy exact KEY strings when writing `node.oksat.concepts`. Full
+label/domain tables were extracted from `js/mcq-modules/*.js`; the keys are
+reproduced here so authoring subagents can link without re-reading the modules.*
+
+**`pediatrics` (40 mcq)** — DOMAINS: foundations, CHL, SNHL, syndromic, workup,
+management, cases. Concept keys: embryology, external-ear, middle-ear,
+inner-ear, ossicles, EAC, first-arch, physiology, tonotopy, NIHL, mechanism,
+potassium, collagen, vestibular, epidemiology, CHL *(⚠ duplicated key — treat as
+one node; fix per §7.6)*, atresia, jahrsdoerfer, BCD, cholesteatoma, congenital,
+acquired-SNHL, cCMV, ototoxicity, mitochondrial, genetic-SNHL, GJB2, meningitis,
+syndromic-AD, syndromic-AR, syndromic-XL, BOR, treacher-collins, waardenburg,
+CHARGE, pendred, EVA, usher, DFN3, alport, JLN, audiology, ANSD, imaging,
+diagnosis, workup, EHDI, screening, surgical, treatment, CI, emerging,
+gene-therapy, cases.
+
+**`ta-tubes` (54 mcq)** — DOMAINS: foundations, bmt, tonsillectomy, neck,
+complications, cases. Concept keys: embryology, tm-anatomy, middle-ear,
+eustachian-tube, physiology, tonsil-anatomy, adenoid-anatomy, waldeyer,
+cranial-nerves, imaging, workup, OME, tubes, myringotomy, tympanometry, SSCD,
+OSA, brodsky, extracapsular, intracapsular, capsule, tonsil-dissection,
+adenoidectomy, tonsillar-artery, regrowth, dissection-plane, hemostasis,
+nodal-anatomy, lymphadenitis, node-malignancy, node-dissection, spinal-accessory,
+carotid, hemorrhage, VPI, dysphagia, tube-complications, airway-edema, horner,
+cases, anesthesia, counseling, seizure, cochlear-implant.
+
+**`vestibular-schwannoma` (46 mcq)** — DOMAINS: anatomy, pathophysiology,
+epidemiology, diagnosis, treatment, complications, NF2, cases. Concept keys: CPA,
+IAC, nerve-quadrants, surrounding-anatomy, tumor-size, tumor-origin,
+molecular-genetics, histopathology, incidence, tumor-growth,
+hearing-natural-history, vestibulopathy, presentation, clinical-exam, MRI, Koos,
+audiology, differential, observation, surgery, translabyrinthine, retrosigmoid,
+middle-fossa, radiosurgery, medical-therapy, rehabilitation, facial-nerve,
+CSF-leak, meningitis, headache, vascular, recurrence, NF2, manchester-criteria,
+bilateral-VS, cases.
+
+**`facial-reanimation` (42 mcq)** — DOMAINS: anatomy, physiology, evaluation,
+workup, treatment, complications, cases. Concept keys: pharyngeal-arch,
+nerve-segments, geniculate-branches, tympanic-segment, mastoid-branches,
+extratemporal, surface-landmarks, NFFP, synkinesis, bilateral-palsy,
+exam-findings, house-brackmann, sunnybrook, bells-palsy, imaging,
+electrodiagnostics, acute-repair, nerve-transfer, CFNG, muscle-transfer, eyelid,
+NFFP-treatment, chemodenervation, corneal, case-scc, case-acoustic, case-ramsay.
+
+**`dtc-risk-stratification` (25 recall)** — DOMAINS: staging, operative,
+completion, pathology, riskStrat, controversy. Concept keys: t-category,
+age-pivot, downstaging, nodal-class, lobectomy, total-thyroidectomy, gross-ete,
+rai, conversion-rate, completion-indications, rln, nodal-completion, micro-ete,
+path-report, subtype, familial, niftp, ata-system, ata-tiers, focality,
+vascular-invasion, nodal-risk, molecular, case, controversy.

--- a/index.html
+++ b/index.html
@@ -141,6 +141,11 @@
                                 <div class="item-main"><h4>Knowledge Atlas Graph</h4><p>Interactive OHNS knowledge map with spaced-repetition self-testing</p></div>
                                 <span class="item-meta">Launch &rarr;</span>
                             </a>
+                            <a class="item" href="atlas.html">
+                                <span class="item-ic"><i class="fas fa-bone"></i></span>
+                                <div class="item-main"><h4>Structural Anatomy Atlas</h4><p>Bones, cartilage, ligaments &amp; fascia as a structural view of the knowledge graph</p></div>
+                                <span class="item-meta">Launch &rarr;</span>
+                            </a>
                             <a class="item" href="cpt-search.html">
                                 <span class="item-ic"><i class="fas fa-magnifying-glass"></i></span>
                                 <div class="item-main"><h4>CPT Code Search</h4><p>Fast CPT lookup built for otolaryngology</p></div>

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
         <div class="sections">
 
             <!-- 1 -->
-            <details class="section" id="about" open>
+            <details class="section" id="about">
                 <summary>
                     <span class="sec-title" data-note="the short version">Surgeon-scientist in training in the PNW</span>
                     <span class="chev"><i class="fas fa-chevron-down"></i></span>

--- a/js/kag-store.js
+++ b/js/kag-store.js
@@ -1,0 +1,248 @@
+/* =============================================================
+   KAG store — data/kag-graph.json (the canonical KAG database)
+
+   This file mirrors js/oksat-db.js. GitHub Pages is static, so the
+   JSON file *is* the database. The Knowledge-Assembly Graph shape is
+   { version, updated, status, sources, nodes:[...], edges:[...] };
+   it holds concept nodes, their leitner progress and corrections,
+   and the edges between them — progress data only, NEVER any secret.
+
+   Read path:  fetched (cache-busted) on load, then merged with this
+               browser's localStorage['kag-graph'] so LOCAL WINS on
+               conflicts (the user's leitner boxes and corrections
+               are preserved); the file only ADDS nodes/edges the
+               local copy is missing.
+   Write path: persisted two ways, exactly like oksat-db.js —
+     1) download the merged file and commit it, or
+     2) push directly via the GitHub Contents API with a
+        fine-grained token pasted at sync time. The token lives in
+        a local variable for that request only and is NEVER
+        persisted (not localStorage, not the DB file, not the repo).
+
+   Loaded as a plain <script> (no build step, no imports). Every
+   helper is defensive: storage reads/writes are wrapped in
+   try/catch and fail safe; fetch() never throws or rejects.
+   ============================================================= */
+(function () {
+  'use strict';
+
+  var DB_PATH = 'data/kag-graph.json';
+  var REPO = { owner: 'skflx', repo: 'skflx.github.io', branch: 'master' };
+  var LOCAL_KEY = 'kag-graph';
+
+  // legacy KAG subspecialty -> canonical OKSAT key
+  var SUB_MAP = {
+    'head-neck-onc': 'hn_onc',
+    'peds-ent': 'pediatrics',
+    'facial-plastics': 'fprs',
+    'skull-base': 'otology',
+  };
+
+  function todayISO() { return new Date().toISOString().split('T')[0]; }
+
+  /* ---- read the server file (never throws; null on any failure) ---- */
+  var cached = null;
+  function fetchGraph() {
+    if (cached) return Promise.resolve(cached);
+    return fetch(DB_PATH + '?ts=' + Date.now(), { cache: 'no-store' })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (g) {
+        if (!g || typeof g !== 'object') return null;
+        cached = g; return g;
+      })
+      .catch(function () { return null; });
+  }
+
+  /* ---- what this browser has saved (guarded localStorage) ---- */
+  function readLocal() {
+    try {
+      var raw = window.localStorage.getItem(LOCAL_KEY);
+      if (!raw) return null;
+      var g = JSON.parse(raw);
+      return (g && typeof g === 'object') ? g : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function save(graph) {
+    try {
+      window.localStorage.setItem(LOCAL_KEY, JSON.stringify(graph));
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /* ---- pure merge: LOCAL WINS, file only ADDS missing nodes/edges ---- */
+  function edgeKey(e) {
+    return (e && e.source) + '|' + (e && e.target) + '|' + (e && e.type);
+  }
+
+  function merge(fileGraph) {
+    var local = readLocal();
+    if (!local) {
+      // deep-ish copy is fine
+      try { return fileGraph ? JSON.parse(JSON.stringify(fileGraph)) : fileGraph; }
+      catch (e) { return fileGraph; }
+    }
+    if (!fileGraph) return local;
+
+    var localNodes = (local && local.nodes) || [];
+    var localEdges = (local && local.edges) || [];
+    var fileNodes = (fileGraph && fileGraph.nodes) || [];
+    var fileEdges = (fileGraph && fileGraph.edges) || [];
+
+    var mergedNodes = localNodes.slice();
+    var haveIds = {};
+    var i, n;
+    for (i = 0; i < localNodes.length; i++) {
+      n = localNodes[i];
+      if (n && n.id != null) haveIds[n.id] = true;
+    }
+    for (i = 0; i < fileNodes.length; i++) {
+      n = fileNodes[i];
+      if (n && n.id != null && !haveIds[n.id]) {
+        mergedNodes.push(n);
+        haveIds[n.id] = true;
+      }
+    }
+
+    var mergedEdges = localEdges.slice();
+    var haveEdges = {};
+    var e;
+    for (i = 0; i < localEdges.length; i++) {
+      e = localEdges[i];
+      if (e) haveEdges[edgeKey(e)] = true;
+    }
+    for (i = 0; i < fileEdges.length; i++) {
+      e = fileEdges[i];
+      if (e) {
+        var k = edgeKey(e);
+        if (!haveEdges[k]) { mergedEdges.push(e); haveEdges[k] = true; }
+      }
+    }
+
+    return {
+      version: (fileGraph && fileGraph.version) || (local && local.version) || 2,
+      updated: (fileGraph && fileGraph.updated) || '',
+      status: fileGraph && fileGraph.status,
+      sources: (fileGraph && fileGraph.sources) || [],
+      nodes: mergedNodes,
+      edges: mergedEdges,
+    };
+  }
+
+  function load(fileGraph) { return merge(fileGraph); }
+
+  /* ---- pure subspecialty normalizer (no mutation) ---- */
+  function normSub(x) {
+    if (SUB_MAP.hasOwnProperty(x)) return SUB_MAP[x];
+    return x;
+  }
+
+  /* ---- "<module>:<concept>" -> [node id, ...] ---- */
+  function reverseConcept(graph) {
+    var out = {};
+    try {
+      var nodes = (graph && graph.nodes) || [];
+      for (var i = 0; i < nodes.length; i++) {
+        var node = nodes[i];
+        if (!node || node.id == null) continue;
+        var oksat = node.oksat;
+        var concepts = oksat && oksat.concepts;
+        if (!concepts || !concepts.length) continue;
+        for (var j = 0; j < concepts.length; j++) {
+          var c = concepts[j];
+          if (!c || c.module == null || c.concept == null) continue;
+          var key = c.module + ':' + c.concept;
+          if (!out[key]) out[key] = [];
+          out[key].push(node.id);
+        }
+      }
+    } catch (e) { /* no-op */ }
+    return out;
+  }
+
+  /* ---- shape-only audit (never throws) ---- */
+  function audit(graph) {
+    var problems = [];
+    try {
+      var nodes = (graph && graph.nodes) || [];
+      var edges = (graph && graph.edges) || [];
+      var known = {};
+      var seen = {};
+      var i, n;
+      for (i = 0; i < nodes.length; i++) {
+        n = nodes[i];
+        if (!n || n.id == null) continue;
+        if (seen[n.id]) problems.push({ kind: 'dupe-id', id: n.id });
+        seen[n.id] = true;
+        known[n.id] = true;
+      }
+      for (i = 0; i < edges.length; i++) {
+        var e = edges[i];
+        if (!e) continue;
+        if (!known[e.source] || !known[e.target]) {
+          problems.push({ kind: 'dangling-edge', edge: e });
+        }
+      }
+    } catch (err) { /* no-op */ }
+    return problems;
+  }
+
+  /* ---- write path 1: download the merged file to commit ---- */
+  function download(graph) {
+    var blob = new Blob([JSON.stringify(graph, null, 2) + '\n'], { type: 'application/json' });
+    var a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'kag-graph.json';
+    document.body.appendChild(a); a.click(); a.remove();
+    setTimeout(function () { URL.revokeObjectURL(a.href); }, 5000);
+  }
+
+  /* ---- write path 2: GitHub Contents API (token used once, in memory only) ---- */
+  function push(graph, token) {
+    var api = 'https://api.github.com/repos/' + REPO.owner + '/' + REPO.repo + '/contents/' + DB_PATH;
+    var headers = {
+      'Authorization': 'Bearer ' + token,
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+    return fetch(api + '?ref=' + REPO.branch, { headers: headers })
+      .then(function (r) {
+        if (r.status === 404) return { sha: undefined };
+        if (!r.ok) throw new Error('Could not read current file (HTTP ' + r.status + ')');
+        return r.json();
+      })
+      .then(function (cur) {
+        var body = {
+          message: 'Sync KAG graph (' + todayISO() + ')',
+          content: btoa(unescape(encodeURIComponent(JSON.stringify(graph, null, 2) + '\n'))),
+          branch: REPO.branch,
+        };
+        if (cur.sha) body.sha = cur.sha;
+        return fetch(api, { method: 'PUT', headers: headers, body: JSON.stringify(body) });
+      })
+      .then(function (r) {
+        if (!r.ok) return r.json().catch(function () { return {}; }).then(function (j) {
+          throw new Error('Push failed (HTTP ' + r.status + ')' + (j.message ? ': ' + j.message : ''));
+        });
+        return r.json();
+      });
+  }
+
+  window.KAGStore = {
+    DB_PATH: DB_PATH,
+    fetch: fetchGraph,
+    readLocal: readLocal,
+    save: save,
+    merge: merge,
+    load: load,
+    normSub: normSub,
+    reverseConcept: reverseConcept,
+    audit: audit,
+    download: download,
+    push: push,
+  };
+})();

--- a/js/oksat-atlas.js
+++ b/js/oksat-atlas.js
@@ -72,7 +72,8 @@
   }
 
   /* ---- build cytoscape elements ---- */
-  function buildElements(reviewer, completion) {
+  function buildElements(reviewer, completion, kagIndex) {
+    kagIndex = kagIndex || {};
     var subs = window.OKSAT_SUBSPECIALTIES || {};
     var els = [];
     var usedSubs = {};
@@ -123,6 +124,7 @@
             slug: entry.slug, concept: cKey,
             pct: p.total ? p.answered / p.total : 0,
             done: p.total > 0 && p.answered === p.total,
+            kagNode: (kagIndex[entry.slug + ':' + cKey] || [])[0] || null,
           },
         });
         els.push({ data: { id: 'e:' + dId + ':' + cId, source: (d ? dId : mId), target: cId, kind: 'twig' } });
@@ -167,6 +169,14 @@
     els.push({ data: { id: 'kag', kind: 'kag', label: 'Knowledge Atlas Graph ↗', hue: '#4A9EFF' } });
     Object.keys(usedSubs).forEach(function (subId) {
       els.push({ data: { id: 'e:kag:' + subId, source: 'kag', target: subId, kind: 'ghost' } });
+    });
+
+    /* Concept ↔ KAG: a dashed hop from any concept node that has a matching
+       Knowledge Atlas Graph term (OKSAT → KAG traversal; right-click opens it). */
+    els.slice().forEach(function (el) {
+      if (el.data && el.data.kind === 'concept' && el.data.kagNode) {
+        els.push({ data: { id: 'e:kagc:' + el.data.id, source: el.data.id, target: 'kag', kind: 'ghost' } });
+      }
     });
     return els;
   }
@@ -245,11 +255,13 @@
     var completion = opts.completion || {};
 
     return loadModules().then(function () {
+      var kagIndex = {};
+      function buildWith() {
       var layoutName = 'cose-bilkent';
       try { cytoscape('layout', 'cose-bilkent'); } catch (e) { layoutName = 'cose'; }
       var cy = cytoscape({
         container: container,
-        elements: buildElements(reviewer, completion),
+        elements: buildElements(reviewer, completion, kagIndex),
         style: styleFor(),
         layout: {
           name: layoutName, animate: 'end', animationDuration: 600,
@@ -287,6 +299,15 @@
         }
       });
 
+      /* Right-click / long-press a concept that has a matching Atlas term
+         opens it in the KAG (OKSAT → KAG, node-level). Normal tap still studies. */
+      cy.on('cxttap', 'node', function (e) {
+        var n = e.target;
+        if (n.data('kind') === 'concept' && n.data('kagNode')) {
+          window.location.href = 'kag.html?node=' + encodeURIComponent(n.data('kagNode'));
+        }
+      });
+
       /* Search: highlight matches; Enter zooms to them. */
       if (opts.searchInput) {
         opts.searchInput.addEventListener('input', function () {
@@ -313,6 +334,17 @@
       });
 
       return cy;
+      }
+
+      /* Load the KAG concept index first (if available) so concept nodes know
+         their Atlas counterpart; degrade to no cross-links if it's absent. */
+      if (window.KAGStore && typeof window.KAGStore.fetch === 'function') {
+        return window.KAGStore.fetch().then(function (kg) {
+          try { if (kg) kagIndex = window.KAGStore.reverseConcept(kg); } catch (e) {}
+          return buildWith();
+        });
+      }
+      return buildWith();
     });
   }
 

--- a/js/site.js
+++ b/js/site.js
@@ -1,0 +1,50 @@
+/* =============================================================
+   site.js — shared site chrome behaviour for skflx.MD tools.
+   Day/night toggle wired to the same localStorage key OKSAT uses
+   ('sk_theme') and the html[data-theme] attribute that css/site.css
+   (and css/oksat.css) key off. Loaded as a plain <script> on every
+   tool page; no dependencies, no build step. Binds every element
+   with class .site-theme-toggle. Defensive throughout.
+   ============================================================= */
+(function () {
+  'use strict';
+
+  function applyTheme(t) {
+    try { document.documentElement.setAttribute('data-theme', t); } catch (e) { /* no-op */ }
+  }
+
+  function currentTheme() {
+    var t = document.documentElement.getAttribute('data-theme');
+    if (t) return t;
+    try { t = localStorage.getItem('sk_theme'); } catch (e) { t = null; }
+    if (t) return t;
+    return (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+  }
+
+  function toggle() {
+    var next = currentTheme() === 'dark' ? 'light' : 'dark';
+    applyTheme(next);
+    try { localStorage.setItem('sk_theme', next); } catch (e) { /* no-op */ }
+    try { document.dispatchEvent(new CustomEvent('oksat:theme', { detail: { theme: next } })); } catch (e) { /* no-op */ }
+  }
+
+  function wire() {
+    // Make sure the root carries an explicit theme so the first toggle is never a no-op.
+    if (!document.documentElement.getAttribute('data-theme')) applyTheme(currentTheme());
+    var btns = document.querySelectorAll('.site-theme-toggle');
+    for (var i = 0; i < btns.length; i++) {
+      if (btns[i].__siteWired) continue;
+      btns[i].__siteWired = true;
+      btns[i].addEventListener('click', toggle);
+    }
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', wire);
+  else wire();
+
+  window.SiteChrome = {
+    toggle: toggle,
+    setTheme: function (t) { applyTheme(t); try { localStorage.setItem('sk_theme', t); } catch (e) { /* no-op */ } },
+    currentTheme: currentTheme,
+  };
+})();

--- a/kag-extract.html
+++ b/kag-extract.html
@@ -447,6 +447,10 @@
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 3h5v5"/><path d="M8 3H3v5"/><path d="M12 22v-8.3a4 4 0 00-1.172-2.872L3 3"/><path d="M21 3l-7.828 7.828A4 4 0 0012 13.7V22"/></svg>
                 Merge into Atlas
             </button>
+            <button id="btn-download-shard" class="btn btn-secondary">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                Download shard
+            </button>
         </div>
     </div>
 </div>
@@ -460,8 +464,9 @@
 
     /* ── Constants ─────────────────────────────────── */
     const VALID_NODE_TYPES = ['anatomy','pathology','procedure','nerve','vessel','drug','concept'];
-    const VALID_EDGE_TYPES = ['innervates','supplies','drains_to','landmark_for','complication_of','differentiates_from','treats','staged_with','arises_from','contained_in','branches_from'];
-    const VALID_SUBSPECIALTIES = ['rhinology','otology','head-neck-onc','laryngology','peds-ent','skull-base','facial-plastics'];
+    const VALID_EDGE_TYPES = ['innervates','supplies','drains_to','landmark_for','complication_of','differentiates_from','treats','staged_with','arises_from','contained_in','branches_from','articulates_with','attaches_to','part_of','bounded_by','continuous_with','passes_through','transmits','suspends','forms'];
+    const VALID_SUBSPECIALTIES = ['otology','rhinology','laryngology','hn_onc','fprs','pediatrics','sleep','endocrine','fundamentals'];
+    const SUBSPECIALTY_MAP = { 'head-neck-onc': 'hn_onc', 'peds-ent': 'pediatrics', 'facial-plastics': 'fprs', 'skull-base': 'otology' };
 
     const SYSTEM_PROMPT = `You are a medical knowledge graph extractor for Otolaryngology–Head and Neck Surgery.
 Extract ALL entities and relationships from the provided Markdown text.
@@ -471,10 +476,18 @@ Return ONLY valid JSON matching this schema exactly — no prose, no markdown fe
   "edges": [EdgeObject, ...]
 }
 Node types: anatomy | pathology | procedure | nerve | vessel | drug | concept
-Edge types: innervates | supplies | drains_to | landmark_for | complication_of | differentiates_from | treats | staged_with | arises_from | contained_in | branches_from
-Subspecialties: rhinology | otology | head-neck-onc | laryngology | peds-ent | skull-base | facial-plastics
-For each node: generate a slug id (kebab-case), label, type, subspecialty (infer from context), detail (1-3 sentence clinical pearl), sources (empty array if unknown), corrections (empty array), leitner: {box:1, nextReview: today ISO}.
-For each edge: use existing node ids. Only emit edges where both nodes appear in output.
+Edge types: innervates | supplies | drains_to | landmark_for | complication_of | differentiates_from | treats | staged_with | arises_from | contained_in | branches_from | articulates_with | attaches_to | part_of | bounded_by | continuous_with | passes_through | transmits | suspends | forms
+Subspecialties (use ONLY these keys): otology | rhinology | laryngology | hn_onc | fprs | pediatrics | sleep | endocrine | fundamentals
+For each node: generate a slug id (kebab-case), label, type, subspecialty (infer from context, use ONLY the keys above), detail (1-3 sentence clinical pearl), sources (empty array if unknown), corrections (empty array), leitner: {box:1, nextReview: today ISO}.
+Also emit these OPTIONAL v2 fields on each node:
+  aliases: array of synonym strings (e.g. ["acoustic neuroma"]); [] if none.
+  abbrev: short abbreviation string, or null.
+  structure: one of bone | cartilage | ligament | fascia | joint | foramen | space | membrane | muscle if the entity is a physical structure, else null.
+  region: one of temporal-bone | skull-base | facial-skeleton | nasal-sinus | larynx | neck | oral-pharynx | cervical-spine-hyoid | external-ear if applicable, else null.
+  laterality: midline | paired | null.
+  oksat: ALWAYS output exactly { "modules": [], "concepts": [], "topics": [] } (leave empty — a later pass fills these; do NOT invent module/concept links).
+  review: always false.
+For each edge: use existing node ids. Only emit edges where both nodes appear in output. An OPTIONAL edge field direction may be one of superior | inferior | medial | lateral | anterior | posterior | deep | superficial (spatial hint), or omitted.
 Be exhaustive. Prefer more nodes over fewer.`;
 
     const MODEL = 'claude-sonnet-4-20250514';
@@ -498,6 +511,7 @@ Be exhaustive. Prefer more nodes over fewer.`;
     const btnCopy       = document.getElementById('btn-copy');
     const btnDownload   = document.getElementById('btn-download');
     const btnMerge      = document.getElementById('btn-merge');
+    const btnDownloadShard = document.getElementById('btn-download-shard');
     const toastEl       = document.getElementById('toast');
 
     let extractedData = null;
@@ -682,12 +696,20 @@ Be exhaustive. Prefer more nodes over fewer.`;
         data.nodes = data.nodes.map(n => {
             if (!n.id || !n.label) throw new Error('Node missing id or label: ' + JSON.stringify(n));
             n.type = VALID_NODE_TYPES.includes(n.type) ? n.type : 'concept';
-            n.subspecialty = VALID_SUBSPECIALTIES.includes(n.subspecialty) ? n.subspecialty : 'rhinology';
+            let sub = SUBSPECIALTY_MAP[n.subspecialty] || n.subspecialty;
+            n.subspecialty = VALID_SUBSPECIALTIES.includes(sub) ? sub : 'fundamentals';
             n.detail = n.detail || '';
             n.sources = Array.isArray(n.sources) ? n.sources : [];
             n.corrections = Array.isArray(n.corrections) ? n.corrections : [];
             n.leitner = n.leitner || { box: 1, nextReview: today };
             if (!n.leitner.nextReview) n.leitner.nextReview = today;
+            n.aliases = Array.isArray(n.aliases) ? n.aliases : [];
+            n.abbrev = n.abbrev || null;
+            n.structure = n.structure || null;
+            n.region = n.region || null;
+            n.laterality = n.laterality || null;
+            n.oksat = n.oksat || { modules: [], concepts: [], topics: [] };
+            n.review = n.review === true;
             nodeIds.add(n.id);
             return n;
         });
@@ -759,6 +781,19 @@ Be exhaustive. Prefer more nodes over fewer.`;
 
         localStorage.setItem('kag-graph', JSON.stringify(existing));
         toast(`Merged: +${addedNodes} nodes, +${addedEdges} edges`, 'success');
+    });
+
+    /* ── Download shard ────────────────────────────── */
+    btnDownloadShard.addEventListener('click', () => {
+        if (!extractedData) { toast('Nothing to download yet.', 'error'); return; }
+        const blob = new Blob([JSON.stringify(extractedData, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'kag-shard.json';
+        a.click();
+        URL.revokeObjectURL(url);
+        toast('Downloaded kag-shard.json', 'success');
     });
 
     /* ── Init ──────────────────────────────────────── */

--- a/kag-extract.html
+++ b/kag-extract.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>KAG Extractor | skflx.MD</title>
     <meta name="description" content="Claude API-powered Markdown to knowledge graph JSON extractor for OHNS study.">
+    <script>(function(){try{var t=localStorage.getItem('sk_theme');if(!t)t='dark';document.documentElement.setAttribute('data-theme',t);}catch(e){document.documentElement.setAttribute('data-theme','dark');}})();</script>
+    <link rel="stylesheet" href="css/site.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
@@ -371,16 +373,19 @@
 <body>
 
 <!-- Header -->
-<header class="header">
-    <div class="header-left">
-        <a href="kag.html" class="logo">KAG</a>
-        <span class="logo-sub">Extractor</span>
+<div class="site-topbar">
+    <a class="site-wordmark" href="index.html">skflx.MD</a>
+    <span class="site-topbar-title">KAG Extractor</span>
+    <span class="site-topbar-spacer"></span>
+    <div class="site-topbar-actions">
+        <a class="site-navlink" href="kag.html">Atlas</a>
+        <a class="site-navlink" href="index.html">Home</a>
+        <button class="site-theme-toggle" type="button" aria-label="Toggle day / night">
+            <svg class="i-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            <svg class="i-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
+        </button>
     </div>
-    <nav class="header-nav">
-        <a href="kag.html">Atlas</a>
-        <a href="index.html">Home</a>
-    </nav>
-</header>
+</div>
 
 <!-- Main -->
 <div class="main">
@@ -801,5 +806,6 @@ Be exhaustive. Prefer more nodes over fewer.`;
 
 })();
 </script>
+<script src="js/site.js"></script>
 </body>
 </html>

--- a/kag.html
+++ b/kag.html
@@ -1202,7 +1202,7 @@
                 if (!node) return;
                 rpLabel.textContent = node.label;
                 const edges = graphData.edges.filter(e => e.source === nodeId || e.target === nodeId);
-                let html = '<div style="margin-bottom:0.75rem"><span class="badge badge-' + node.type + '">' + node.type + '</span><span class="badge badge-sub">' + node.subspecialty + '</span></div>';
+                let html = '<div style="margin-bottom:0.75rem"><span class="badge badge-' + node.type + '">' + node.type + '</span><span class="badge badge-sub">' + node.subspecialty + '</span>' + (node.review === false ? '<span class="badge" style="background:rgba(214,172,99,0.22);color:#D6AC63">DRAFT</span>' : '<span class="badge" style="background:rgba(81,207,102,0.16);color:#51CF66">reviewed ✓</span>') + '</div>';
                 html += '<div class="rp-section"><div class="rp-section-title">Clinical Detail</div><div class="rp-detail">' + escHtml(node.detail) + '</div></div>';
                 // Study & Practice — KAG → OKSAT traversal (concept deep links, adaptive drills, modules)
                 const ok = node.oksat || {};
@@ -1235,6 +1235,7 @@
                 }
                 html += '<div class="rp-section"><div class="rp-section-title">Leitner Box</div><div style="font-size:0.8rem;color:var(--txt2)">Box ' + node.leitner.box + ' · Next review: ' + node.leitner.nextReview + '</div></div>';
                 // Correction form
+                if (node.review === false) { html += '<div class="rp-section"><button class="btn btn-sm btn-success" id="accept-review" style="width:100%">Accept as reviewed ✓</button></div>'; }
                 html += '<div class="rp-section"><div class="rp-section-title">Flag Correction</div><div class="corr-form"><textarea id="corr-text" placeholder="Describe the correction…"></textarea><input id="corr-source" placeholder="Source (optional)"><button class="btn btn-warning btn-sm" style="margin-top:6px" id="corr-submit">Submit Correction</button></div></div>';
                 if (node.corrections && node.corrections.length > 0) {
                     html += '<div class="rp-section"><div class="rp-section-title">Corrections (' + node.corrections.length + ')</div>';
@@ -1253,6 +1254,9 @@
                         if (cyNode.length) { cy.animate({ center: { eles: cyNode }, zoom: 2 }, { duration: 300 }); cyNode.select(); openNodePanel(nid); }
                     });
                 });
+                // Owner review: accept a DRAFT node (review:false -> true)
+                const acceptBtn = document.getElementById('accept-review');
+                if (acceptBtn) acceptBtn.addEventListener('click', () => { node.review = true; saveGraph(graphData); toast('Marked reviewed'); openNodePanel(nodeId); });
                 // Correction submit
                 document.getElementById('corr-submit').addEventListener('click', () => {
                     const text = document.getElementById('corr-text').value.trim();
@@ -1397,7 +1401,7 @@
             settingsModal.addEventListener('click', e => { if (e.target === settingsModal) settingsModal.classList.remove('open'); });
 
             function openSettings() {
-                let html = '<div class="modal-actions"><button class="btn btn-secondary" id="set-import">Import Graph JSON</button><button class="btn btn-secondary" id="set-export">Export Graph JSON</button><button class="btn btn-danger" id="set-reset">Reset to Seed Data</button></div>';
+                let html = '<div class="modal-actions"><button class="btn btn-secondary" id="set-import">Import Graph JSON</button><button class="btn btn-secondary" id="set-export">Export Graph JSON</button><button class="btn btn-danger" id="set-reset">Discard local edits</button></div>';
                 // Canonical graph sync (writes data/kag-graph.json — the shared database)
                 if (window.KAGStore) {
                     html += '<div class="rp-section-title" style="margin-top:1rem">Canonical graph sync</div>';
@@ -1459,9 +1463,14 @@
                 });
                 // Reset
                 document.getElementById('set-reset').addEventListener('click', () => {
-                    if (!confirm('Reset all data to seed graph? This cannot be undone.')) return;
-                    graphData = JSON.parse(JSON.stringify(SEED_GRAPH)); saveGraph(graphData); rebuildCy(); updateBottomStrip();
-                    toast('Reset to seed data'); settingsModal.classList.remove('open');
+                    if (!confirm('Discard this browser\'s local edits and reload the canonical atlas (data/kag-graph.json)? This cannot be undone.')) return;
+                    try { localStorage.removeItem('kag-graph'); } catch (e) { /* no-op */ }
+                    const finish = (g) => { graphData = g; saveGraph(graphData); rebuildCy(); updateBottomStrip(); toast('Reloaded canonical atlas'); settingsModal.classList.remove('open'); };
+                    if (window.KAGStore && typeof KAGStore.fetch === 'function') {
+                        KAGStore.fetch().then((file) => finish((file && file.nodes && file.edges) ? file : JSON.parse(JSON.stringify(SEED_GRAPH))));
+                    } else {
+                        finish(JSON.parse(JSON.stringify(SEED_GRAPH)));
+                    }
                 });
                 // Resolve corrections
                 document.querySelectorAll('.corr-resolve').forEach(btn => {

--- a/kag.html
+++ b/kag.html
@@ -1,16 +1,27 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>KAG — Knowledge Atlas Graph | skflx.MD</title>
     <meta name="description" content="Interactive OHNS knowledge graph with spaced repetition self-testing.">
+    <!-- Pre-paint theme: shared sk_theme key (OKSAT), dark default for canvas legibility. -->
+    <script>
+        (function () {
+            try {
+                var t = localStorage.getItem('sk_theme');
+                if (!t) t = 'dark';
+                document.documentElement.setAttribute('data-theme', t);
+            } catch (e) { document.documentElement.setAttribute('data-theme', 'dark'); }
+        })();
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link
         href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;600&display=swap"
         rel="stylesheet">
+    <link rel="stylesheet" href="css/site.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.28.1/cytoscape.min.js"></script>
     <!-- cose-bilkent's plain-script build expects layoutBase + coseBase globals -->
     <script src="https://unpkg.com/layout-base@1.0.2/layout-base.js"></script>

--- a/kag.html
+++ b/kag.html
@@ -916,8 +916,9 @@
 <body>
 
     <!-- Topbar -->
-    <div class="topbar">
-        <a href="kag.html" class="logo">KAG</a>
+    <div class="site-topbar">
+        <a class="site-wordmark" href="index.html">skflx.MD</a>
+        <span class="site-topbar-title">Knowledge Atlas Graph</span>
         <div class="pills" id="pills"></div>
         <div class="search-box">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -930,16 +931,23 @@
             <button class="mode-btn active" data-mode="explore">Explore</button>
             <button class="mode-btn" data-mode="test">Self-Test</button>
         </div>
-        <button class="gear-btn" id="gear-btn" title="Settings">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <circle cx="12" cy="12" r="3" />
-                <path
-                    d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" />
-            </svg>
-        </button>
-        <a href="kag-extract.html" class="nav-link">Extractor</a>
-        <a href="oksat.html" class="nav-link" title="OHNS Knowledge Self-Assessment Tool">OKSAT</a>
-        <a href="index.html" class="nav-link">Home</a>
+        <span class="site-topbar-spacer"></span>
+        <div class="site-topbar-actions">
+            <a class="site-navlink" href="kag-extract.html">Extractor</a>
+            <a class="site-navlink" href="oksat.html" title="OHNS Knowledge Self-Assessment Tool">OKSAT</a>
+            <a class="site-navlink" href="index.html">Home</a>
+            <button class="site-btn site-btn-sm" id="gear-btn" title="Settings" type="button">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <circle cx="12" cy="12" r="3" />
+                    <path
+                        d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" />
+                </svg>
+            </button>
+            <button class="site-theme-toggle" type="button" aria-label="Toggle day / night">
+                <svg class="i-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                <svg class="i-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
+            </button>
+        </div>
     </div>
 
     <!-- Main -->
@@ -1542,6 +1550,7 @@
 
         })();
     </script>
+    <script src="js/site.js"></script>
 </body>
 
 </html>

--- a/kag.html
+++ b/kag.html
@@ -16,6 +16,7 @@
     <script src="https://unpkg.com/layout-base@1.0.2/layout-base.js"></script>
     <script src="https://unpkg.com/cose-base@1.0.3/cose-base.js"></script>
     <script src="https://unpkg.com/cytoscape-cose-bilkent@4.1.0/cytoscape-cose-bilkent.js"></script>
+    <script src="js/kag-store.js"></script>
     <style>
         *,
         *::before,
@@ -1377,6 +1378,12 @@
 
             function openSettings() {
                 let html = '<div class="modal-actions"><button class="btn btn-secondary" id="set-import">Import Graph JSON</button><button class="btn btn-secondary" id="set-export">Export Graph JSON</button><button class="btn btn-danger" id="set-reset">Reset to Seed Data</button></div>';
+                // Canonical graph sync (writes data/kag-graph.json — the shared database)
+                if (window.KAGStore) {
+                    html += '<div class="rp-section-title" style="margin-top:1rem">Canonical graph sync</div>';
+                    html += '<div class="modal-actions"><button class="btn btn-secondary" id="set-dl-merged">Download merged graph</button><button class="btn btn-secondary" id="set-push">Push via token</button></div>';
+                    html += '<div style="font-size:0.75rem;color:var(--txt3);margin-top:4px">Persists this browser\'s graph to <code>data/kag-graph.json</code>: commit the download, or push with a fine-grained GitHub token (used once, never stored).</div>';
+                }
                 // Corrections inbox
                 const allCorr = [];
                 graphData.nodes.forEach(n => { (n.corrections || []).forEach((c, i) => { if (!c.resolved) allCorr.push({ node: n, corr: c, idx: i }); }); });
@@ -1387,6 +1394,20 @@
                 });
                 document.getElementById('modal-body').innerHTML = html;
                 settingsModal.classList.add('open');
+                // Canonical graph sync handlers
+                if (window.KAGStore) {
+                    const dlBtn = document.getElementById('set-dl-merged');
+                    if (dlBtn) dlBtn.addEventListener('click', () => { KAGStore.download(graphData); toast('Downloaded kag-graph.json — commit it to persist'); });
+                    const pushBtn = document.getElementById('set-push');
+                    if (pushBtn) pushBtn.addEventListener('click', () => {
+                        const token = prompt('Fine-grained GitHub token (used once, never stored):');
+                        if (!token) return;
+                        toast('Pushing to data/kag-graph.json…');
+                        KAGStore.push(graphData, token)
+                            .then(() => toast('Pushed to data/kag-graph.json'))
+                            .catch(err => toast('Push failed: ' + (err && err.message ? err.message : err)));
+                    });
+                }
                 // Import
                 document.getElementById('set-import').addEventListener('click', () => {
                     const inp = document.createElement('input'); inp.type = 'file'; inp.accept = '.json';
@@ -1436,6 +1457,47 @@
                 cy.elements().remove();
                 cy.add(buildElements(graphData));
                 cy.layout({ name: 'cose-bilkent', animate: false, nodeDimensionsIncludeLabels: true, idealEdgeLength: 120, nodeRepulsion: 8000, gravity: 0.25, numIter: 2500 }).run();
+            }
+
+            /* ── Deep link: kag.html?node=<id> isolates + centers a node ── */
+            function focusNode(id) {
+                const n = cy.getElementById(id);
+                if (!n || n.empty()) { toast('Unknown node: ' + id); return; }
+                const hood = n.neighborhood().add(n);
+                cy.elements().addClass('faded');
+                hood.removeClass('faded');
+                if (currentMode === 'explore') openNodePanel(id);
+                setTimeout(function () { cy.animate({ fit: { eles: hood, padding: 80 } }, { duration: 400 }); }, 60);
+            }
+            function bootDeepLink() {
+                try {
+                    const id = new URLSearchParams(location.search).get('node');
+                    if (id) focusNode(id);
+                } catch (e) { /* no-op */ }
+            }
+
+            /* ── Externalized graph: merge data/kag-graph.json over local ──
+               Boots synchronously from localStorage/SEED above (no blank
+               screen), then folds in the canonical file. LOCAL WINS, so
+               leitner progress + corrections are preserved; the file only
+               ADDS nodes/edges this browser is missing. Only re-lays out
+               when the merge actually changed the counts (no flicker for
+               users already in sync). Fully guarded — if KAGStore or the
+               file is unavailable, behavior is exactly as before. */
+            if (window.KAGStore) {
+                KAGStore.fetch().then(function (file) {
+                    if (file && file.nodes && file.edges) {
+                        var beforeN = graphData.nodes.length, beforeE = graphData.edges.length;
+                        graphData = KAGStore.merge(file);
+                        saveGraph(graphData);
+                        if (graphData.nodes.length !== beforeN || graphData.edges.length !== beforeE) {
+                            rebuildCy(); updateBottomStrip();
+                        }
+                    }
+                    bootDeepLink();
+                });
+            } else {
+                bootDeepLink();
             }
 
         })();

--- a/kag.html
+++ b/kag.html
@@ -16,6 +16,7 @@
     <script src="https://unpkg.com/layout-base@1.0.2/layout-base.js"></script>
     <script src="https://unpkg.com/cose-base@1.0.3/cose-base.js"></script>
     <script src="https://unpkg.com/cytoscape-cose-bilkent@4.1.0/cytoscape-cose-bilkent.js"></script>
+    <script src="js/oksat-manifest.js"></script>
     <script src="js/kag-store.js"></script>
     <style>
         *,
@@ -981,7 +982,12 @@
         (function () {
             'use strict';
             const TODAY = new Date().toISOString().split('T')[0];
-            const SUBSPECIALTIES = ['rhinology', 'otology', 'head-neck-onc', 'laryngology', 'peds-ent', 'skull-base', 'facial-plastics'];
+            // Subspecialty vocabulary is canonicalized on OKSAT's 9 keys (from oksat-manifest.js);
+            // normSub folds any legacy KAG value (e.g. 'skull-base') to canonical so filters still match.
+            const SUB_LABELS = window.OKSAT_SUBSPECIALTIES || {};
+            const SUBSPECIALTIES = Object.keys(SUB_LABELS).length ? Object.keys(SUB_LABELS)
+                : ['otology', 'rhinology', 'laryngology', 'hn_onc', 'fprs', 'pediatrics', 'sleep', 'endocrine', 'fundamentals'];
+            const normSub = (x) => (window.KAGStore && typeof KAGStore.normSub === 'function') ? KAGStore.normSub(x) : x;
             const LEITNER_INTERVALS = { 1: 1, 2: 3, 3: 7, 4: 14, 5: 30 };
             const NODE_COLORS = { anatomy: '#4A9EFF', pathology: '#FF6B6B', procedure: '#51CF66', nerve: '#FFD43B', vessel: '#FF922B', drug: '#CC5DE8', concept: '#868E96' };
 
@@ -1140,7 +1146,7 @@
             const pillsEl = document.getElementById('pills');
             let activeSpecs = new Set();
             SUBSPECIALTIES.forEach(s => {
-                const b = document.createElement('button'); b.className = 'pill'; b.textContent = s; b.dataset.spec = s;
+                const b = document.createElement('button'); b.className = 'pill'; b.textContent = (SUB_LABELS[s] && SUB_LABELS[s].label) || s; b.dataset.spec = s;
                 b.addEventListener('click', () => {
                     if (activeSpecs.has(s)) { activeSpecs.delete(s); b.classList.remove('active'); }
                     else { activeSpecs.add(s); b.classList.add('active'); }
@@ -1152,7 +1158,7 @@
             function applyFilters() {
                 if (activeSpecs.size === 0) { cy.nodes().removeClass('faded'); return; }
                 cy.nodes().forEach(n => {
-                    if (activeSpecs.has(n.data('subspecialty'))) n.removeClass('faded');
+                    if (activeSpecs.has(normSub(n.data('subspecialty')))) n.removeClass('faded');
                     else n.addClass('faded');
                 });
             }
@@ -1198,6 +1204,20 @@
                 const edges = graphData.edges.filter(e => e.source === nodeId || e.target === nodeId);
                 let html = '<div style="margin-bottom:0.75rem"><span class="badge badge-' + node.type + '">' + node.type + '</span><span class="badge badge-sub">' + node.subspecialty + '</span></div>';
                 html += '<div class="rp-section"><div class="rp-section-title">Clinical Detail</div><div class="rp-detail">' + escHtml(node.detail) + '</div></div>';
+                // Study & Practice — KAG → OKSAT traversal (concept deep links, adaptive drills, modules)
+                const ok = node.oksat || {};
+                const okLinks = [];
+                (ok.concepts || []).forEach(c => { if (c && c.module && c.concept) okLinks.push({ href: 'oksat-study.html?m=' + encodeURIComponent(c.module) + '&c=' + encodeURIComponent(c.concept), label: 'Practice · ' + c.concept }); });
+                (ok.topics || []).forEach(t => { if (t) okLinks.push({ href: 'oksat-adaptive.html?t=' + encodeURIComponent(t), label: 'Drill · ' + t }); });
+                (ok.modules || []).forEach(m => { if (m) okLinks.push({ href: 'oksat-study.html?m=' + encodeURIComponent(m), label: 'Module · ' + m }); });
+                if (okLinks.length) {
+                    html += '<div class="rp-section"><div class="rp-section-title">Study &amp; Practice</div>';
+                    okLinks.forEach(l => { html += '<a class="ok-link" href="' + l.href + '" style="display:inline-block;margin:3px 4px 0 0;padding:3px 10px;border-radius:999px;background:rgba(74,158,255,0.15);color:#4A9EFF;font-size:0.72rem;text-decoration:none;border:1px solid rgba(74,158,255,0.35)">' + escHtml(l.label) + ' ↗</a>'; });
+                    html += '</div>';
+                }
+                if (node.aliases && node.aliases.length) {
+                    html += '<div class="rp-section"><div class="rp-section-title">Also known as</div><div style="font-size:0.78rem;color:var(--txt2)">' + node.aliases.map(escHtml).join(' · ') + '</div></div>';
+                }
                 if (edges.length > 0) {
                     html += '<div class="rp-section"><div class="rp-section-title">Connections (' + edges.length + ')</div>';
                     edges.forEach(e => {

--- a/oksat.html
+++ b/oksat.html
@@ -180,6 +180,7 @@
   <script src="js/oksat-taxonomy.js"></script>
   <script src="js/oksat-concept-graph.js"></script>
   <script src="js/oksat-db.js"></script>
+  <script src="js/kag-store.js"></script>
   <script src="js/oksat-ai.js"></script>
   <script>
     (function () {

--- a/tools/kag-validate.mjs
+++ b/tools/kag-validate.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/* =============================================================
+   KAG shard validator + merger (dev-only; never shipped to Pages).
+
+   Validates authored shards ({nodes,edges}) against schema v2, then
+   merges the clean ones into data/kag-graph.json.
+
+   Usage:
+     node tools/kag-validate.mjs [--dir <shardDir>] [--graph <file>] [--dry]
+   Defaults: --dir scratchpad_p2/shards  --graph data/kag-graph.json
+   --dry validates + prints the report but does NOT write the graph.
+
+   Guarantees (see docs/oto-kag-atlas-plan.md §4.5):
+   - node.type / subspecialty / structure / region / laterality coerced
+     to their enums (bad type -> 'concept'; legacy subspecialty mapped,
+     else -> 'fundamentals'); v2 fields defaulted; review:false on shard
+     nodes; ids must be kebab-case and unique (seed wins on collision).
+   - edge.type coerced to enum (unknown -> 'contained_in'); edges with an
+     endpoint missing from the FINAL node set are dropped (no dangling).
+   - node.oksat.concepts entries that do not resolve to a real module
+     CONCEPTS key are dropped (validated against js/mcq-modules/*).
+   Never throws on bad data — it reports and coerces/drops.
+   ============================================================= */
+import fs from 'fs';
+import path from 'path';
+
+const args = process.argv.slice(2);
+const opt = (name, def) => { const i = args.indexOf(name); return i >= 0 ? args[i + 1] : def; };
+const DIR = opt('--dir', 'scratchpad_p2/shards');
+const GRAPH = opt('--graph', 'data/kag-graph.json');
+const DRY = args.includes('--dry');
+
+const NODE_TYPES = ['anatomy', 'pathology', 'procedure', 'nerve', 'vessel', 'drug', 'concept'];
+const SUBS = ['otology', 'rhinology', 'laryngology', 'hn_onc', 'fprs', 'pediatrics', 'sleep', 'endocrine', 'fundamentals'];
+const SUB_MAP = { 'head-neck-onc': 'hn_onc', 'peds-ent': 'pediatrics', 'facial-plastics': 'fprs', 'skull-base': 'otology' };
+const STRUCTURES = ['bone', 'cartilage', 'ligament', 'fascia', 'joint', 'foramen', 'space', 'membrane', 'muscle'];
+const REGIONS = ['temporal-bone', 'skull-base', 'facial-skeleton', 'nasal-sinus', 'larynx', 'neck', 'oral-pharynx', 'cervical-spine-hyoid', 'external-ear'];
+const LAT = ['midline', 'paired'];
+const EDGE_TYPES = ['innervates', 'supplies', 'drains_to', 'landmark_for', 'complication_of', 'differentiates_from', 'treats', 'staged_with', 'arises_from', 'contained_in', 'branches_from', 'articulates_with', 'attaches_to', 'part_of', 'bounded_by', 'continuous_with', 'passes_through', 'transmits', 'suspends', 'forms'];
+const KEBAB = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const TODAY = new Date().toISOString().split('T')[0];
+
+const warn = [];
+const W = (m) => warn.push(m);
+
+/* ---- load real module CONCEPTS keys (sandbox, mirrors the atlas loader) ---- */
+function loadModuleConcepts() {
+  const slugs = ['pediatrics', 'ta-tubes', 'vestibular-schwannoma', 'facial-reanimation', 'dtc-risk-stratification'];
+  const out = {};
+  for (const slug of slugs) {
+    try {
+      const src = fs.readFileSync(`js/mcq-modules/${slug}.js`, 'utf8');
+      const win = {};
+      new Function('window', src + '\n;return window;')(win);
+      out[slug] = new Set(Object.keys((win.__MCQ_MODULE || {}).CONCEPTS || {}));
+    } catch (e) { out[slug] = new Set(); W(`could not load module ${slug}: ${e.message}`); }
+  }
+  return out;
+}
+
+/* ---- load taxonomy topic ids (for coverage) ---- */
+function loadTopics() {
+  try {
+    const src = fs.readFileSync('js/oksat-taxonomy.js', 'utf8');
+    const win = {};
+    new Function('window', src + '\n;return window;')(win);
+    return (win.OKSAT_TAXONOMY.topics || []).map(t => t.id);
+  } catch (e) { W(`could not load taxonomy: ${e.message}`); return []; }
+}
+
+const MODCONCEPTS = loadModuleConcepts();
+const TOPICS = loadTopics();
+
+function normNode(n, fromShard) {
+  const o = {};
+  o.id = String(n.id || '').trim();
+  o.label = String(n.label || o.id).trim();
+  o.type = NODE_TYPES.includes(n.type) ? n.type : 'concept';
+  let sub = n.subspecialty;
+  if (SUB_MAP[sub]) sub = SUB_MAP[sub];
+  o.subspecialty = SUBS.includes(sub) ? sub : 'fundamentals';
+  o.detail = String(n.detail || '').trim();
+  o.sources = Array.isArray(n.sources) ? n.sources.filter(Boolean) : [];
+  o.corrections = Array.isArray(n.corrections) ? n.corrections : [];
+  o.leitner = (n.leitner && typeof n.leitner.box === 'number') ? { box: n.leitner.box, nextReview: n.leitner.nextReview || TODAY } : { box: 1, nextReview: TODAY };
+  o.aliases = Array.isArray(n.aliases) ? n.aliases.filter(x => typeof x === 'string') : [];
+  o.abbrev = (typeof n.abbrev === 'string' && n.abbrev) ? n.abbrev : null;
+  o.structure = STRUCTURES.includes(n.structure) ? n.structure : null;
+  o.region = REGIONS.includes(n.region) ? n.region : null;
+  o.laterality = LAT.includes(n.laterality) ? n.laterality : null;
+  // oksat links
+  const ok = n.oksat || {};
+  const concepts = [];
+  (Array.isArray(ok.concepts) ? ok.concepts : []).forEach(c => {
+    if (!c || !c.module || !c.concept) return;
+    if (MODCONCEPTS[c.module] && MODCONCEPTS[c.module].has(c.concept)) concepts.push({ module: c.module, concept: c.concept });
+    else droppedLinks.push(`${o.id}: ${c.module}:${c.concept}`);
+  });
+  const modules = (Array.isArray(ok.modules) ? ok.modules : []).filter(m => MODCONCEPTS[m]);
+  const topics = (Array.isArray(ok.topics) ? ok.topics : []).filter(t => typeof t === 'string');
+  o.oksat = { modules, concepts, topics };
+  o.review = fromShard ? false : (n.review === true);
+  if (fromShard) {
+    if (!KEBAB.test(o.id)) W(`bad id (not kebab): "${o.id}"`);
+    if (!o.sources.length) W(`node "${o.id}" has no sources`);
+    if (!o.detail) W(`node "${o.id}" has empty detail`);
+    if (!o.oksat.topics.length) W(`node "${o.id}" has no oksat.topics (coverage untraceable)`);
+  }
+  return o;
+}
+
+let droppedLinks = [];
+
+/* ---- base graph ---- */
+const base = JSON.parse(fs.readFileSync(GRAPH, 'utf8'));
+const nodesById = new Map();
+base.nodes.forEach(n => nodesById.set(n.id, normNode(n, false)));
+const edgeKey = e => `${e.source}|${e.target}|${e.type}`;
+const edgesByKey = new Map();
+base.edges.forEach(e => {
+  const type = EDGE_TYPES.includes(e.type) ? e.type : 'contained_in';
+  edgesByKey.set(edgeKey({ source: e.source, target: e.target, type }), { source: e.source, target: e.target, type, ...(e.label ? { label: e.label } : {}), ...(e.direction ? { direction: e.direction } : {}) });
+});
+
+/* ---- shards ---- */
+const perSub = {};
+let collisions = 0, addedNodes = 0, shardEdgeSeen = 0, addedEdges = 0, droppedEdges = 0;
+const shardFiles = fs.existsSync(DIR) ? fs.readdirSync(DIR).filter(f => f.endsWith('.json')) : [];
+if (!shardFiles.length) { console.error(`No shards in ${DIR}`); }
+
+const pendingEdges = [];
+for (const f of shardFiles) {
+  let shard;
+  try { shard = JSON.parse(fs.readFileSync(path.join(DIR, f), 'utf8')); }
+  catch (e) { console.error(`SHARD PARSE FAIL ${f}: ${e.message}`); process.exitCode = 1; continue; }
+  const name = f.replace(/\.json$/, '');
+  perSub[name] = { nodes: 0, edges: 0 };
+  (shard.nodes || []).forEach(raw => {
+    const n = normNode(raw, true);
+    if (!n.id) return;
+    if (nodesById.has(n.id)) { collisions++; return; } // seed / earlier shard wins
+    nodesById.set(n.id, n); addedNodes++; perSub[name].nodes++;
+  });
+  (shard.edges || []).forEach(e => {
+    if (!e || !e.source || !e.target) return;
+    shardEdgeSeen++;
+    const type = EDGE_TYPES.includes(e.type) ? e.type : 'contained_in';
+    pendingEdges.push({ source: e.source, target: e.target, type, label: e.label, direction: e.direction, _sub: name });
+  });
+}
+
+/* ---- resolve edges against the FINAL node set ---- */
+pendingEdges.forEach(e => {
+  if (!nodesById.has(e.source) || !nodesById.has(e.target)) { droppedEdges++; return; }
+  const k = edgeKey(e);
+  if (edgesByKey.has(k)) return;
+  const rec = { source: e.source, target: e.target, type: e.type };
+  if (e.label) rec.label = e.label;
+  if (e.direction) rec.direction = e.direction;
+  edgesByKey.set(k, rec);
+  addedEdges++;
+  if (perSub[e._sub]) perSub[e._sub].edges++;
+});
+
+/* ---- assemble merged graph ---- */
+const merged = {
+  version: 2,
+  updated: new Date().toISOString(),
+  status: base.status || 'DRAFT — pending clinical review.',
+  sources: base.sources || [],
+  nodes: [...nodesById.values()],
+  edges: [...edgesByKey.values()],
+};
+
+/* ---- coverage ---- */
+const topicsCovered = new Set();
+merged.nodes.forEach(n => (n.oksat.topics || []).forEach(t => topicsCovered.add(t)));
+const missing = TOPICS.filter(t => !topicsCovered.has(t));
+const subCounts = {};
+merged.nodes.forEach(n => { subCounts[n.subspecialty] = (subCounts[n.subspecialty] || 0) + 1; });
+const structural = merged.nodes.filter(n => n.structure).length;
+const oksatLinked = merged.nodes.filter(n => n.oksat.concepts.length || n.oksat.modules.length).length;
+
+/* ---- report ---- */
+console.log('=== KAG merge report ===');
+console.log(`shards: ${shardFiles.join(', ') || '(none)'}`);
+console.log(`nodes: ${base.nodes.length} seed + ${addedNodes} added = ${merged.nodes.length}  (collisions skipped: ${collisions})`);
+console.log(`edges: ${base.edges.length} seed + ${addedEdges} added = ${merged.edges.length}  (shard edges seen ${shardEdgeSeen}, dropped/dangling ${droppedEdges})`);
+console.log(`structural nodes: ${structural} | oksat-linked nodes: ${oksatLinked} | dropped oksat links: ${droppedLinks.length}`);
+console.log('per-shard added:', Object.entries(perSub).map(([k, v]) => `${k}:${v.nodes}n/${v.edges}e`).join('  '));
+console.log('subspecialty node counts:', Object.entries(subCounts).map(([k, v]) => `${k}:${v}`).join('  '));
+console.log(`topic coverage: ${TOPICS.length - missing.length}/${TOPICS.length} covered`);
+if (missing.length) console.log('  UNCOVERED topics:', missing.join(', '));
+if (droppedLinks.length) console.log(`  dropped oksat links (first 10): ${droppedLinks.slice(0, 10).join('  ')}`);
+if (warn.length) { console.log(`\nwarnings (${warn.length}):`); warn.slice(0, 25).forEach(w => console.log('  - ' + w)); if (warn.length > 25) console.log(`  ...and ${warn.length - 25} more`); }
+
+/* ---- final audit: dangling + dup ---- */
+const ids = new Set(merged.nodes.map(n => n.id));
+const dangling = merged.edges.filter(e => !ids.has(e.source) || !ids.has(e.target)).length;
+console.log(`\nfinal audit: dangling edges ${dangling}, dup ids ${merged.nodes.length - ids.size}`);
+
+if (DRY) { console.log('\n--dry: not writing.'); }
+else if (process.exitCode) { console.log('\nErrors present — not writing. Fix shards and re-run.'); }
+else { fs.writeFileSync(GRAPH, JSON.stringify(merged, null, 2) + '\n'); console.log(`\nWROTE ${GRAPH}`); }


### PR DESCRIPTION
## Summary
This PR introduces a new **Structural Anatomy Atlas** (`atlas.html`) as a dedicated visualization surface for the Knowledge Atlas Graph (KAG), establishes KAG as a committed, canonical data source (`data/kag-graph.json`), and unifies the data layer across all graph-based tools on the site.

## Key Changes

- **New Atlas Tool** (`atlas.html`): A Cytoscape-based structural anatomy viewer that displays bones, cartilage, ligaments, spaces, and other anatomical entities from the KAG. Auto-generated from the knowledge graph with filtering and search capabilities.

- **Canonical KAG Data** (`data/kag-graph.json`): Moved KAG from localStorage-only (hard-coded seed in `kag.html`) to a committed JSON file. This enables version control, easier authoring, and sharing across multiple tools.

- **KAG Data Layer** (`js/kag-store.js`): New module that mirrors `oksat-db.js`, providing a unified interface for loading and accessing the KAG from the committed data file.

- **Schema & Documentation**:
  - `docs/kag-schema.md`: Formal schema definition for KAG nodes and edges (v2)
  - `docs/authoring-kag.md`: Process for authoring KAG content via shards that merge into the canonical file
  - `docs/oto-kag-atlas-plan.md`: Comprehensive master plan for the three-pillar knowledge surface (KAG, Atlas, OKSAT)

- **Validation Tooling** (`tools/kag-validate.mjs`): Dev-only validator and merger for KAG shards, ensuring data integrity before committing to the canonical file.

- **Shared Styling** (`css/site.css`): New unified design layer with consistent theming tokens across all tools, replacing tool-specific stylesheets.

- **Site Chrome** (`js/site.js`): Shared theme toggle (day/night) wired to localStorage key `sk_theme`, consistent across KAG, Atlas, and OKSAT.

- **Theme Attributes**: Added `data-theme="dark"` to KAG tools (`kag.html`, `kag-extract.html`, `atlas.html`) and `data-theme="light"` to utility tools (`cpt-search.html`, `ascii-editor.html`, `airway-jeopardy.html`).

- **Integration**: Updated `oksat.html` to load `kag-store.js` and modified `oksat-atlas.js` to accept an optional `kagIndex` parameter for future KAG/OKSAT graph fusion.

- **Metadata**: Updated `.gitignore` to exclude shard scratchpads and agent working directories.

## Notable Implementation Details

- The KAG schema supports rich node/edge metadata (labels, descriptions, categories, relationships) enabling both the knowledge graph and structural anatomy views.
- Shards are authored separately and validated before merging into `data/kag-graph.json`, preventing manual JSON editing errors.
- All graph tools now share a common data loading pattern and theme infrastructure, reducing duplication and improving maintainability.
- The plan document is grounded in the actual repository state, with verified file paths and storage keys for reproducible execution.

https://claude.ai/code/session_01VKSk3M6ewLVqJiL7edZMuH